### PR TITLE
Add responsive SVG background and update header/hero styling

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -5,33 +5,19 @@ import { Faq } from '@/components/Faq'
 export default function HomePage() {
   return (
     <main>
-      {/* Secção inicial com título, botão de adesão e margem superior */}
-      <section className="mt-10 flex flex-col items-center gap-8 text-center md:flex-row md:gap-16 md:text-left">
-        {/* Bloco esquerdo com o título principal e botão de adesão */}
-        <div className="flex flex-col items-center justify-center space-y-8 md:items-start">
+      {/* Secção inicial com título e botão de adesão */}
+      <section className="mt-10 flex flex-col items-center gap-8 text-center text-white">
+        {/* Bloco com o título principal e botão de adesão */}
+        <div className="flex flex-col items-center justify-center space-y-8">
           <h1 className="text-4xl font-bold leading-none md:text-8xl">
             <span className="block">CURSO</span>
             <span className="block">COMPLETO</span>
           </h1>
           <Link
             href="/inscrever-se"
-            className="rounded bg-black px-10 py-4 font-bold text-white hover:bg-black/80"
+            className="rounded bg-[#F66400] px-10 py-4 font-bold text-white hover:bg-[#F66400]/80"
           >
             Adere já!
-          </Link>
-        </div>
-        {/* Bloco direito com frase promocional e botão para empresas */}
-        <div className="mt-8 flex flex-col items-center space-y-4 bg-black p-4 text-white md:mt-0 md:items-start">
-          {/* Frase promocional apresentada em destaque com fundo preto */}
-          <p className="text-2xl font-bold md:text-4xl">
-            É uma empresa de estudos de mercado? Temos parcerias para lhe trazer clientes mistério formados &rarr;
-          </p>
-          {/* Botão invertido com fundo branco e texto preto */}
-          <Link
-            href="/enterprise"
-            className="rounded bg-white px-10 py-4 font-bold text-black hover:bg-white/80"
-          >
-            Saiba mais
           </Link>
         </div>
       </section>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -17,6 +17,14 @@ html, body {
   min-height: 100vh;
   /* Define fundo branco simples para todo o site */
   background-color: #ffffff;
+  /* Define imagem de fundo padrão */
+  background-image: url('/background-desktop.svg');
+  /* Faz o SVG cobrir todo o ecrã */
+  background-size: cover;
+  /* Evita repetição do SVG */
+  background-repeat: no-repeat;
+  /* Mantém o fundo fixo em desktop */
+  background-attachment: fixed;
   /* Impede rolagem horizontal mantendo a vertical */
   overflow-x: hidden;
   overflow-y: auto;
@@ -128,3 +136,13 @@ button {
   background: #000000cc;
 }
 
+
+/* Versão adaptada do fundo para ecrãs pequenos */
+@media (max-width: 768px) {
+  html, body {
+    /* Utiliza SVG específico para mobile */
+    background-image: url('/background-mobile.svg');
+    /* Permite rolagem suave no mobile */
+    background-attachment: scroll;
+  }
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -60,8 +60,8 @@ const iconLinks = [
 // Cabeçalho principal do site
 export function Header() {
   return (
-    // Cabeçalho aderente ao topo com fundo preto e texto branco
-    <header className="sticky top-0 z-50 bg-black text-white">
+    // Cabeçalho aderente ao topo com fundo transparente e texto branco
+    <header className="sticky top-0 z-50 bg-transparent text-white">
       {/* Contêiner com três colunas para alinhar os elementos */}
       <div className="mx-auto grid max-w-6xl grid-cols-3 items-center p-4 md:p-6">
         {/* Menu hambúrguer no lado esquerdo */}

--- a/frontend/public/background-desktop.svg
+++ b/frontend/public/background-desktop.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.dev/svgjs" width="1440" height="560" preserveAspectRatio="none" viewBox="0 0 1440 560">
+    <g mask="url(&quot;#SvgjsMask1184&quot;)" fill="none">
+        <rect width="1440" height="560" x="0" y="0" fill="url(&quot;#SvgjsLinearGradient1185&quot;)"></rect>
+        <path d="M271.8 659.62C408.11 646.49 493.35 360.13 729.27 358.35 965.19 356.57 958.01 428.35 1186.74 428.35 1415.48 428.35 1528.51 358.55 1644.21 358.35" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M457.47 644.28C644.74 596.56 702.33 94.44 991.72 85.57 1281.11 76.7 1389.51 196.97 1525.97 197.57" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M206.16 597.85C344.4 585.61 433.61 301.76 674.69 300.13 915.76 298.5 908.95 370.13 1143.21 370.13 1377.48 370.13 1493.31 300.32 1611.74 300.13" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M731.81 582.38C877.93 557.77 950.19 201.04 1183.91 199.07 1417.64 197.1 1517.29 342.89 1636.02 344.67" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M78.57 610.7C211.39 604.69 314.45 379.32 557.13 378.75 799.81 378.18 796.41 448.75 1035.69 448.75 1274.97 448.75 1393.34 378.93 1514.25 378.75" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+    </g>
+    <defs>
+        <mask id="SvgjsMask1184">
+            <rect width="1440" height="560" fill="#ffffff"></rect>
+        </mask>
+        <linearGradient x1="84.72%" y1="-39.29%" x2="15.28%" y2="139.29%" gradientUnits="userSpaceOnUse" id="SvgjsLinearGradient1185">
+            <stop stop-color="#0e2a47" offset="0"></stop>
+            <stop stop-color="rgba(195, 0, 255, 1)" offset="1"></stop>
+        </linearGradient>
+    </defs>
+</svg>

--- a/frontend/public/background-mobile.svg
+++ b/frontend/public/background-mobile.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.dev/svgjs" width="360" height="640" preserveAspectRatio="none" viewBox="0 0 1440 560">
+    <g mask="url(&quot;#SvgjsMask1184&quot;)" fill="none">
+        <rect width="1440" height="560" x="0" y="0" fill="url(&quot;#SvgjsLinearGradient1185&quot;)"></rect>
+        <path d="M271.8 659.62C408.11 646.49 493.35 360.13 729.27 358.35 965.19 356.57 958.01 428.35 1186.74 428.35 1415.48 428.35 1528.51 358.55 1644.21 358.35" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M457.47 644.28C644.74 596.56 702.33 94.44 991.72 85.57 1281.11 76.7 1389.51 196.97 1525.97 197.57" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M206.16 597.85C344.4 585.61 433.61 301.76 674.69 300.13 915.76 298.5 908.95 370.13 1143.21 370.13 1377.48 370.13 1493.31 300.32 1611.74 300.13" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M731.81 582.38C877.93 557.77 950.19 201.04 1183.91 199.07 1417.64 197.1 1517.29 342.89 1636.02 344.67" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+        <path d="M78.57 610.7C211.39 604.69 314.45 379.32 557.13 378.75 799.81 378.18 796.41 448.75 1035.69 448.75 1274.97 448.75 1393.34 378.93 1514.25 378.75" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+    </g>
+    <defs>
+        <mask id="SvgjsMask1184">
+            <rect width="1440" height="560" fill="#ffffff"></rect>
+        </mask>
+        <linearGradient x1="84.72%" y1="-39.29%" x2="15.28%" y2="139.29%" gradientUnits="userSpaceOnUse" id="SvgjsLinearGradient1185">
+            <stop stop-color="#0e2a47" offset="0"></stop>
+            <stop stop-color="rgba(195, 0, 255, 1)" offset="1"></stop>
+        </linearGradient>
+    </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add SVG background for desktop and mobile
- load background via global CSS with media query
- make header transparent
- highlight home hero in white with orange call-to-action

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd75d32d30832e88eb538eae456b0d