### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -35,10 +35,10 @@ export default function HomePage() {
   return (
     <main>
       {/* Secção inicial com título e frases rotativas */}
-      <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center gap-16">
+      <section className="flex min-h-[calc(100vh-5rem)] flex-col items-center justify-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
         {/* Bloco esquerdo com o título principal e botão de adesão */}
-        <div className="flex flex-col items-start justify-center space-y-8">
-          <h1 className="text-8xl font-bold leading-none">
+        <div className="flex flex-col items-center justify-center space-y-8 md:items-start">
+          <h1 className="text-4xl font-bold leading-none md:text-8xl">
             <span className="block">CURSO</span>
             <span className="block">COMPLETO</span>
           </h1>
@@ -50,8 +50,8 @@ export default function HomePage() {
           </Link>
         </div>
         {/* Bloco direito com caixa que exibe frases rotativas */}
-        <div className="flex justify-center">
-          <div className="flex h-80 w-80 items-center justify-center border-2 border-white p-4 text-center">
+        <div className="mt-8 flex justify-center md:mt-0">
+          <div className="flex h-64 w-64 items-center justify-center border-2 border-white p-4 text-center md:h-80 md:w-80">
             <p>{phrases[index]}</p>
           </div>
         </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -32,7 +32,8 @@ button {
   margin: 20px;
   background-color: #ffffff;
   box-shadow: 0 15px 25px rgba(0, 0, 0, 0.6);
-  width: 400px;
+  width: 100%;
+  max-width: 400px;
   display: flex;
   justify-content: center;
   flex-direction: column;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,18 @@ import React from 'react'
 import { Header } from '../components/Header'
 import { CookieBar } from '../components/CookieBar'
 
+// Metadados básicos da aplicação
+export const metadata = {
+  title: 'Cliente Mistério',
+  description: 'Plataforma de curso para clientes mistério',
+}
+
+// Meta tag de viewport para adaptação mobile
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+}
+
 // Layout raiz com cabeçalho e estilos globais
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,27 +1,33 @@
+'use client'
+
+import { useState } from 'react'
 import Link from 'next/link'
 
 // Cabeçalho com navegação principal
 export function Header() {
+  // Estado para controlar a abertura do menu mobile
+  const [menuOpen, setMenuOpen] = useState(false)
+
   return (
     // Cabeçalho fixo com elementos distribuídos em três colunas
     <header className="fixed left-0 right-0 top-0">
-      {/* Barra de navegação com texto do logótipo, menus centrais e ícones à direita */}
-      <nav className="mx-auto flex max-w-6xl items-center justify-between p-6 text-white text-lg font-bold">
+      {/* Barra de navegação com logótipo, menus e ícones */}
+      <nav className="mx-auto flex max-w-6xl items-center justify-between p-4 text-white text-lg font-bold md:p-6">
         {/* Texto do logótipo no canto superior esquerdo */}
         <div className="flex flex-1 justify-start">
           <Link href="/" aria-label="Página inicial">
             <span className="text-2xl font-bold">Cliente Mistério</span>
           </Link>
         </div>
-        {/* Menus de navegação centrados */}
-        <div className="flex flex-1 justify-center space-x-6">
+        {/* Menus visíveis apenas em ecrãs médios para cima */}
+        <div className="hidden flex-1 justify-center space-x-6 md:flex">
           <Link href="/">Início</Link>
           <Link href="/curso">Curso</Link>
           <Link href="/contacto">Contacto</Link>
           <Link href="/enterprise">Enterprise</Link>
         </div>
-        {/* Ícones de login e pesquisa no canto superior direito */}
-        <div className="flex flex-1 items-center justify-end space-x-4">
+        {/* Ícones à direita visíveis apenas em ecrãs médios para cima */}
+        <div className="hidden flex-1 items-center justify-end space-x-4 md:flex">
           <Link href="/entrar" aria-label="Fazer login" className="inline-flex">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -60,7 +66,72 @@ export function Header() {
             </svg>
           </Link>
         </div>
+        {/* Botão hamburger para abrir o menu em mobile */}
+        <button
+          className="inline-flex md:hidden"
+          aria-label="Abrir menu"
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="h-6 w-6"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
       </nav>
+      {/* Menu mobile mostrado quando o botão é clicado */}
+      {menuOpen && (
+        <div className="flex flex-col items-center space-y-4 bg-white/10 p-4 text-lg font-bold text-white md:hidden">
+          <Link href="/">Início</Link>
+          <Link href="/curso">Curso</Link>
+          <Link href="/contacto">Contacto</Link>
+          <Link href="/enterprise">Enterprise</Link>
+          <div className="flex space-x-4">
+            <Link href="/entrar" aria-label="Fazer login" className="inline-flex">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="h-6 w-6"
+              >
+                <circle cx="12" cy="8" r="4" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 20c0-4 4-6 8-6s8 2 8 6"
+                />
+              </svg>
+            </Link>
+            <Link href="#" aria-label="Pesquisar" className="inline-flex">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="h-6 w-6"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line
+                  x1="21"
+                  y1="21"
+                  x2="16.65"
+                  y2="16.65"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </Link>
+          </div>
+        </div>
+      )}
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- add viewport metadata for mobile
- implement responsive menu in header
- adapt homepage layout and form styles for small screens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb24c0700c832ebba09845be0b7be1