### PR TITLE
Fix layout imports and add footer with cookie consent

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -40,3 +40,24 @@ html, body {
   top: 50%;
   left: 50%;
   width: 200%;
+  height: 200%;
+  /* Gradiente circular translúcido */
+  background: radial-gradient(circle, rgba(255,255,255,0.15), transparent);
+  transform: translate(-50%, -50%) rotate(0deg);
+  animation: rotate 20s linear infinite;
+}
+
+/* Direção inversa para a segunda camada */
+.animated-background::after {
+  animation-direction: reverse;
+}
+
+/* Animação de rotação */
+@keyframes rotate {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,14 @@
-+ import '../styles/globals.css'
-+ import Header from '../components/Header'
-+ import Footer from '../components/Footer'
-+ import CookieBar from '../components/CookieBar
-
-// Fonte principal do site
-const inter = Inter({ subsets: ['latin'] });
+import './globals.css'
+import React from 'react'
+import { Header } from '../components/Header'
+import { Footer } from '../components/Footer'
+import { CookieBar } from '../components/CookieBar'
 
 // Layout raiz com cabeçalho, rodapé e fundo animado
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt">
-      <body className={inter.className}>
+      <body>
         {/* Contêiner com fundo animado */}
         <div className="animated-background">
           <Header /> {/* Cabeçalho exibido no topo */}
@@ -20,5 +18,5 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </div>
       </body>
     </html>
-  );
+  )
 }

--- a/components/CookieBar.tsx
+++ b/components/CookieBar.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+
+// Barra de consentimento de cookies
+export function CookieBar() {
+  // Estado para verificar se o utilizador já aceitou os cookies
+  const [accepted, setAccepted] = useState(true)
+
+  useEffect(() => {
+    // Verifica no localStorage se o consentimento já foi dado
+    const stored = localStorage.getItem('cookie_accept')
+    if (stored !== 'true') {
+      setAccepted(false)
+    }
+  }, [])
+
+  // Regista o consentimento e oculta a barra
+  const handleAccept = () => {
+    localStorage.setItem('cookie_accept', 'true')
+    setAccepted(true)
+  }
+
+  if (accepted) return null
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-gray-800 p-4 text-center text-white">
+      {/* Mensagem informativa sobre cookies */}
+      <p className="mb-2">Usamos cookies para melhorar a experiência.</p>
+      <button
+        onClick={handleAccept}
+        className="rounded bg-yellow-400 px-4 py-2 font-semibold text-purple-900"
+      >
+        Aceitar
+      </button>
+    </div>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import React from 'react'
+
+// Rodapé simples exibindo direitos autorais
+export function Footer() {
+  return (
+    <footer className="bg-transparent p-4 text-center text-white">
+      {/* Texto de direitos autorais com o ano atual */}
+      <p>&copy; {new Date().getFullYear()} Cliente Mistério. Todos os direitos reservados.</p>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- correct root layout imports and remove unused font
- add footer and cookie consent bar components
- repair global CSS animation blocks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9b05c9ecc832ea5f6e59e7baaacf2