### PR TITLE
fix: provide API root endpoint for health check

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,5 +15,12 @@ Base.metadata.create_all(bind=engine)
 app = FastAPI(title="Cliente Mistério API")
 
 
+# Rota principal que confirma que a API está ativa
+@app.get("/")
+def read_root():
+    # Devolve uma mensagem simples para indicar que o servidor está a funcionar
+    return {"message": "API is running"}
+
+
 # Inclui o router de autenticação na aplicação
 app.include_router(auth_router)


### PR DESCRIPTION
## Summary
- add root route to FastAPI app for basic health check

## Testing
- `python -m py_compile backend/*.py`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba1d8fcc80832ea0e75ee01ec234ce