### PR TITLE
Fix homepage interactions and add contact form

### DIFF
--- a/app/(public)/contacto/page.tsx
+++ b/app/(public)/contacto/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+// Página de contacto com formulário básico
+import { useState } from 'react'
+
+export default function ContactPage() {
+  // Estado do formulário para armazenar os valores dos campos
+  const [form, setForm] = useState({ name: '', email: '', message: '' })
+
+  // Atualiza o estado quando o utilizador altera um campo
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  // Envia o formulário e limpa os campos
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert('Mensagem enviada!')
+    setForm({ name: '', email: '', message: '' })
+  }
+
+  return (
+    <section className="mx-auto max-w-xl py-20">
+      {/* Formulário de contacto */}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-white">Nome</label>
+          <input
+            type="text"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            className="w-full rounded p-2 text-black"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-white">Email</label>
+          <input
+            type="email"
+            name="email"
+            value={form.email}
+            onChange={handleChange}
+            className="w-full rounded p-2 text-black"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-white">Mensagem</label>
+          <textarea
+            name="message"
+            value={form.message}
+            onChange={handleChange}
+            className="w-full rounded p-2 text-black"
+            rows={5}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="rounded bg-yellow-400 px-6 py-2 font-semibold text-purple-900"
+        >
+          Enviar
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -1,15 +1,14 @@
 // Página inicial com layout inspirado em plataforma de cursos
-import Image from 'next/image'
 import Link from 'next/link'
 
 export default function HomePage() {
   return (
     <>
       {/* Secção hero com título, descrição e chamada para ação */}
-      <section className="flex flex-col items-center justify-between gap-10 py-20 md:flex-row md:text-left">
+      <section className="flex flex-col items-center justify-center gap-10 py-20 text-center">
         {/* Bloco de texto principal */}
-        <div className="max-w-xl text-center md:text-left">
-          <h1 className="text-5xl font-bold text-white">Plataforma de aprendizagem online</h1>
+        <div className="max-w-xl text-center">
+          <h1 className="text-5xl font-bold text-white">Curso Completo de Cliente Mistério</h1>
           <p className="mt-4 text-lg text-gray-200">
             Desenvolve competências com cursos e certificados de especialistas.
           </p>
@@ -18,13 +17,9 @@ export default function HomePage() {
               href="/comprar"
               className="rounded bg-yellow-400 px-6 py-3 font-semibold text-purple-900"
             >
-              Inscreve-te grátis
+              Adere já
             </Link>
           </div>
-        </div>
-        {/* Ilustração do lado direito */}
-        <div className="max-w-sm">
-          <Image src="/logo.svg" alt="Ilustração do curso" width={400} height={300} />
         </div>
       </section>
       {/* Secção com características do curso */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,6 +45,7 @@ html, body {
   background: radial-gradient(circle, rgba(255,255,255,0.15), transparent);
   transform: translate(-50%, -50%) rotate(0deg);
   animation: rotate 20s linear infinite;
+  pointer-events: none; /* Garante que não bloqueia cliques */
 }
 
 /* Direção inversa para a segunda camada */

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -42,7 +42,6 @@ export function Header() {
         <div className="hidden space-x-6 md:flex">
           <Link href="/">Início</Link>
           <Link href="/sobre">Sobre</Link>
-          <Link href="/blog">Blog</Link>
           <Link href="/contacto">Contacto</Link>
         </div>
         {/* Ações à direita */}


### PR DESCRIPTION
## Summary
- make hero links clickable and update text for mystery client course
- drop Blog menu option and add contact page with form
- enable pointer interactions on animated background

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9b4470048832e9840e54de9d4534b