### PR TITLE
Adjust form styles and FAQ position

### DIFF
--- a/frontend/app/(public)/contacto/page.tsx
+++ b/frontend/app/(public)/contacto/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-// Página de contacto com formulário básico
+// Página de contacto com formulário formatado como os restantes
 import { useState } from 'react'
 
 export default function ContactPage() {
@@ -22,49 +22,58 @@ export default function ContactPage() {
   }
 
   return (
-    <section className="mx-auto max-w-xl py-20">
-      {/* Formulário de contacto */}
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block text-white">Nome</label>
+    // Centraliza o formulário no ecrã
+    <section className="flex min-h-screen items-center justify-center">
+      {/* Formulário com mesma formatação que login e registo */}
+      <form onSubmit={handleSubmit} className="form-control">
+        {/* Título do formulário */}
+        <p className="title">Contacto</p>
+
+        {/* Campo do nome */}
+        <div className="input-field">
           <input
             type="text"
             name="name"
+            className="input"
             value={form.name}
             onChange={handleChange}
-            className="w-full rounded border border-white bg-transparent p-2 text-white"
             required
           />
+          <label className="label">Nome</label>
         </div>
-        <div>
-          <label className="block text-white">Email</label>
+
+        {/* Campo do email */}
+        <div className="input-field">
           <input
             type="email"
             name="email"
+            className="input"
             value={form.email}
             onChange={handleChange}
-            className="w-full rounded border border-white bg-transparent p-2 text-white"
             required
           />
+          <label className="label">Email</label>
         </div>
-        <div>
-          <label className="block text-white">Mensagem</label>
+
+        {/* Campo da mensagem */}
+        <div className="input-field">
           <textarea
             name="message"
+            className="input"
             value={form.message}
             onChange={handleChange}
-            className="w-full rounded border border-white bg-transparent p-2 text-white"
             rows={5}
             required
           />
+          <label className="label">Mensagem</label>
         </div>
-        <button
-          type="submit"
-          className="rounded border border-white px-6 py-2 font-bold text-white hover:bg-white/20"
-        >
+
+        {/* Botão de submissão */}
+        <button type="submit" className="submit-btn">
           Enviar
         </button>
       </form>
     </section>
   )
 }
+

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -39,6 +39,8 @@ button {
   gap: 10px;
   padding: 25px;
   border-radius: 8px;
+  /* Garante que o texto dentro do formulário seja preto */
+  color: #000000;
 }
 
 /* Título do formulário */
@@ -97,14 +99,15 @@ button {
 .submit-btn {
   margin-top: 30px;
   height: 55px;
+  /* Define fundo claro para o botão */
   background: #f2f2f2;
   border-radius: 11px;
   border: 0;
   outline: none;
-  color: #ffffff;
+  /* Coloca o texto a preto para melhor legibilidade */
+  color: #000000;
   font-size: 18px;
   font-weight: 700;
-  background: linear-gradient(180deg, #363636 0%, #1b1b1b 50%, #000000 100%);
   box-shadow: 0px 0px 0px 0px #ffffff, 0px 0px 0px 0px #000000;
   transition: all 0.3s cubic-bezier(0.15, 0.83, 0.66, 1);
   cursor: pointer;

--- a/frontend/components/Faq.tsx
+++ b/frontend/components/Faq.tsx
@@ -44,7 +44,8 @@ const faqItems = [
 // Renderiza a secção de FAQ na página
 export function Faq() {
   return (
-    <section className="mx-auto max-w-3xl pb-20">
+    // Ajusta a posição para aproximar as FAQs da secção anterior
+    <section className="mx-auto max-w-3xl -mt-10 pb-20">
       {/* Título principal da secção */}
       <h2 className="mb-8 text-center text-3xl font-bold text-gray-800">FAQs</h2>
       {/* Lista de perguntas */}


### PR DESCRIPTION
## Summary
- Make form text black and unify submit button styling
- Apply login/register style to contact page
- Move FAQ section slightly upwards

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb177a7934832ea253757470cdf317