### PR TITLE
Justificar textos e corrigir layout

### DIFF
--- a/frontend/app/(private)/dashboard/page.tsx
+++ b/frontend/app/(private)/dashboard/page.tsx
@@ -12,7 +12,7 @@ export default function DashboardPage() {
         {/* Título principal do dashboard */}
         <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
         {/* Frase motivacional para contextualizar o aluno */}
-        <p className="mb-8 text-center text-black">Explore o conteúdo interativo do curso.</p>
+        <p className="mb-8 text-black">Explore o conteúdo interativo do curso.</p>
         {/* Contêiner responsivo com o iframe do curso (código fornecido) */}
         <div style={{ width: '100%' }}>
           <div

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -5,8 +5,8 @@ import { Faq } from '@/components/Faq'
 export default function HomePage() {
   return (
     <main>
-      {/* Secção inicial com título e botão de adesão alinhada ao topo */}
-      <section className="flex flex-col items-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
+      {/* Secção inicial com título, botão de adesão e margem superior */}
+      <section className="mt-10 flex flex-col items-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
         {/* Bloco esquerdo com o título principal e botão de adesão */}
         <div className="flex flex-col items-center justify-center space-y-8 md:items-start">
           <h1 className="text-4xl font-bold leading-none md:text-8xl">
@@ -21,15 +21,15 @@ export default function HomePage() {
           </Link>
         </div>
         {/* Bloco direito com frase promocional e botão para empresas */}
-        <div className="mt-8 flex flex-col items-center space-y-4 md:mt-0 md:items-start">
-          {/* Frase promocional apresentada em destaque */}
+        <div className="mt-8 flex flex-col items-center space-y-4 bg-black p-4 text-white md:mt-0 md:items-start">
+          {/* Frase promocional apresentada em destaque com fundo preto */}
           <p className="text-2xl font-bold md:text-4xl">
             É uma empresa de estudos de mercado? Temos parcerias para lhe trazer clientes mistério formados &rarr;
           </p>
-          {/* Botão que redireciona para a página enterprise */}
+          {/* Botão invertido com fundo branco e texto preto */}
           <Link
             href="/enterprise"
-            className="rounded bg-black px-10 py-4 font-bold text-white hover:bg-black/80"
+            className="rounded bg-white px-10 py-4 font-bold text-black hover:bg-white/80"
           >
             Saiba mais
           </Link>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -22,6 +22,11 @@ html, body {
   overflow-y: auto;
 }
 
+/* Justifica o texto de todos os parágrafos */
+p {
+  text-align: justify;
+}
+
 /* Torna o texto de todos os botões em negrito */
 button {
   font-weight: 700;

--- a/frontend/components/Faq.tsx
+++ b/frontend/components/Faq.tsx
@@ -44,8 +44,8 @@ const faqItems = [
 // Renderiza a secção de FAQ na página
 export function Faq() {
   return (
-    // Ajusta a posição para aproximar as FAQs da secção anterior
-    <section className="mx-auto -mt-10 max-w-3xl pb-20">
+    // Adiciona margem superior para afastar as FAQs da secção anterior
+    <section className="mx-auto mt-10 max-w-3xl pb-20">
       {/* Título principal da secção */}
       <h2 className="mb-8 text-center text-3xl font-bold text-black">FAQs</h2>
       {/* Lista de perguntas */}


### PR DESCRIPTION
## Resumo
- Justifica todo o texto em parágrafos.
- Afasta a secção do curso e das FAQs para melhor leitura.
- Inverte as cores da chamada para empresas, com fundo preto e botão branco.

## Testes
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcbd8a3528832e9638b41458fe7331