### PR TITLE
feat: restyle header and restore course info

### DIFF
--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -3,20 +3,31 @@ import Link from 'next/link'
 
 export default function HomePage() {
   return (
-    <section className="py-20 text-center">
-      {/* Título principal do site */}
-      <h1 className="text-4xl font-bold">Curso Cliente Mistério</h1>
-      {/* Descrição breve do curso */}
-      <p className="mt-4 text-gray-600">Aprenda a avaliar serviços como um cliente oculto.</p>
-      {/* Botões de chamada para ação */}
-      <div className="mt-8 space-x-4">
-        <Link href="/comprar" className="rounded bg-blue-600 px-4 py-2 text-white">
-          Comprar curso
-        </Link>
-        <Link href="/entrar" className="rounded bg-gray-200 px-4 py-2">
-          Entrar
-        </Link>
-      </div>
-    </section>
+    <>
+      <section className="py-20 text-center">
+        {/* Título principal do site */}
+        <h1 className="text-4xl font-bold text-white">Curso Cliente Mistério</h1>
+        {/* Descrição breve do curso */}
+        <p className="mt-4 text-gray-200">Aprenda a avaliar serviços como um cliente oculto.</p>
+        {/* Botões de chamada para ação */}
+        <div className="mt-8 space-x-4">
+          <Link href="/comprar" className="rounded bg-blue-600 px-4 py-2 text-white">
+            Comprar curso
+          </Link>
+          <Link href="/entrar" className="rounded bg-gray-200 px-4 py-2">
+            Entrar
+          </Link>
+        </div>
+      </section>
+      {/* Secção com informações detalhadas do curso */}
+      <section className="mx-auto mt-12 max-w-2xl text-left text-white">
+        <h2 className="text-2xl font-semibold">Informações do Curso</h2>
+        <ul className="mt-4 list-inside list-disc space-y-2">
+          <li>5 módulos com exemplos práticos</li>
+          <li>Acesso durante 12 meses</li>
+          <li>Certificado de conclusão</li>
+        </ul>
+      </section>
+    </>
   )
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -31,18 +31,27 @@ export function Header() {
   }
 
   return (
-    <header className="bg-white shadow">
-      <nav className="container mx-auto flex items-center justify-between p-4">
-        <Link href="/" className="font-bold">
-          Cliente Mistério
-        </Link>
+    // Cabeçalho transparente sem barra branca
+    <header className="bg-transparent">
+      {/* Navegação principal com texto branco */}
+      <nav className="container mx-auto flex items-center justify-between p-4 text-white">
+        {/* Título e pequena descrição do curso */}
+        <div className="flex flex-col">
+          <Link href="/" className="font-bold">
+            Cliente Mistério
+          </Link>
+          <span className="text-sm">Curso online de avaliação de serviços</span>
+        </div>
+        {/* Ligações de navegação para páginas principais */}
         <div className="space-x-4">
           <Link href="/">Início</Link>
           <Link href="/aluno">Conteúdo do Curso</Link>
           <Link href="/comprar">Comprar</Link>
           {isLogged ? (
+            // Botão de saída quando o utilizador está autenticado
             <button onClick={handleSignOut}>Sair</button>
           ) : (
+            // Link para a página de entrada quando não autenticado
             <Link href="/entrar">Entrar</Link>
           )}
         </div>


### PR DESCRIPTION
## Summary
- remover fundo branco do cabeçalho e aplicar texto branco
- reintroduzir descrição do curso na navegação
- adicionar secção com detalhes do curso na página inicial

## Testing
- `npm test` (falhou: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9a58d3854832e89e33b3d51acbf60