### PR TITLE
Fix mobile menu width and add global page margins

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* Estrutura principal com fundo gradiente e texto branco */}
         <div className="min-h-screen text-white">
           <Header /> {/* Cabeçalho exibido no topo */}
-          <main>{children}</main> {/* Conteúdo variável sem espaçamento superior */}
+          <main className="mx-4 mb-8 mt-24 md:mx-8">{children}</main> {/* Conteúdo principal com margens */}
           <CookieBar /> {/* Aviso de cookies obrigatório */}
         </div>
       </body>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -95,7 +95,7 @@ export function Header() {
         </div>
 
         {/* Menu mobile utilizando <details> para dispensar JavaScript */}
-        <details className="relative md:hidden">
+        <details className="md:hidden">
           {/* Botão que abre ou fecha o menu */}
           <summary
             aria-label="Abrir menu"
@@ -117,7 +117,7 @@ export function Header() {
             </svg>
           </summary>
           {/* Conteúdo do menu apresentado quando aberto */}
-          <div className="absolute left-0 right-0 top-full flex flex-col items-center space-y-4 bg-[#fb4444] p-4 text-lg font-bold text-white">
+          <div className="absolute left-0 right-0 top-full flex w-full flex-col items-center space-y-4 bg-[#fb4444] p-4 text-lg font-bold text-white">
             {mainLinks.map((link) => (
               <Link key={link.href} href={link.href}>
                 {link.label}


### PR DESCRIPTION
## Summary
- ensure mobile menu covers full screen width
- add consistent margins around main content

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb6c4d73e4832eb26e01fbee423db3