### PR TITLE
feat: add basic email validation

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,31 +1,56 @@
-# schemas.py
-from pydantic import BaseModel, EmailStr
+"""Esquemas Pydantic usados para validação de dados."""
 
-# Esquema para os dados enviados no registo
+import re
+from pydantic import BaseModel, field_validator
+
+
 class UserCreate(BaseModel):
+    """Dados recebidos aquando do registo de um novo utilizador."""
+
     # Nome completo do utilizador
     name: str
     # E-mail do utilizador
-    email: EmailStr
+    email: str
     # Palavra-passe em texto simples (será cifrada)
     password: str
 
-# Esquema para os dados devolvidos ao cliente
+    @field_validator("email")
+    def validate_email(cls, v: str) -> str:
+        """Valida formato básico do e-mail."""
+        pattern = r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$"
+        if not re.match(pattern, v):
+            raise ValueError("Invalid email format")
+        return v
+
+
 class UserRead(BaseModel):
+    """Dados devolvidos ao cliente após operações de utilizador."""
+
     # Identificador do utilizador
     id: int
     # Nome completo do utilizador
     name: str
     # E-mail do utilizador
-    email: EmailStr
+    email: str
 
     class Config:
         # Permitir conversão a partir de objetos ORM
         from_attributes = True
 
-# Esquema para os dados enviados no login
+
 class UserLogin(BaseModel):
+    """Dados recebidos aquando do login."""
+
     # E-mail usado na autenticação
-    email: EmailStr
+    email: str
     # Palavra-passe introduzida
     password: str
+
+    @field_validator("email")
+    def validate_email(cls, v: str) -> str:
+        """Valida formato básico do e-mail."""
+        pattern = r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$"
+        if not re.match(pattern, v):
+            raise ValueError("Invalid email format")
+        return v
+


### PR DESCRIPTION
## Summary
- add regex-based email validators to avoid missing dependency

## Testing
- `curl -s http://localhost:8000/`
- `curl -s -X POST http://localhost:8000/auth/register -H 'Content-Type: application/json' -d '{"name":"Alice","email":"alice@example.com","password":"secret"}'`
- `curl -s -X POST http://localhost:8000/auth/login -H 'Content-Type: application/json' -d '{"email":"alice@example.com","password":"secret"}'`


------
https://chatgpt.com/codex/tasks/task_e_68ba9fa23484832e88fb4e293a7e7bd3