### PR TITLE
fix: adjust header and background layering

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,12 +3,16 @@ import Link from 'next/link';
 // Cabeçalho fixo com navegação principal
 export default function Header() {
   return (
-    <header className="fixed top-0 z-50 w-full bg-white shadow">
+    // Cabeçalho fixo transparente no topo da página
+    <header className="fixed top-0 z-50 w-full bg-transparent">
+      {/* Contêiner centralizado com espaçamento interno */}
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
-        <Link href="/" className="font-bold text-lg">
+        {/* Logotipo com texto branco */}
+        <Link href="/" className="font-bold text-lg text-white">
           CLIENTE MISTÉRIO
         </Link>
-        <nav className="space-x-4">
+        {/* Navegação principal com itens em branco e realce azul ao passar o rato */}
+        <nav className="space-x-4 text-white">
           <Link href="/" className="hover:text-accent">
             INÍCIO
           </Link>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,6 +20,7 @@ html, body {
 /* Contêiner responsável pelo fundo animado */
 .animated-background {
   position: relative;
+  z-index: 0; /* Cria contexto de empilhamento para o fundo animado */
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -51,6 +52,8 @@ html, body {
   animation: rotate 8s linear infinite;
   filter: blur(50px);
   opacity: 0.8;
+  z-index: -1; /* Posiciona o brilho atrás do conteúdo */
+  pointer-events: none; /* Permite interação com os elementos acima */
 }
 
 /* Segunda camada giratória para maior profundidade */


### PR DESCRIPTION
## Summary
- make header transparent and text white
- place animated background behind content to allow clicks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Failed to fetch font `Inter` from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_68b845cf68c8832e99f1bfecf447d7e7