### PR TITLE
feat: update font and home layout

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,18 +1,26 @@
 import Link from 'next/link'
 
-// Página inicial com título centralizado e botão de registo
+// Página inicial com dois blocos lado a lado: título e descrição
 export default function HomePage() {
   return (
-    <section className="flex min-h-[calc(100vh-5rem)] flex-col items-center justify-center">
-      {/* Texto principal exibido no centro da página */}
-      <h1 className="text-4xl font-bold">Curso Completo - Cliente Mistério</h1>
-      {/* Botão que redireciona para a página de registo */}
-      <Link
-        href="/inscrever-se"
-        className="mt-6 rounded bg-white px-8 py-3 font-medium text-[#b82c3c]"
-      >
-        Adere já
-      </Link>
+    <section className="flex min-h-[calc(100vh-5rem)] items-center">
+      {/* Bloco esquerdo com o título principal */}
+      <div className="flex w-1/2 justify-center">
+        <h1 className="text-6xl font-bold">Curso Completo</h1>
+      </div>
+      {/* Bloco direito com a descrição e botão de registo */}
+      <div className="w-1/2 px-8">
+        <p className="text-xl">
+          Baseado em experiência prática em projetos reais em Portugal, o curso apresenta de forma
+          simples e objetiva tudo o que precisa de saber para começar ou evoluir nesta área.
+        </p>
+        <Link
+          href="/inscrever-se"
+          className="mt-6 inline-block rounded bg-white px-8 py-3 font-medium text-[#b82c3c]"
+        >
+          Adere já
+        </Link>
+      </div>
     </section>
   )
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,19 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Declaração do tipo de letra Butler Stencil */
-@font-face {
-  font-family: 'butler-regular_stencil';
-  src: url('https://fonts.cdnfonts.com/s/20312/Butler_Stencil.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
-}
-
 /* Estilos globais base */
 html, body {
-  /* Aplica o tipo de letra em todo o site */
-  font-family: 'butler-regular_stencil', serif;
+  /* Aplica o tipo de letra Roboto em todo o site */
+  font-family: 'Roboto', sans-serif;
   /* Define texto branco em todo o site */
   @apply text-white;
   /* Remove margens e preenchimentos padrão */


### PR DESCRIPTION
## Summary
- use Roboto font across the site
- split home page hero into two columns with description

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baef126c58832e9657209bdeb3ccd4