### PR TITLE
feat: update header branding and layout

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -3,9 +3,9 @@ import Link from 'next/link'
 // Página inicial com título destacado e espaço para imagem ou vídeo
 export default function HomePage() {
   return (
-    <section className="flex min-h-[calc(100vh-5rem)] items-center">
+    <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center gap-16">
       {/* Bloco esquerdo com o título principal e botão de adesão */}
-      <div className="flex w-1/2 flex-col items-start justify-center space-y-8 pl-16">
+      <div className="flex flex-col items-start justify-center space-y-8">
         <h1 className="text-8xl font-bold leading-none">
           <span className="block">CURSO</span>
           <span className="block">COMPLETO</span>
@@ -18,7 +18,7 @@ export default function HomePage() {
         </Link>
       </div>
       {/* Bloco direito com caixa vazia para imagem ou vídeo futuro */}
-      <div className="flex w-1/2 justify-center">
+      <div className="flex justify-center">
         <div className="h-80 w-80 border-2 border-white" />
       </div>
     </section>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,17 +1,16 @@
 import Link from 'next/link'
-import Image from 'next/image'
 
 // Cabeçalho com navegação principal
 export function Header() {
   return (
     // Cabeçalho fixo com elementos distribuídos em três colunas
     <header className="fixed left-0 right-0 top-0">
-      {/* Barra de navegação com logo, menus centrais e ícones à direita */}
-      <nav className="mx-auto flex max-w-6xl items-center justify-between p-6 text-white">
-        {/* Logótipo no canto superior esquerdo */}
+      {/* Barra de navegação com texto do logótipo, menus centrais e ícones à direita */}
+      <nav className="mx-auto flex max-w-6xl items-center justify-between p-6 text-white text-lg font-bold">
+        {/* Texto do logótipo no canto superior esquerdo */}
         <div className="flex flex-1 justify-start">
           <Link href="/" aria-label="Página inicial">
-            <Image src="/logo.svg" alt="Cliente Mistério" width={48} height={48} />
+            <span className="text-2xl font-bold">Cliente Mistério</span>
           </Link>
         </div>
         {/* Menus de navegação centrados */}


### PR DESCRIPTION
## Summary
- replace image logo with bold "Cliente Mistério" text
- enlarge and bold header navigation links
- center homepage panels for balanced layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb0957b9ec832eb32f645c182ce987