### PR TITLE
Add registration form and rename 'Sobre' to 'Curso'

### DIFF
--- a/app/(public)/curso/page.tsx
+++ b/app/(public)/curso/page.tsx
@@ -1,0 +1,13 @@
+// Página com informação geral sobre o curso
+export default function CoursePage() {
+  return (
+    <section className="py-20 text-center">
+      {/* Título da página */}
+      <h2 className="text-3xl font-bold">Sobre o curso</h2>
+      {/* Descrição do curso */}
+      <p className="mt-4 text-gray-600">
+        Descubra os conteúdos e benefícios oferecidos pelo nosso curso.
+      </p>
+    </section>
+  )
+}

--- a/app/(public)/inscrever-se/page.tsx
+++ b/app/(public)/inscrever-se/page.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+// Página com formulário de registo para o curso
+import { FormEvent, useState } from 'react'
+
+export default function RegisterPage() {
+  // Estado local para armazenar os dados do formulário
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  // Função chamada ao submeter o formulário
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    // Aqui poderiam ser enviados os dados para a API
+    alert(`Registo enviado para ${name} (${email})`)
+    // Limpa os campos após envio
+    setName('')
+    setEmail('')
+    setPassword('')
+  }
+
+  return (
+    <section className="flex min-h-screen items-center justify-center bg-gray-100 p-6">
+      {/* Contentor do formulário */}
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md space-y-4 rounded bg-white p-8 shadow"
+      >
+        {/* Título do formulário */}
+        <h2 className="text-center text-2xl font-bold">Registar no curso</h2>
+        {/* Campo para o nome completo */}
+        <input
+          type="text"
+          placeholder="Nome completo"
+          className="w-full rounded border p-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        {/* Campo para o e-mail */}
+        <input
+          type="email"
+          placeholder="E-mail"
+          className="w-full rounded border p-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        {/* Campo para a palavra-passe */}
+        <input
+          type="password"
+          placeholder="Palavra-passe"
+          className="w-full rounded border p-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {/* Botão de envio */}
+        <button
+          type="submit"
+          className="w-full rounded bg-green-600 p-2 font-semibold text-white"
+        >
+          Registar
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -14,7 +14,7 @@ export default function HomePage() {
           </p>
           <div className="mt-8">
             <Link
-              href="/comprar"
+              href="/inscrever-se"
               className="rounded bg-yellow-400 px-6 py-3 font-semibold text-purple-900"
             >
               Adere já

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -41,13 +41,13 @@ export function Header() {
         {/* Ligações de navegação */}
         <div className="hidden space-x-6 md:flex">
           <Link href="/">Início</Link>
-          <Link href="/sobre">Sobre</Link>
+          <Link href="/curso">Curso</Link>
           <Link href="/contacto">Contacto</Link>
         </div>
         {/* Ações à direita */}
         <div className="space-x-4">
           <Link
-            href="/comprar"
+            href="/inscrever-se"
             className="rounded bg-yellow-400 px-4 py-2 font-semibold text-purple-900"
           >
             Inscrever-se


### PR DESCRIPTION
## Summary
- add dedicated course page and registration form
- update navigation links and home CTA to new registration page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9b900bf2c832e8164eeda4eed3375