### PR TITLE
feat: add scroll and basic auth pages

### DIFF
--- a/src/app/(site)/login/page.tsx
+++ b/src/app/(site)/login/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { loginUser } from '../../../lib/auth';
+
+// Página de login com formulário simples
+export default function LoginPage() {
+  // Estado para email e password introduzidos
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  // Estado para mensagens de erro
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  // Função chamada ao submeter o formulário
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    // Verifica se as credenciais são válidas
+    const success = loginUser({ email, password });
+    if (success) {
+      // Guarda o email do utilizador autenticado
+      localStorage.setItem('currentUser', email);
+      router.push('/');
+    } else {
+      setError('Credenciais inválidas');
+    }
+  }
+
+  return (
+    // Contêiner centralizado para o formulário
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h2 className="text-center text-2xl font-bold">Login</h2>
+        {/* Exibe mensagem de erro se existir */}
+        {error && <p className="text-center text-red-500">{error}</p>}
+        {/* Campo de email */}
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="w-full rounded border px-3 py-2"
+        />
+        {/* Campo de password */}
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full rounded border px-3 py-2"
+        />
+        {/* Botão de submissão */}
+        <button
+          type="submit"
+          className="w-full rounded bg-accent py-2 font-bold text-white"
+        >
+          Entrar
+        </button>
+        {/* Link para página de registo */}
+        <p className="text-center text-sm">
+          Não tem conta?{' '}
+          <Link href="/register" className="text-accent">
+            Registe-se
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(site)/register/page.tsx
+++ b/src/app/(site)/register/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { registerUser } from '../../../lib/auth';
+
+// Página de registo com formulário simples
+export default function RegisterPage() {
+  // Estado para email e password introduzidos
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  // Função chamada ao submeter o formulário
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    // Regista o utilizador no localStorage
+    registerUser({ email, password });
+    // Redireciona para o ecrã de login
+    router.push('/login');
+  }
+
+  return (
+    // Contêiner centralizado para o formulário
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h2 className="text-center text-2xl font-bold">Registo</h2>
+        {/* Campo de email */}
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="w-full rounded border px-3 py-2"
+        />
+        {/* Campo de password */}
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full rounded border px-3 py-2"
+        />
+        {/* Botão de submissão */}
+        <button
+          type="submit"
+          className="w-full rounded bg-accent py-2 font-bold text-white"
+        >
+          Criar conta
+        </button>
+        {/* Link para página de login */}
+        <p className="text-center text-sm">
+          Já tem conta?{' '}
+          <Link href="/login" className="text-accent">
+            Entre aqui
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           CLIENTE MISTÉRIO
         </Link>
         {/* Navegação principal com itens em branco e realce azul ao passar o rato */}
-        <nav className="space-x-4 text-white">
+        <nav className="flex items-center space-x-4 text-white">
           <Link href="/" className="hover:text-accent">
             INÍCIO
           </Link>
@@ -21,6 +21,21 @@ export default function Header() {
           </Link>
           <Link href="/contactos" className="hover:text-accent">
             CONTACTOS
+          </Link>
+          {/* Ícone para aceder ao ecrã de login */}
+          <Link href="/login" className="hover:text-accent">
+            {/* Ícone de utilizador simples */}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="h-5 w-5"
+            >
+              {/* Cabeça do utilizador */}
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z" />
+              {/* Corpo do utilizador */}
+              <path d="M12 14c-3.33 0-6 2.69-6 6h12c0-3.31-2.67-6-6-6z" />
+            </svg>
           </Link>
         </nav>
       </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,23 @@
+// Funções simples de autenticação usando localStorage
+// Os nomes de variáveis e funções estão em inglês conforme requerido
+
+// Tipo para representar um utilizador
+export type AuthUser = {
+  email: string;
+  password: string;
+};
+
+// Regista um novo utilizador armazenando os dados no localStorage
+export function registerUser(user: AuthUser): void {
+  const users: AuthUser[] = JSON.parse(localStorage.getItem('users') || '[]');
+  users.push(user);
+  localStorage.setItem('users', JSON.stringify(users));
+}
+
+// Verifica se as credenciais correspondem a algum utilizador registado
+export function loginUser(user: AuthUser): boolean {
+  const users: AuthUser[] = JSON.parse(localStorage.getItem('users') || '[]');
+  return users.some(
+    (stored) => stored.email === user.email && stored.password === user.password
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,12 +9,13 @@ html, body {
   /* Remove margens e preenchimentos padrão */
   margin: 0;
   padding: 0;
-  /* Faz o corpo ocupar toda a altura da janela */
-  height: 100vh;
+  /* Garante altura mínima sem bloquear a rolagem */
+  min-height: 100vh;
   /* Aplica o gradiente pastel de fundo */
   background: linear-gradient(135deg, #ffe8f3, #d9f3ff);
-  /* Impede rolagem além do fundo animado */
-  overflow: hidden;
+  /* Impede rolagem horizontal mantendo a vertical */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* Contêiner responsável pelo fundo animado */
@@ -22,8 +23,10 @@ html, body {
   position: relative;
   z-index: 0; /* Cria contexto de empilhamento para o fundo animado */
   width: 100%;
-  height: 100%;
-  overflow: hidden;
+  min-height: 100%;
+  /* Oculta transbordo lateral e permite rolagem vertical */
+  overflow-x: hidden;
+  overflow-y: auto;
   /* Gradiente radial suave sobreposto ao fundo */
   background: radial-gradient(circle, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.1));
 }


### PR DESCRIPTION
## Summary
- allow vertical scrolling on site layout
- add login/register pages with localStorage authentication
- add login icon to header navigation

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68b850ba6f4c832eb37c4783ef8b6156