### PR TITLE
feat: aplicar gradiente e reativar curso genially

### DIFF
--- a/app/(private)/aluno/page.tsx
+++ b/app/(private)/aluno/page.tsx
@@ -8,10 +8,15 @@ export default function StudentPage() {
   return (
     <ProtectedClient>
       <section className="py-8">
+        {/* Título da página para o aluno */}
+        <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
+        {/* Frase motivacional para o aluno */}
+        <p className="mb-8 text-center text-gray-600">Explore o conteúdo interativo do curso.</p>
         {/* Iframe com o conteúdo do Genially */}
         <iframe
-          src="https://view.genial.ly/SEU_GENIALLY_ID"
+          src="https://view.genially.com/68b97653b3a4717fa5a9e8b1"
           style={{ width: '100%', height: '80vh', border: 0 }}
+          allowFullScreen
         />
       </section>
     </ProtectedClient>

--- a/app/(public)/entrar/page.tsx
+++ b/app/(public)/entrar/page.tsx
@@ -36,7 +36,9 @@ export default function LoginPage() {
 
   return (
     <section className="mx-auto max-w-md">
-      <h2 className="mb-4 text-center text-2xl font-bold">Entrar</h2>
+      <h2 className="mb-2 text-center text-2xl font-bold">Entrar</h2>
+      {/* Frase de orientação para o utilizador */}
+      <p className="mb-6 text-center text-gray-600">Aceda ao curso inserindo os seus dados.</p>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="flex flex-col space-y-1">
           <label className="text-sm font-medium">Email</label>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,3 +3,11 @@
 @tailwind utilities;
 
 /* Estilos globais adicionais podem ser colocados aqui */
+
+/* Aplica um gradiente pastel ao fundo de toda a aplicação */
+html, body {
+  /* Garante altura mínima da viewport */
+  min-height: 100vh;
+  /* Gradiente suave de cima para baixo */
+  background: linear-gradient(180deg, #f4e6f1 0%, #f3a0d7 50%, #d9f3ff 100%);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,8 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="pt">
-      <body className="min-h-screen bg-gray-50">
+      {/* Corpo principal, o fundo em gradiente é aplicado via CSS global */}
+      <body className="min-h-screen">
         {/* Cabeçalho presente em todas as páginas */}
         <Header />
         {/* Conteúdo específico de cada rota */}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 
 /** Configuração do Next.js com headers de segurança e modo estrito */
 // Política de Content Security Policy permitindo incorporar Genially
-const csp = "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; frame-src https://view.genial.ly; frame-ancestors 'none';"
+const csp = "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; frame-src https://view.genially.com; frame-ancestors 'none';"
 
 const nextConfig = {
   reactStrictMode: true,


### PR DESCRIPTION
## Summary
- add pastel gradient background and update root layout
- show guidance phrase on login page and restore Genially course for students
- allow Genially frame in CSP headers

## Testing
- `npm run build` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a185ca6c832e9abb90e8cac72761