### PR TITLE
feat: add authentication backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 npm-debug.log*
 yarn-error.log*
 dist
+__pycache__/
+*.pyc

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,79 @@
+# auth.py
+import os
+from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+from jose import jwt
+
+from database import SessionLocal
+from models import User
+from schemas import UserCreate, UserRead, UserLogin
+
+# Router que agrupa as rotas de autenticação
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+# Contexto usado para gerar e validar hashes de palavra-passe
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Chave secreta usada para assinar os tokens (definida em variáveis de ambiente)
+SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")
+# Algoritmo utilizado para assinar os tokens
+ALGORITHM = "HS256"
+# Duração padrão dos tokens de acesso
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+
+# Dependência que fornece uma sessão de base de dados
+def get_db():
+    # Cria uma nova sessão
+    db = SessionLocal()
+    try:
+        # Entrega a sessão ao chamador
+        yield db
+    finally:
+        # Fecha a sessão após utilização
+        db.close()
+
+# Função que cria um token JWT
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    # Copia os dados para evitar alterações externas
+    to_encode = data.copy()
+    # Calcula o momento de expiração
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    # Adiciona o campo de expiração
+    to_encode.update({"exp": expire})
+    # Codifica os dados num token JWT
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+# Rota que cria um novo utilizador
+@router.post("/register", response_model=UserRead)
+def register(user_in: UserCreate, db: Session = Depends(get_db)):
+    # Verifica se já existe utilizador com o mesmo e-mail
+    if db.query(User).filter(User.email == user_in.email).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    # Gera o hash da palavra-passe
+    hashed_password = pwd_context.hash(user_in.password)
+    # Cria a instância do utilizador
+    user = User(name=user_in.name, email=user_in.email, password_hash=hashed_password)
+    # Adiciona e confirma o novo utilizador na base de dados
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    # Devolve o utilizador sem a palavra-passe
+    return user
+
+# Rota que valida as credenciais e devolve um token
+@router.post("/login")
+def login(user_in: UserLogin, db: Session = Depends(get_db)):
+    # Procura o utilizador pelo e-mail
+    user = db.query(User).filter(User.email == user_in.email).first()
+    if not user:
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    # Verifica se a palavra-passe corresponde ao hash
+    if not pwd_context.verify(user_in.password, user.password_hash):
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    # Gera o token de acesso com o ID do utilizador
+    access_token = create_access_token({"sub": str(user.id)}, timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    # Devolve o token e o tipo
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,16 @@
+# database.py
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+# URL de ligação à base de dados (usada em Render; recolhida das variáveis de ambiente)
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg2://user:password@localhost:5432/sunny_sales")
+
+# Criação do motor da base de dados
+engine = create_engine(DATABASE_URL)
+
+# Criação da sessão para interações com a base de dados
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Base para definição dos modelos
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,13 @@
+# main.py
+from fastapi import FastAPI
+from database import Base, engine
+from auth import router as auth_router
+
+# Cria todas as tabelas na base de dados
+Base.metadata.create_all(bind=engine)
+
+# Instância principal da aplicação FastAPI
+app = FastAPI(title="Sunny Sales API")
+
+# Inclui o router de autenticação na aplicação
+app.include_router(auth_router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,17 @@
+# models.py
+from sqlalchemy import Column, Integer, String
+from database import Base
+
+# Modelo que representa a tabela de utilizadores
+class User(Base):
+    # Nome da tabela na base de dados
+    __tablename__ = "users"
+
+    # Coluna: identificador único do utilizador
+    id = Column(Integer, primary_key=True, index=True)
+    # Coluna: nome do utilizador
+    name = Column(String, nullable=False)
+    # Coluna: e-mail do utilizador
+    email = Column(String, unique=True, index=True, nullable=False)
+    # Coluna: hash da palavra-passe do utilizador
+    password_hash = Column(String, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+passlib[bcrypt]
+python-jose[cryptography]
+psycopg2-binary

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,31 @@
+# schemas.py
+from pydantic import BaseModel, EmailStr
+
+# Esquema para os dados enviados no registo
+class UserCreate(BaseModel):
+    # Nome completo do utilizador
+    name: str
+    # E-mail do utilizador
+    email: EmailStr
+    # Palavra-passe em texto simples (será cifrada)
+    password: str
+
+# Esquema para os dados devolvidos ao cliente
+class UserRead(BaseModel):
+    # Identificador do utilizador
+    id: int
+    # Nome completo do utilizador
+    name: str
+    # E-mail do utilizador
+    email: EmailStr
+
+    class Config:
+        # Permitir conversão a partir de objetos ORM
+        from_attributes = True
+
+# Esquema para os dados enviados no login
+class UserLogin(BaseModel):
+    # E-mail usado na autenticação
+    email: EmailStr
+    # Palavra-passe introduzida
+    password: str


### PR DESCRIPTION
## Summary
- add FastAPI backend with authentication
- configure SQLAlchemy and JWT logic
- ignore Python cache files

## Testing
- `python -m py_compile backend/*.py`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9c0c48e94832e99f1e5444e14ea85