### PR TITLE
Remove header spacing across all pages

### DIFF
--- a/frontend/app/(private)/dashboard/page.tsx
+++ b/frontend/app/(private)/dashboard/page.tsx
@@ -7,7 +7,8 @@ import { ProtectedClient } from '../../../components/ProtectedClient'
 export default function DashboardPage() {
   return (
     <ProtectedClient>
-      <section className="py-8">
+      {/* Secção principal do dashboard sem margem superior */}
+      <section className="pb-8">
         {/* Título principal do dashboard */}
         <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
         {/* Frase motivacional para contextualizar o aluno */}

--- a/frontend/app/(public)/comprar/page.tsx
+++ b/frontend/app/(public)/comprar/page.tsx
@@ -1,7 +1,8 @@
 // Página com link para o pagamento do curso
 export default function BuyPage() {
   return (
-    <section className="py-20 text-center">
+    // Secção principal para compra do curso sem espaço superior
+    <section className="text-center pb-20">
       {/* Título da página */}
       <h2 className="text-3xl font-bold">Comprar curso</h2>
       {/* Explicação do processo de compra */}

--- a/frontend/app/(public)/contacto/page.tsx
+++ b/frontend/app/(public)/contacto/page.tsx
@@ -22,8 +22,8 @@ export default function ContactPage() {
   }
 
   return (
-    // Centraliza o formulário no ecrã
-    <section className="flex min-h-screen items-center justify-center">
+    // Centraliza o formulário horizontalmente sem espaço no topo
+    <section className="flex justify-center pb-20">
       {/* Formulário com mesma formatação que login e registo */}
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}

--- a/frontend/app/(public)/curso/page.tsx
+++ b/frontend/app/(public)/curso/page.tsx
@@ -1,7 +1,8 @@
 // Página com informação detalhada sobre o curso
 export default function CoursePage() {
   return (
-    <section className="py-20 max-w-3xl mx-auto">
+    // Secção principal com conteúdos do curso sem espaço superior
+    <section className="mx-auto max-w-3xl pb-20">
       {/* Título principal da página */}
       <h2 className="text-3xl font-bold text-center">Sobre o curso</h2>
 

--- a/frontend/app/(public)/enterprise/page.tsx
+++ b/frontend/app/(public)/enterprise/page.tsx
@@ -1,7 +1,8 @@
 // Página "Enterprise" com texto centralizado
 export default function EnterprisePage() {
   return (
-    <section className="flex min-h-screen items-center justify-center">
+    // Secção principal centrada horizontalmente sem espaço superior
+    <section className="flex justify-center pb-20">
       {/* Texto principal da página Enterprise */}
       <h1 className="text-4xl font-bold">Enterprise</h1>
     </section>

--- a/frontend/app/(public)/entrar/page.tsx
+++ b/frontend/app/(public)/entrar/page.tsx
@@ -45,8 +45,8 @@ export default function LoginPage() {
   }
 
   return (
-    // Centraliza o formulário no ecrã e posiciona-o mais abaixo
-    <section className="flex min-h-screen items-center justify-center">
+    // Centraliza o formulário horizontalmente sem espaço no topo
+    <section className="flex justify-center pb-20">
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}
         <p className="title">Entrar</p>

--- a/frontend/app/(public)/inscrever-se/page.tsx
+++ b/frontend/app/(public)/inscrever-se/page.tsx
@@ -30,8 +30,8 @@ export default function RegisterPage() {
   }
 
   return (
-    // Centraliza o formulário no ecrã e posiciona-o mais abaixo
-    <section className="flex min-h-screen items-center justify-center">
+    // Centraliza o formulário horizontalmente sem espaço no topo
+    <section className="flex justify-center pb-20">
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}
         <p className="title">Inscrever-se</p>

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -6,8 +6,8 @@ import { Faq } from '@/components/Faq'
 export default function HomePage() {
   return (
     <main>
-      {/* Secção inicial com título e botão de adesão */}
-      <section className="flex min-h-screen flex-col items-center justify-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
+      {/* Secção inicial com título e botão de adesão alinhada ao topo */}
+      <section className="flex flex-col items-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
         {/* Bloco esquerdo com o título principal e botão de adesão */}
         <div className="flex flex-col items-center justify-center space-y-8 md:items-start">
           <h1 className="text-4xl font-bold leading-none md:text-8xl">

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,8 +24,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="min-h-screen text-white">
           <Header /> {/* Cabeçalho exibido no topo */}
 
-          <main className="mx-4 mb-8 mt-8 md:mx-8">{children}</main> {/* Conteúdo principal com margens */}
- main
+          {/* Conteúdo principal sem margem superior para encostar ao cabeçalho */}
+          <main className="mx-4 mb-8 md:mx-8">{children}</main>
+
           <CookieBar /> {/* Aviso de cookies obrigatório */}
         </div>
       </body>


### PR DESCRIPTION
## Summary
- remove top margin in root layout so content touches header
- strip top padding and centering from page sections to align first sections with header

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5ad5e08832eaf623bdd539abc42