### PR TITLE
feat: center auth forms and rotate homepage messages

### DIFF
--- a/frontend/app/(public)/contacto/page.tsx
+++ b/frontend/app/(public)/contacto/page.tsx
@@ -60,7 +60,7 @@ export default function ContactPage() {
         </div>
         <button
           type="submit"
-          className="rounded border border-white px-6 py-2 font-semibold text-white hover:bg-white/20"
+          className="rounded border border-white px-6 py-2 font-bold text-white hover:bg-white/20"
         >
           Enviar
         </button>

--- a/frontend/app/(public)/entrar/page.tsx
+++ b/frontend/app/(public)/entrar/page.tsx
@@ -45,8 +45,8 @@ export default function LoginPage() {
   }
 
   return (
-    // Centraliza o formulário na página
-    <section className="flex justify-center">
+    // Centraliza o formulário no ecrã e posiciona-o mais abaixo
+    <section className="flex min-h-screen items-center justify-center">
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}
         <p className="title">Entrar</p>

--- a/frontend/app/(public)/inscrever-se/page.tsx
+++ b/frontend/app/(public)/inscrever-se/page.tsx
@@ -30,8 +30,8 @@ export default function RegisterPage() {
   }
 
   return (
-    // Centraliza o formulário na página
-    <section className="flex justify-center">
+    // Centraliza o formulário no ecrã e posiciona-o mais abaixo
+    <section className="flex min-h-screen items-center justify-center">
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}
         <p className="title">Inscrever-se</p>

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,7 +1,36 @@
-import Link from 'next/link'
+'use client'
 
-// Página inicial com título destacado e espaço para imagem ou vídeo
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+// Lista de frases a serem alternadas na caixa
+const phrases = [
+  'Recebe produtos gratuitos para experimentar',
+  'Ganha dinheiro ao dar a tua opinião',
+  'Testa serviços e marcas em primeira mão',
+  'Ofertas exclusivas só para clientes mistério',
+  'Ajuda as empresas a melhorar e é recompensado',
+  'Transforma avaliações em oportunidades',
+  'Participa em missões divertidas e pagas',
+  'A tua opinião tem valor — e é paga por isso',
+  'Experimenta antes de todos os outros',
+  'Converte o teu tempo livre em recompensas',
+]
+
+// Página inicial com título destacado e caixa de frases rotativas
 export default function HomePage() {
+  // Índice da frase atual a ser mostrada
+  const [index, setIndex] = useState(0)
+
+  // Altera a frase a cada 5 segundos
+  useEffect(() => {
+    const interval = setInterval(
+      () => setIndex((i) => (i + 1) % phrases.length),
+      5000
+    )
+    return () => clearInterval(interval)
+  }, [])
+
   return (
     <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center gap-16">
       {/* Bloco esquerdo com o título principal e botão de adesão */}
@@ -12,14 +41,16 @@ export default function HomePage() {
         </h1>
         <Link
           href="/inscrever-se"
-          className="rounded bg-white px-10 py-4 font-medium text-[#b53de6]"
+          className="rounded bg-white px-10 py-4 font-bold text-[#b53de6]"
         >
           Adere já!
         </Link>
       </div>
-      {/* Bloco direito com caixa vazia para imagem ou vídeo futuro */}
+      {/* Bloco direito com caixa que exibe frases rotativas */}
       <div className="flex justify-center">
-        <div className="h-80 w-80 border-2 border-white" />
+        <div className="flex h-80 w-80 items-center justify-center border-2 border-white p-4 text-center">
+          <p>{phrases[index]}</p>
+        </div>
       </div>
     </section>
   )

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -22,6 +22,11 @@ html, body {
   overflow-y: auto;
 }
 
+/* Torna o texto de todos os botões em negrito */
+button {
+  font-weight: 700;
+}
+
 /* Contêiner principal do formulário */
 .form-control {
   margin: 20px;

--- a/frontend/components/CookieBar.tsx
+++ b/frontend/components/CookieBar.tsx
@@ -29,7 +29,7 @@ export function CookieBar() {
       <p className="mb-2">Usamos cookies para melhorar a experiência.</p>
       <button
         onClick={handleAccept}
-        className="rounded border border-white px-4 py-2 font-semibold text-white hover:bg-white/20"
+        className="rounded border border-white px-4 py-2 font-bold text-white hover:bg-white/20"
       >
         Aceitar
       </button>


### PR DESCRIPTION
## Summary
- center login and registration forms lower on screen
- show rotating marketing phrases on homepage square
- enforce bold text for all buttons

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb12bf43b0832e80ccc30a136ff642