### PR TITLE
Atualiza call-to-action e menu mobile

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,40 +1,12 @@
-'use client'
-
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import Image from 'next/image'
 import { Faq } from '@/components/Faq'
 
-// Lista de frases a serem alternadas na caixa
-const phrases = [
-  'Recebe produtos gratuitos para experimentar',
-  'Ganha dinheiro ao dar a tua opinião',
-  'Testa serviços e marcas em primeira mão',
-  'Ofertas exclusivas só para clientes mistério',
-  'Ajuda as empresas a melhorar e é recompensado',
-  'Transforma avaliações em oportunidades',
-  'Participa em missões divertidas e pagas',
-  'A tua opinião tem valor — e é paga por isso',
-  'Experimenta antes de todos os outros',
-  'Converte o teu tempo livre em recompensas',
-]
-
-// Página inicial com título destacado e caixa de frases rotativas
+// Página inicial com título destacado e imagem
 export default function HomePage() {
-  // Índice da frase atual a ser mostrada
-  const [index, setIndex] = useState(0)
-
-  // Altera a frase a cada 5 segundos
-  useEffect(() => {
-    const interval = setInterval(
-      () => setIndex((i) => (i + 1) % phrases.length),
-      5000
-    )
-    return () => clearInterval(interval)
-  }, [])
-
   return (
     <main>
-      {/* Secção inicial com título e frases rotativas */}
+      {/* Secção inicial com título e botão de adesão */}
       <section className="flex min-h-[calc(100vh-5rem)] flex-col items-center justify-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
         {/* Bloco esquerdo com o título principal e botão de adesão */}
         <div className="flex flex-col items-center justify-center space-y-8 md:items-start">
@@ -44,16 +16,20 @@ export default function HomePage() {
           </h1>
           <Link
             href="/inscrever-se"
-            className="rounded bg-white px-10 py-4 font-bold text-[#b53de6]"
+            className="rounded bg-white px-10 py-4 font-bold text-[#fb4444]"
           >
             Adere já!
           </Link>
         </div>
-        {/* Bloco direito com caixa que exibe frases rotativas */}
+        {/* Bloco direito com imagem abstrata branca */}
         <div className="mt-8 flex justify-center md:mt-0">
-          <div className="flex h-64 w-64 items-center justify-center border-2 border-white p-4 text-center md:h-80 md:w-80">
-            <p>{phrases[index]}</p>
-          </div>
+          <Image
+            src="/abstract-white.svg"
+            alt="Imagem abstrata branca"
+            width={320}
+            height={320}
+            className="h-64 w-64 md:h-80 md:w-80"
+          />
         </div>
       </section>
       {/* Secção de perguntas frequentes */}
@@ -61,3 +37,4 @@ export default function HomePage() {
     </main>
   )
 }
+

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,9 +1,6 @@
-'use client'
-
-import { useState } from 'react'
 import Link from 'next/link'
 
-// Ligações principais para o menu
+// Lista de ligações principais para o menu
 const mainLinks = [
   { href: '/', label: 'Início' },
   { href: '/curso', label: 'Curso' },
@@ -11,7 +8,7 @@ const mainLinks = [
   { href: '/enterprise', label: 'Enterprise' },
 ]
 
-// Ligações com ícones para ações rápidas
+// Lista de ligações com ícones para ações rápidas
 const iconLinks = [
   {
     href: '/entrar',
@@ -62,28 +59,19 @@ const iconLinks = [
 
 // Cabeçalho com navegação principal
 export function Header() {
-  // Estado para controlar a abertura do menu mobile
-  const [menuOpen, setMenuOpen] = useState(false)
-
-  // Alterna a visibilidade do menu mobile
-  const toggleMenu = () => setMenuOpen((open) => !open)
-
-  // Função para fechar o menu após navegar para uma página
-  const closeMenu = () => setMenuOpen(false)
-
   return (
-    // Cabeçalho fixo com z-index elevado para manter o menu sobre o conteúdo
+    // Cabeçalho fixo com fundo vermelho
     <header className="fixed left-0 right-0 top-0 z-50 bg-[#fb4444]">
-      {/* Barra de navegação com logótipo, menus e ícones */}
-      <nav className="mx-auto flex max-w-6xl items-center justify-between p-4 text-white text-lg font-bold md:p-6">
-        {/* Texto do logótipo no canto superior esquerdo */}
+      {/* Barra de navegação principal */}
+      <nav className="mx-auto flex max-w-6xl items-center justify-between p-4 text-lg font-bold text-white md:p-6">
+        {/* Logótipo no canto superior esquerdo */}
         <div className="flex flex-1 justify-start">
           <Link href="/" aria-label="Página inicial">
             <span className="text-2xl font-bold">Cliente Mistério</span>
           </Link>
         </div>
 
-        {/* Menus visíveis apenas em ecrãs médios para cima */}
+        {/* Menu central visível apenas em ecrãs médios para cima */}
         <div className="hidden flex-1 justify-center space-x-6 md:flex">
           {mainLinks.map((link) => (
             <Link key={link.href} href={link.href}>
@@ -106,54 +94,50 @@ export function Header() {
           ))}
         </div>
 
-        {/* Botão hamburger para abrir o menu em mobile */}
-          <button
-            type="button"
-            className="inline-flex md:hidden"
+        {/* Menu mobile utilizando <details> para dispensar JavaScript */}
+        <details className="relative md:hidden">
+          {/* Botão que abre ou fecha o menu */}
+          <summary
             aria-label="Abrir menu"
-            aria-expanded={menuOpen}
-            aria-controls="mobile-menu"
-            onClick={toggleMenu}
+            className="cursor-pointer list-none marker:content-none"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth="2"
-            className="h-6 w-6"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-      </nav>
-
-      {/* Menu mobile mostrado abaixo do cabeçalho quando o botão é clicado */}
-      {menuOpen && (
-        <div
-          id="mobile-menu"
-          className="absolute left-0 right-0 top-full flex flex-col items-center space-y-4 bg-[#fb4444] p-4 text-lg font-bold text-white md:hidden"
-        >
-          {mainLinks.map((link) => (
-            <Link key={link.href} href={link.href} onClick={closeMenu}>
-              {link.label}
-            </Link>
-          ))}
-          <div className="flex space-x-4">
-            {iconLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                aria-label={link.label}
-                className="inline-flex"
-                onClick={closeMenu}
-              >
-                {link.icon}
+              stroke="currentColor"
+              strokeWidth="2"
+              className="h-6 w-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </summary>
+          {/* Conteúdo do menu apresentado quando aberto */}
+          <div className="absolute left-0 right-0 top-full flex flex-col items-center space-y-4 bg-[#fb4444] p-4 text-lg font-bold text-white">
+            {mainLinks.map((link) => (
+              <Link key={link.href} href={link.href}>
+                {link.label}
               </Link>
             ))}
+            <div className="flex space-x-4">
+              {iconLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  aria-label={link.label}
+                  className="inline-flex"
+                >
+                  {link.icon}
+                </Link>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        </details>
+      </nav>
     </header>
   )
 }

--- a/frontend/public/abstract-white.svg
+++ b/frontend/public/abstract-white.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320">
+  <circle cx="96" cy="96" r="60" fill="rgba(255,255,255,0.6)" />
+  <circle cx="224" cy="192" r="80" fill="rgba(255,255,255,0.4)" />
+  <path d="M0 256 Q160 200 320 256 L320 320 0 320 Z" fill="rgba(255,255,255,0.5)" />
+</svg>


### PR DESCRIPTION
## Summary
- change "Adere já" button text to #fb4444
- replace rotating text box with abstract white image
- rebuild mobile menu using `<details>` for reliable toggling

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb662b48b0832eaf6d9cd77befe8e1