### PR TITLE
Add signup button and profile icon

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,9 +1,18 @@
-// Página inicial com título centralizado
+import Link from 'next/link'
+
+// Página inicial com título centralizado e botão de registo
 export default function HomePage() {
   return (
-    <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
+    <section className="flex min-h-[calc(100vh-5rem)] flex-col items-center justify-center">
       {/* Texto principal exibido no centro da página */}
       <h1 className="text-4xl font-bold">Curso Completo - Cliente Mistério</h1>
+      {/* Botão que redireciona para a página de registo */}
+      <Link
+        href="/inscrever-se"
+        className="mt-6 rounded bg-white px-8 py-3 font-medium text-[#b82c3c]"
+      >
+        Adere já
+      </Link>
     </section>
   )
 }

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -10,12 +10,30 @@ export function Header() {
         <Link href="/" className="text-2xl font-bold">
           Cliente Mistério
         </Link>
-        {/* Ligações de navegação para as páginas principais */}
-        <div className="space-x-6">
+        {/* Ligações de navegação para as páginas principais e ícone de perfil */}
+        <div className="flex items-center space-x-6">
           <Link href="/">Início</Link>
           <Link href="/curso">Curso</Link>
           <Link href="/contacto">Contacto</Link>
           <Link href="/enterprise">Enterprise</Link>
+          {/* Ícone de perfil que redireciona para a página de login */}
+          <Link href="/entrar" aria-label="Fazer login" className="inline-flex">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="h-6 w-6"
+            >
+              <circle cx="12" cy="8" r="4" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 20c0-4 4-6 8-6s8 2 8 6"
+              />
+            </svg>
+          </Link>
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- add "Adere já" button on home page linking to registration
- add profile icon in header linking to login

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae5c48c24832ea2c0ad66f35e2484