### PR TITLE
fix: remove header gap

### DIFF
--- a/frontend/app/(public)/enterprise/page.tsx
+++ b/frontend/app/(public)/enterprise/page.tsx
@@ -1,7 +1,7 @@
 // Página "Enterprise" com texto centralizado
 export default function EnterprisePage() {
   return (
-    <section className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
+    <section className="flex min-h-screen items-center justify-center">
       {/* Texto principal da página Enterprise */}
       <h1 className="text-4xl font-bold">Enterprise</h1>
     </section>

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -7,7 +7,7 @@ export default function HomePage() {
   return (
     <main>
       {/* Secção inicial com título e botão de adesão */}
-      <section className="flex min-h-[calc(100vh-5rem)] flex-col items-center justify-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
+      <section className="flex min-h-screen flex-col items-center justify-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
         {/* Bloco esquerdo com o título principal e botão de adesão */}
         <div className="flex flex-col items-center justify-center space-y-8 md:items-start">
           <h1 className="text-4xl font-bold leading-none md:text-8xl">

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* Estrutura principal com fundo gradiente e texto branco */}
         <div className="min-h-screen text-white">
           <Header /> {/* Cabeçalho exibido no topo */}
-          <main className="pt-20">{children}</main> {/* Conteúdo variável com espaçamento superior */}
+          <main>{children}</main> {/* Conteúdo variável sem espaçamento superior */}
           <CookieBar /> {/* Aviso de cookies obrigatório */}
         </div>
       </body>


### PR DESCRIPTION
## Summary
- remove top padding in root layout
- adjust hero and enterprise sections to full-screen height

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `python -m py_compile backend/*.py`
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68bb69399318832e9a42e40a8d6c90d2