### PR TITLE
Centralize forms and move FAQs

### DIFF
--- a/frontend/app/(public)/contacto/page.tsx
+++ b/frontend/app/(public)/contacto/page.tsx
@@ -22,8 +22,8 @@ export default function ContactPage() {
   }
 
   return (
-    // Centraliza o formulário horizontalmente sem espaço no topo
-    <section className="flex justify-center pb-20">
+    // Centraliza o formulário vertical e horizontalmente
+    <section className="flex min-h-screen items-center justify-center pb-20">
       {/* Formulário com mesma formatação que login e registo */}
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}

--- a/frontend/app/(public)/entrar/page.tsx
+++ b/frontend/app/(public)/entrar/page.tsx
@@ -45,8 +45,8 @@ export default function LoginPage() {
   }
 
   return (
-    // Centraliza o formulário horizontalmente sem espaço no topo
-    <section className="flex justify-center pb-20">
+    // Centraliza o formulário vertical e horizontalmente
+    <section className="flex min-h-screen items-center justify-center pb-20">
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}
         <p className="title">Entrar</p>

--- a/frontend/app/(public)/faq/page.tsx
+++ b/frontend/app/(public)/faq/page.tsx
@@ -1,0 +1,11 @@
+import { Faq } from '@/components/Faq'
+
+// Página dedicada às perguntas frequentes
+export default function FaqPage() {
+  return (
+    <main>
+      {/* Secção exclusiva para FAQs */}
+      <Faq />
+    </main>
+  )
+}

--- a/frontend/app/(public)/inscrever-se/page.tsx
+++ b/frontend/app/(public)/inscrever-se/page.tsx
@@ -30,8 +30,8 @@ export default function RegisterPage() {
   }
 
   return (
-    // Centraliza o formulário horizontalmente sem espaço no topo
-    <section className="flex justify-center pb-20">
+    // Centraliza o formulário vertical e horizontalmente
+    <section className="flex min-h-screen items-center justify-center pb-20">
       <form onSubmit={handleSubmit} className="form-control">
         {/* Título do formulário */}
         <p className="title">Inscrever-se</p>

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import { Faq } from '@/components/Faq'
 
 // Página inicial com título destacado e texto informativo
 export default function HomePage() {
@@ -15,14 +14,12 @@ export default function HomePage() {
           </h1>
           <Link
             href="/inscrever-se"
-            className="rounded bg-[#F66400] px-10 py-4 font-bold text-white hover:bg-[#F66400]/80"
+            className="rounded bg-white px-10 py-4 font-bold text-black hover:bg-gray-200"
           >
             Adere já!
           </Link>
         </div>
       </section>
-      {/* Secção de perguntas frequentes */}
-      <Faq />
     </main>
   )
 }

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -5,6 +5,7 @@ const mainLinks = [
   { href: '/', label: 'Início' },
   { href: '/curso', label: 'Curso' },
   { href: '/contacto', label: 'Contacto' },
+  { href: '/faq', label: 'FAQs' },
   { href: '/enterprise', label: 'Enterprise' },
 ]
 


### PR DESCRIPTION
## Summary
- Center contact, registration, and login forms vertically on mobile
- Move FAQs to dedicated page and link from header
- Style home call-to-action button with white background and black text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bda83d4be4832e92d4ce5904939b31