### PR TITLE
Reduce header spacing for cleaner layout

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,8 +24,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="min-h-screen text-white">
           <Header /> {/* Cabeçalho exibido no topo */}
 
-          <main className="mx-4 mb-8 mt-8 md:mx-8">{children}</main> {/* Conteúdo principal com margens */}
- main
+          {/* Conteúdo principal com margens e espaço reduzido no topo */}
+          <main className="mx-4 mb-8 mt-4 md:mx-8">{children}</main>
+
           <CookieBar /> {/* Aviso de cookies obrigatório */}
         </div>
       </body>


### PR DESCRIPTION
## Summary
- reduce top margin of main content to cut excess space under header
- remove stray text left in layout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5ad5e08832eaf623bdd539abc42