### PR TITLE
feat: add landing layout with purple theme

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,25 +1,25 @@
 import Link from 'next/link'
 
-// Página inicial com dois blocos lado a lado: título e descrição
+// Página inicial com título destacado e espaço para imagem ou vídeo
 export default function HomePage() {
   return (
     <section className="flex min-h-[calc(100vh-5rem)] items-center">
-      {/* Bloco esquerdo com o título principal */}
-      <div className="flex w-1/2 justify-center">
-        <h1 className="text-6xl font-bold">Curso Completo</h1>
-      </div>
-      {/* Bloco direito com a descrição e botão de registo */}
-      <div className="w-1/2 px-8">
-        <p className="text-xl">
-          Baseado em experiência prática em projetos reais em Portugal, o curso apresenta de forma
-          simples e objetiva tudo o que precisa de saber para começar ou evoluir nesta área.
-        </p>
+      {/* Bloco esquerdo com o título principal e botão de adesão */}
+      <div className="flex w-1/2 flex-col items-start justify-center space-y-8 pl-16">
+        <h1 className="text-8xl font-bold leading-none">
+          <span className="block">CURSO</span>
+          <span className="block">COMPLETO</span>
+        </h1>
         <Link
           href="/inscrever-se"
-          className="mt-6 inline-block rounded bg-white px-8 py-3 font-medium text-[#b82c3c]"
+          className="rounded bg-white px-10 py-4 font-medium text-[#b53de6]"
         >
-          Adere já
+          Adere já!
         </Link>
+      </div>
+      {/* Bloco direito com caixa vazia para imagem ou vídeo futuro */}
+      <div className="flex w-1/2 justify-center">
+        <div className="h-80 w-80 border-2 border-white" />
       </div>
     </section>
   )

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -15,8 +15,8 @@ html, body {
   padding: 0;
   /* Garante altura mínima sem bloquear a rolagem */
   min-height: 100vh;
-  /* Define fundo vermelho para todo o site */
-  background: #b82c3c;
+  /* Define fundo gradiente roxo semelhante ao design fornecido */
+  background: linear-gradient(135deg, #b53de6 0%, #a534de 100%);
   /* Impede rolagem horizontal mantendo a vertical */
   overflow-x: hidden;
   overflow-y: auto;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,8 +9,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="pt">
       <body>
-        {/* Estrutura principal com fundo vermelho e texto branco */}
-        <div className="min-h-screen bg-[#b82c3c] text-white">
+        {/* Estrutura principal com fundo gradiente roxo e texto branco */}
+        <div className="min-h-screen text-white">
           <Header /> {/* Cabeçalho exibido no topo */}
           <main className="pt-20">{children}</main> {/* Conteúdo variável com espaçamento superior */}
           <Footer /> {/* Rodapé com informações adicionais */}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,22 +1,28 @@
 import Link from 'next/link'
+import Image from 'next/image'
 
 // Cabeçalho com navegação principal
 export function Header() {
   return (
-    <header className="fixed left-0 right-0 top-0 bg-[#b82c3c]">
-      {/* Barra de navegação principal */}
+    // Cabeçalho fixo com elementos distribuídos em três colunas
+    <header className="fixed left-0 right-0 top-0">
+      {/* Barra de navegação com logo, menus centrais e ícones à direita */}
       <nav className="mx-auto flex max-w-6xl items-center justify-between p-6 text-white">
-        {/* Nome do site no canto superior esquerdo */}
-        <Link href="/" className="text-2xl font-bold">
-          Cliente Mistério
-        </Link>
-        {/* Ligações de navegação para as páginas principais e ícone de perfil */}
-        <div className="flex items-center space-x-6">
+        {/* Logótipo no canto superior esquerdo */}
+        <div className="flex flex-1 justify-start">
+          <Link href="/" aria-label="Página inicial">
+            <Image src="/logo.svg" alt="Cliente Mistério" width={48} height={48} />
+          </Link>
+        </div>
+        {/* Menus de navegação centrados */}
+        <div className="flex flex-1 justify-center space-x-6">
           <Link href="/">Início</Link>
           <Link href="/curso">Curso</Link>
           <Link href="/contacto">Contacto</Link>
           <Link href="/enterprise">Enterprise</Link>
-          {/* Ícone de perfil que redireciona para a página de login */}
+        </div>
+        {/* Ícones de login e pesquisa no canto superior direito */}
+        <div className="flex flex-1 items-center justify-end space-x-4">
           <Link href="/entrar" aria-label="Fazer login" className="inline-flex">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -31,6 +37,26 @@ export function Header() {
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 d="M4 20c0-4 4-6 8-6s8 2 8 6"
+              />
+            </svg>
+          </Link>
+          <Link href="#" aria-label="Pesquisar" className="inline-flex">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="h-6 w-6"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <line
+                x1="21"
+                y1="21"
+                x2="16.65"
+                y2="16.65"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
             </svg>
           </Link>


### PR DESCRIPTION
## Summary
- center navigation links and add logo, login, and search icons in header
- build purple gradient landing section with call-to-action and media placeholder
- apply global purple gradient background

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68baf9cb5d0c832e80a8f93b33d009a2