### PR TITLE
feat: add decorative svg background

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import React from 'react'
 import { Header } from '../components/Header'
 import { CookieBar } from '../components/CookieBar'
+import { BackgroundLines } from '../components/BackgroundLines'
 
 // Metadados básicos da aplicação
 export const metadata = {
@@ -20,14 +21,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="pt">
       <body>
-        {/* Estrutura principal com estilo base preto e branco */}
-        <div className="min-h-screen">
+        {/* Estrutura principal com linhas SVG no fundo */}
+        <div className="relative min-h-screen">
+          <BackgroundLines /> {/* Linhas decorativas atrás do conteúdo */}
           <Header /> {/* Cabeçalho exibido no topo */}
-
 
           {/* Conteúdo principal sem margem superior para encostar ao cabeçalho */}
           <main className="mx-4 mb-8 md:mx-8">{children}</main>
-
 
           <CookieBar /> {/* Aviso de cookies obrigatório */}
         </div>

--- a/frontend/components/BackgroundLines.tsx
+++ b/frontend/components/BackgroundLines.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+
+// SVG com linhas decorativas para o fundo
+export function BackgroundLines() {
+  return (
+    <svg
+      className="absolute inset-0 w-full h-full -z-10 pointer-events-none"
+      xmlns="http://www.w3.org/2000/svg"
+      version="1.1"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      width="100%"
+      height="100%"
+      preserveAspectRatio="none"
+      viewBox="0 0 1440 560"
+    >
+      {/* Grupo de linhas com gradientes e máscara */}
+      <g mask="url(#SvgjsMask1003)" fill="none">
+        <path d="M931 59L930 -279" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M361 180L360 350" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M155 502L154 257" strokeWidth="8" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M873 27L872 -337" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M469 169L468 397" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M483 521L482 911" strokeWidth="8" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M1285 365L1284 649" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M693 316L692 486" strokeWidth="6" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M596 429L595 717" strokeWidth="8" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M124 116L123 299" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M295 357L294 83" strokeWidth="10" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M915 496L914 181" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M222 417L221 230" strokeWidth="10" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M1380 528L1379 238" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M787 354L786 631" strokeWidth="10" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M638 159L637 -241" strokeWidth="8" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M1104 144L1103 367" strokeWidth="8" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M1351 278L1350 119" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M635 428L634 122" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M518 368L517 133" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M915 155L914 429" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M991 131L990 375" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M339 407L338 5" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M1101 129L1100 -221" strokeWidth="10" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M561 426L560 672" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M418 537L417 175" strokeWidth="8" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M353 322L352 731" strokeWidth="8" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M493 108L492 431" strokeWidth="8" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M1109 450L1108 704" strokeWidth="8" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M240 398L239 559" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M1420 230L1419 -105" strokeWidth="10" stroke="url(#SvgjsLinearGradient1005)" strokeLinecap="round" className="Down" />
+        <path d="M836 306L835 653" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M968 136L967 370" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M510 387L509 797" strokeWidth="10" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M352 66L351 333" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+        <path d="M554 490L553 77" strokeWidth="6" stroke="url(#SvgjsLinearGradient1004)" strokeLinecap="round" className="Up" />
+      </g>
+      {/* Definições de máscara e gradientes */}
+      <defs>
+        <mask id="SvgjsMask1003">
+          <rect width="1440" height="560" fill="#ffffff" />
+        </mask>
+        <linearGradient x1="0%" y1="100%" x2="0%" y2="0%" id="SvgjsLinearGradient1004">
+          <stop stopColor="rgba(255, 255, 255, 0)" offset="0" />
+          <stop stopColor="rgba(255, 255, 255, 1)" offset="1" />
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="SvgjsLinearGradient1005">
+          <stop stopColor="rgba(255, 255, 255, 0)" offset="0" />
+          <stop stopColor="rgba(255, 255, 255, 1)" offset="1" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+


### PR DESCRIPTION
## Summary
- overlay decorative SVG lines on top of existing gradient background

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdb059805c832ea8d7bec0495fe5cc