### PR TITLE
feat: redesign site with new header and theme

### DIFF
--- a/frontend/app/(public)/contacto/page.tsx
+++ b/frontend/app/(public)/contacto/page.tsx
@@ -32,7 +32,7 @@ export default function ContactPage() {
             name="name"
             value={form.name}
             onChange={handleChange}
-            className="w-full rounded p-2 text-black"
+            className="w-full rounded border border-white bg-transparent p-2 text-white"
             required
           />
         </div>
@@ -43,7 +43,7 @@ export default function ContactPage() {
             name="email"
             value={form.email}
             onChange={handleChange}
-            className="w-full rounded p-2 text-black"
+            className="w-full rounded border border-white bg-transparent p-2 text-white"
             required
           />
         </div>
@@ -53,14 +53,14 @@ export default function ContactPage() {
             name="message"
             value={form.message}
             onChange={handleChange}
-            className="w-full rounded p-2 text-black"
+            className="w-full rounded border border-white bg-transparent p-2 text-white"
             rows={5}
             required
           />
         </div>
         <button
           type="submit"
-          className="rounded bg-yellow-400 px-6 py-2 font-semibold text-purple-900"
+          className="rounded border border-white px-6 py-2 font-semibold text-white hover:bg-white/20"
         >
           Enviar
         </button>

--- a/frontend/app/(public)/enterprise/page.tsx
+++ b/frontend/app/(public)/enterprise/page.tsx
@@ -1,0 +1,10 @@
+// Página "Enterprise" com texto centralizado
+export default function EnterprisePage() {
+  return (
+    <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
+      {/* Texto principal da página Enterprise */}
+      <h1 className="text-4xl font-bold">Enterprise</h1>
+    </section>
+  )
+}
+

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,87 +1,9 @@
-// Página inicial com design inspirado em landing pages modernas
-import Link from 'next/link'
-import { Faq } from '@/components/Faq'
-
+// Página inicial com título centralizado
 export default function HomePage() {
   return (
-    <>
-      {/* Secção hero com cruz vermelha ao fundo e chamada para ação */}
-      <section className="hero-cross flex items-center py-32">
-        {/* Bloco de texto principal alinhado à esquerda */}
-        <div className="container mx-auto max-w-4xl space-y-6">
-          <h1 className="text-5xl font-bold text-red-900">Your Gateway to Market Success</h1>
-          <p className="text-lg text-gray-700">
-            Expansion shouldn&apos;t be guesswork. We guide companies into new markets with clear steps, reliable partners and measurable results.
-          </p>
-          <Link
-            href="/contacto"
-            className="inline-block rounded-full bg-red-700 px-8 py-3 font-semibold text-white"
-          >
-            Let&apos;s Talk
-          </Link>
-        </div>
-      </section>
-
-      {/* Secção com características do curso */}
-      <section className="mx-auto grid max-w-4xl gap-6 pb-20 text-center md:grid-cols-3">
-        {/* Primeira característica */}
-        <div className="rounded-lg bg-white p-6 shadow">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-700 text-white">
-            <svg
-              className="h-6 w-6"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M3 4h18v16H3z" />
-              <path d="M12 4v16" />
-            </svg>
-          </div>
-          <h3 className="mt-4 text-lg font-semibold text-gray-800">Curso completo</h3>
-        </div>
-        {/* Segunda característica */}
-        <div className="rounded-lg bg-white p-6 shadow">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-700 text-white">
-            <svg
-              className="h-6 w-6"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <circle cx="12" cy="7" r="4" />
-              <path d="M5.5 21c1.5-4 5-4 6.5-4s5 0 6.5 4" />
-            </svg>
-          </div>
-          <h3 className="mt-4 text-lg font-semibold text-gray-800">Equipa experiente</h3>
-        </div>
-        {/* Terceira característica */}
-        <div className="rounded-lg bg-white p-6 shadow">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-700 text-white">
-            <svg
-              className="h-6 w-6"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M18 8a6 6 0 00-9 4 6 6 0 019 4" />
-              <path d="M6 8a6 6 0 019 4 6 6 0 01-9 4" />
-            </svg>
-          </div>
-          <h3 className="mt-4 text-lg font-semibold text-gray-800">Acesso vitalício</h3>
-        </div>
-      </section>
-
-      {/* Secção de perguntas frequentes */}
-      <Faq />
-    </>
+    <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
+      {/* Texto principal exibido no centro da página */}
+      <h1 className="text-4xl font-bold">Curso Completo - Cliente Mistério</h1>
+    </section>
   )
 }

--- a/frontend/app/(public)/sobre/page.tsx
+++ b/frontend/app/(public)/sobre/page.tsx
@@ -1,0 +1,10 @@
+// Página "Sobre" com texto centralizado
+export default function SobrePage() {
+  return (
+    <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
+      {/* Texto principal da página Sobre */}
+      <h1 className="text-4xl font-bold">Sobre</h1>
+    </section>
+  )
+}
+

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,47 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Estilos globais base (editáveis) */
+/* Estilos globais base */
 html, body {
-  /* Define a cor de texto padrão */
-  @apply text-gray-900;
+  /* Define texto branco em todo o site */
+  @apply text-white;
   /* Remove margens e preenchimentos padrão */
   margin: 0;
   padding: 0;
   /* Garante altura mínima sem bloquear a rolagem */
   min-height: 100vh;
-  /* Define fundo cinzento claro para todo o site */
-  background: #f3f4f6;
+  /* Define fundo vermelho para todo o site */
+  background: #b82c3c;
   /* Impede rolagem horizontal mantendo a vertical */
   overflow-x: hidden;
   overflow-y: auto;
-}
-
-/* Estilo da secção hero com cruz vermelha de fundo */
-.hero-cross {
-  position: relative; /* Permite posicionar elementos filhos de forma absoluta */
-  overflow: hidden; /* Evita que a cruz ultrapasse os limites da secção */
-}
-
-.hero-cross::before,
-.hero-cross::after {
-  content: ""; /* Cria pseudo-elementos vazios */
-  position: absolute;
-  background: #7f1d1d; /* Tom de vermelho semelhante ao do exemplo */
-  opacity: 0.9;
-  z-index: -1; /* Coloca a cruz atrás do conteúdo */
-}
-
-.hero-cross::before {
-  width: 30%; /* Barra vertical da cruz */
-  height: 150%;
-  top: -25%;
-  left: 35%;
-}
-
-.hero-cross::after {
-  width: 150%; /* Barra horizontal da cruz */
-  height: 30%;
-  left: -25%;
-  top: 35%;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,8 +9,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="pt">
       <body>
-        {/* Estrutura principal com fundo cinzento */}
-        <div className="min-h-screen bg-gray-100 text-gray-900">
+        {/* Estrutura principal com fundo vermelho e texto branco */}
+        <div className="min-h-screen bg-[#b82c3c] text-white">
           <Header /> {/* Cabeçalho exibido no topo */}
           <main className="pt-20">{children}</main> {/* Conteúdo variável com espaçamento superior */}
           <Footer /> {/* Rodapé com informações adicionais */}

--- a/frontend/components/CookieBar.tsx
+++ b/frontend/components/CookieBar.tsx
@@ -24,12 +24,12 @@ export function CookieBar() {
   if (accepted) return null
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-gray-800 p-4 text-center text-white">
+    <div className="fixed bottom-0 left-0 right-0 bg-[#b82c3c] p-4 text-center text-white">
       {/* Mensagem informativa sobre cookies */}
       <p className="mb-2">Usamos cookies para melhorar a experiência.</p>
       <button
         onClick={handleAccept}
-        className="rounded bg-yellow-400 px-4 py-2 font-semibold text-purple-900"
+        className="rounded border border-white px-4 py-2 font-semibold text-white hover:bg-white/20"
       >
         Aceitar
       </button>

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 // Rodapé simples exibindo direitos autorais
 export function Footer() {
   return (
-    <footer className="bg-gray-100 p-4 text-center text-gray-600">
+    <footer className="bg-[#b82c3c] p-4 text-center text-white">
       {/* Texto de direitos autorais com o ano atual */}
       <p>&copy; {new Date().getFullYear()} Cliente Mistério. Todos os direitos reservados.</p>
     </footer>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -3,21 +3,19 @@ import Link from 'next/link'
 // Cabeçalho com navegação principal
 export function Header() {
   return (
-    <header className="bg-gray-100">
+    <header className="fixed left-0 right-0 top-0 bg-[#b82c3c]">
       {/* Barra de navegação principal */}
-      <nav className="container mx-auto flex items-center justify-between p-6 text-gray-800">
-        {/* Logótipo ou nome do site */}
-        <Link href="/" className="text-3xl font-bold text-red-700">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between p-6 text-white">
+        {/* Nome do site no canto superior esquerdo */}
+        <Link href="/" className="text-2xl font-bold">
           Cliente Mistério
         </Link>
-        {/* Ligações de navegação */}
-        <div className="hidden space-x-8 md:flex">
-          <Link href="/">Home</Link>
-          <Link href="#about">About</Link>
-          <Link href="#philosophy">Philosophy</Link>
-          <Link href="#development">Development</Link>
-          <Link href="#career">Career</Link>
-          <Link href="/contacto">Contact</Link>
+        {/* Ligações de navegação para as páginas principais */}
+        <div className="space-x-6">
+          <Link href="/">Início</Link>
+          <Link href="/sobre">Sobre</Link>
+          <Link href="/contacto">Contacto</Link>
+          <Link href="/enterprise">Enterprise</Link>
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- apply red theme with white text across the site
- add navigation links and new Enterprise page
- center home page title

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bad0745c04832e87312382725e68b3