### PR TITLE
feat: redesign frontend layout

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,33 +1,32 @@
-// Página inicial com layout inspirado em plataforma de cursos
+// Página inicial com design inspirado em landing pages modernas
 import Link from 'next/link'
 import { Faq } from '@/components/Faq'
 
 export default function HomePage() {
   return (
     <>
-      {/* Secção hero com título, descrição e chamada para ação */}
-      <section className="flex flex-col items-center justify-center gap-10 py-20 text-center">
-        {/* Bloco de texto principal */}
-        <div className="max-w-xl text-center">
-          <h1 className="text-5xl font-bold text-white">Curso Completo de Cliente Mistério</h1>
-          <p className="mt-4 text-lg text-gray-200">
-            Desenvolve competências com cursos e certificados de especialistas.
+      {/* Secção hero com cruz vermelha ao fundo e chamada para ação */}
+      <section className="hero-cross flex items-center py-32">
+        {/* Bloco de texto principal alinhado à esquerda */}
+        <div className="container mx-auto max-w-4xl space-y-6">
+          <h1 className="text-5xl font-bold text-red-900">Your Gateway to Market Success</h1>
+          <p className="text-lg text-gray-700">
+            Expansion shouldn&apos;t be guesswork. We guide companies into new markets with clear steps, reliable partners and measurable results.
           </p>
-          <div className="mt-8">
-            <Link
-              href="/inscrever-se"
-              className="rounded bg-yellow-400 px-6 py-3 font-semibold text-purple-900"
-            >
-              Adere já
-            </Link>
-          </div>
+          <Link
+            href="/contacto"
+            className="inline-block rounded-full bg-red-700 px-8 py-3 font-semibold text-white"
+          >
+            Let&apos;s Talk
+          </Link>
         </div>
       </section>
+
       {/* Secção com características do curso */}
       <section className="mx-auto grid max-w-4xl gap-6 pb-20 text-center md:grid-cols-3">
         {/* Primeira característica */}
-        <div className="rounded-lg bg-white/20 p-6 backdrop-blur">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-purple-600 text-white">
+        <div className="rounded-lg bg-white p-6 shadow">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-700 text-white">
             <svg
               className="h-6 w-6"
               viewBox="0 0 24 24"
@@ -41,11 +40,11 @@ export default function HomePage() {
               <path d="M12 4v16" />
             </svg>
           </div>
-          <h3 className="mt-4 text-lg font-semibold text-white">Curso completo</h3>
+          <h3 className="mt-4 text-lg font-semibold text-gray-800">Curso completo</h3>
         </div>
         {/* Segunda característica */}
-        <div className="rounded-lg bg-white/20 p-6 backdrop-blur">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-purple-600 text-white">
+        <div className="rounded-lg bg-white p-6 shadow">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-700 text-white">
             <svg
               className="h-6 w-6"
               viewBox="0 0 24 24"
@@ -59,11 +58,11 @@ export default function HomePage() {
               <path d="M5.5 21c1.5-4 5-4 6.5-4s5 0 6.5 4" />
             </svg>
           </div>
-          <h3 className="mt-4 text-lg font-semibold text-white">Equipa experiente</h3>
+          <h3 className="mt-4 text-lg font-semibold text-gray-800">Equipa experiente</h3>
         </div>
         {/* Terceira característica */}
-        <div className="rounded-lg bg-white/20 p-6 backdrop-blur">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-purple-600 text-white">
+        <div className="rounded-lg bg-white p-6 shadow">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-700 text-white">
             <svg
               className="h-6 w-6"
               viewBox="0 0 24 24"
@@ -77,9 +76,10 @@ export default function HomePage() {
               <path d="M6 8a6 6 0 019 4 6 6 0 01-9 4" />
             </svg>
           </div>
-          <h3 className="mt-4 text-lg font-semibold text-white">Acesso vitalício</h3>
+          <h3 className="mt-4 text-lg font-semibold text-gray-800">Acesso vitalício</h3>
         </div>
       </section>
+
       {/* Secção de perguntas frequentes */}
       <Faq />
     </>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -11,54 +11,38 @@ html, body {
   padding: 0;
   /* Garante altura mínima sem bloquear a rolagem */
   min-height: 100vh;
-  /* Aplica o gradiente vertical azul como fundo */
-  background: #7F7FD5; /* cor de fallback para navegadores antigos */
-  background: -webkit-linear-gradient(to bottom, #91EAE4, #86A8E7, #7F7FD5); /* suporte para Chrome 10-25 e Safari 5.1-6 */
-  background: linear-gradient(to bottom, #91EAE4, #86A8E7, #7F7FD5); /* padrão moderno (W3C, IE 10+, Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+) */
+  /* Define fundo cinzento claro para todo o site */
+  background: #f3f4f6;
   /* Impede rolagem horizontal mantendo a vertical */
   overflow-x: hidden;
   overflow-y: auto;
 }
 
-/* Contêiner responsável pelo fundo animado */
-.animated-background {
-  position: relative;
-  z-index: 0; /* Cria contexto de empilhamento para o fundo animado */
-  width: 100%;
-  min-height: 100vh; /* Preenche a altura da janela para evitar segunda barra de rolagem */
-  /* Bloqueia transbordo lateral e vertical das camadas animadas */
-  overflow: hidden;
-  /* Gradiente radial suave sobreposto ao fundo */
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.1));
+/* Estilo da secção hero com cruz vermelha de fundo */
+.hero-cross {
+  position: relative; /* Permite posicionar elementos filhos de forma absoluta */
+  overflow: hidden; /* Evita que a cruz ultrapasse os limites da secção */
 }
 
-/* Camadas giratórias para criar o efeito de brilho */
-.animated-background::before,
-.animated-background::after {
-  content: "";
+.hero-cross::before,
+.hero-cross::after {
+  content: ""; /* Cria pseudo-elementos vazios */
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 200%;
-  height: 200%;
-  /* Gradiente circular translúcido */
-  background: radial-gradient(circle, rgba(255,255,255,0.15), transparent);
-  transform: translate(-50%, -50%) rotate(0deg);
-  animation: rotate 20s linear infinite;
-  pointer-events: none; /* Garante que não bloqueia cliques */
+  background: #7f1d1d; /* Tom de vermelho semelhante ao do exemplo */
+  opacity: 0.9;
+  z-index: -1; /* Coloca a cruz atrás do conteúdo */
 }
 
-/* Direção inversa para a segunda camada */
-.animated-background::after {
-  animation-direction: reverse;
+.hero-cross::before {
+  width: 30%; /* Barra vertical da cruz */
+  height: 150%;
+  top: -25%;
+  left: 35%;
 }
 
-/* Animação de rotação */
-@keyframes rotate {
-  from {
-    transform: translate(-50%, -50%) rotate(0deg);
-  }
-  to {
-    transform: translate(-50%, -50%) rotate(360deg);
-  }
+.hero-cross::after {
+  width: 150%; /* Barra horizontal da cruz */
+  height: 30%;
+  left: -25%;
+  top: 35%;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,15 +4,15 @@ import { Header } from '../components/Header'
 import { Footer } from '../components/Footer'
 import { CookieBar } from '../components/CookieBar'
 
-// Layout raiz com cabeçalho, rodapé e fundo animado
+// Layout raiz com cabeçalho, rodapé e estilos globais
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt">
       <body>
-        {/* Contêiner com fundo animado */}
-        <div className="animated-background">
+        {/* Estrutura principal com fundo cinzento */}
+        <div className="min-h-screen bg-gray-100 text-gray-900">
           <Header /> {/* Cabeçalho exibido no topo */}
-          <main className="pt-16">{children}</main> {/* Conteúdo variável com espaço superior */}
+          <main className="pt-20">{children}</main> {/* Conteúdo variável com espaçamento superior */}
           <Footer /> {/* Rodapé com informações adicionais */}
           <CookieBar /> {/* Aviso de cookies obrigatório */}
         </div>

--- a/frontend/components/Faq.tsx
+++ b/frontend/components/Faq.tsx
@@ -44,19 +44,19 @@ export function Faq() {
   return (
     <section className="mx-auto max-w-3xl pb-20">
       {/* Título principal da secção */}
-      <h2 className="mb-8 text-center text-3xl font-bold text-white">FAQs</h2>
+      <h2 className="mb-8 text-center text-3xl font-bold text-gray-800">FAQs</h2>
       {/* Lista de perguntas */}
       <div className="space-y-4">
         {faqItems.map((item) => (
           // Cada item expansível com pergunta e resposta
           <details
             key={item.question}
-            className="rounded-lg bg-white/20 p-4 text-white backdrop-blur"
+            className="rounded-lg bg-white p-4 shadow text-gray-800"
           >
             {/* Pergunta visível que pode ser clicada */}
-            <summary className="cursor-pointer">{item.question}</summary>
+            <summary className="cursor-pointer font-medium">{item.question}</summary>
             {/* Resposta apresentada ao clicar na pergunta */}
-            <p className="mt-2 text-gray-200">{item.answer}</p>
+            <p className="mt-2 text-gray-600">{item.answer}</p>
           </details>
         ))}
       </div>

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,11 +1,9 @@
-'use client'
-
 import React from 'react'
 
 // Rodapé simples exibindo direitos autorais
 export function Footer() {
   return (
-    <footer className="bg-transparent p-4 text-center text-white">
+    <footer className="bg-gray-100 p-4 text-center text-gray-600">
       {/* Texto de direitos autorais com o ano atual */}
       <p>&copy; {new Date().getFullYear()} Cliente Mistério. Todos os direitos reservados.</p>
     </footer>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,66 +1,23 @@
-'use client'
+import Link from 'next/link'
 
 // Cabeçalho com navegação principal
-import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-
 export function Header() {
-  // Estado para indicar se o utilizador está autenticado
-  const [isLogged, setIsLogged] = useState(false)
-  const router = useRouter()
-
-  useEffect(() => {
-    // Verifica a sessão armazenada no localStorage
-    const session = localStorage.getItem('cm_session')
-    if (session) {
-      try {
-        const parsed = JSON.parse(session)
-        setIsLogged(parsed.loggedIn === true)
-      } catch {
-        setIsLogged(false)
-      }
-    }
-  }, [])
-
-  // Termina a sessão e redireciona para a página inicial
-  const handleSignOut = () => {
-    localStorage.removeItem('cm_session')
-    setIsLogged(false)
-    router.push('/')
-  }
-
   return (
-    <header className="bg-transparent">
+    <header className="bg-gray-100">
       {/* Barra de navegação principal */}
-      <nav className="container mx-auto flex items-center justify-between p-6 text-white">
-        {/* Logótipo ou nome do curso */}
-        <Link href="/" className="text-2xl font-bold">
+      <nav className="container mx-auto flex items-center justify-between p-6 text-gray-800">
+        {/* Logótipo ou nome do site */}
+        <Link href="/" className="text-3xl font-bold text-red-700">
           Cliente Mistério
         </Link>
         {/* Ligações de navegação */}
-        <div className="hidden space-x-6 md:flex">
-          <Link href="/">Início</Link>
-          <Link href="/curso">Curso</Link>
-          <Link href="/contacto">Contacto</Link>
-        </div>
-        {/* Ações à direita */}
-        <div className="space-x-4">
-          <Link
-            href="/inscrever-se"
-            className="rounded bg-yellow-400 px-4 py-2 font-semibold text-purple-900"
-          >
-            Inscrever-se
-          </Link>
-          {isLogged ? (
-            <button onClick={handleSignOut} className="px-4 py-2">
-              Sair
-            </button>
-          ) : (
-            <Link href="/entrar" className="px-4 py-2">
-              Entrar
-            </Link>
-          )}
+        <div className="hidden space-x-8 md:flex">
+          <Link href="/">Home</Link>
+          <Link href="#about">About</Link>
+          <Link href="#philosophy">Philosophy</Link>
+          <Link href="#development">Development</Link>
+          <Link href="#career">Career</Link>
+          <Link href="/contacto">Contact</Link>
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- redesign global styling with light gray background and red cross hero section
- simplify header and footer to match modern landing page style
- adjust FAQ and homepage sections for new color scheme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bacc863038832e968307260d11996a