### PR TITLE
Configura export estático e scripts no Next.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,14 @@
+/**
+ * @type {import('next').NextConfig}
+ * Configuração principal do Next.js, exportando o site de forma estática
+ * e desativando a otimização automática de imagens.
+ */
+const nextConfig = {
+  // Gera saída estática para deployment sem servidor
+  output: 'export',
+  // Desativa a otimização de imagens para compatibilidade com export estático
+  images: { unoptimized: true },
+};
+
+// Exporta a configuração para uso pelo Next.js
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
+    "start": "next start -p $PORT"
   },
   "dependencies": {
     "next": "14.1.0",


### PR DESCRIPTION
## Summary
- define static export configuration and disables Next.js image optimization
- adjust npm scripts to use $PORT in start and remove lint script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: next: not found; npm install failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b840130854832eabcfbaf310c5a48d