### PR TITLE
Fix login session flag to align frontend auth

### DIFF
--- a/app/(public)/entrar/page.tsx
+++ b/app/(public)/entrar/page.tsx
@@ -30,8 +30,11 @@ export default function LoginPage() {
 
     try {
       const data = await loginUser({ email, password })
-      // Guarda a sessão com o token
-      localStorage.setItem('cm_session', JSON.stringify({ token: data.access_token }))
+      // Guarda a sessão com o token e marca o utilizador como autenticado
+      localStorage.setItem(
+        'cm_session',
+        JSON.stringify({ token: data.access_token, loggedIn: true })
+      )
       // Redireciona para a área do aluno
       router.push('/aluno')
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- ensure login stores authentication flag so protected pages and header detect session

## Testing
- `npm test` (fails: Missing script: "test")
- `cd backend && pytest` (no tests ran)

------
https://chatgpt.com/codex/tasks/task_e_68ba2446c1dc832e8807f0fbd5db1fea