### PR TITLE
style: replace background with blurred circles

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -16,19 +16,10 @@ html, body {
   /* Garante altura mínima sem bloquear a rolagem */
   min-height: 100vh;
 
-  /* Cor de fundo base em caso de falha no gradiente */
-  background: #FD873F;
-  /* Gradiente compatível com navegadores WebKit */
-  background: -webkit-linear-gradient(153deg, rgba(253, 135, 63, 1) 0%, rgba(234, 121, 95, 1) 32%, rgba(152, 59, 236, 1) 73%, rgba(92, 178, 231, 1) 100%);
-  /* Gradiente compatível com Firefox */
-  background: -moz-linear-gradient(153deg, rgba(253, 135, 63, 1) 0%, rgba(234, 121, 95, 1) 32%, rgba(152, 59, 236, 1) 73%, rgba(92, 178, 231, 1) 100%);
-  /* Gradiente padrão */
-  background: linear-gradient(153deg, rgba(253, 135, 63, 1) 0%, rgba(234, 121, 95, 1) 32%, rgba(152, 59, 236, 1) 73%, rgba(92, 178, 231, 1) 100%);
-  /* Suporte para Internet Explorer */
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FD873F', endColorstr='#5CB2E7', GradientType=0);
-
-  /* Mantém o fundo fixo em desktop */
-  background-attachment: fixed;
+  /* Imagem de fundo para versões desktop */
+  background: url('/background-desktop.svg') no-repeat center center fixed;
+  /* Ajusta a imagem para cobrir toda a área */
+  background-size: cover;
   /* Impede rolagem horizontal mantendo a vertical */
   overflow-x: hidden;
   overflow-y: auto;
@@ -148,8 +139,10 @@ button {
 /* Versão adaptada do fundo para ecrãs pequenos */
 @media (max-width: 768px) {
   html, body {
-
-
+    /* Substitui a imagem de fundo para mobile */
+    background: url('/background-mobile.svg') no-repeat center center;
+    /* Ajusta a imagem para cobrir toda a área */
+    background-size: cover;
     /* Permite rolagem suave no mobile */
     background-attachment: scroll;
   }

--- a/frontend/public/background-desktop.svg
+++ b/frontend/public/background-desktop.svg
@@ -1,19 +1,92 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.dev/svgjs" width="1440" height="560" preserveAspectRatio="none" viewBox="0 0 1440 560">
-    <g mask="url(&quot;#SvgjsMask1184&quot;)" fill="none">
-        <rect width="1440" height="560" x="0" y="0" fill="url(&quot;#SvgjsLinearGradient1185&quot;)"></rect>
-        <path d="M271.8 659.62C408.11 646.49 493.35 360.13 729.27 358.35 965.19 356.57 958.01 428.35 1186.74 428.35 1415.48 428.35 1528.51 358.55 1644.21 358.35" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M457.47 644.28C644.74 596.56 702.33 94.44 991.72 85.57 1281.11 76.7 1389.51 196.97 1525.97 197.57" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M206.16 597.85C344.4 585.61 433.61 301.76 674.69 300.13 915.76 298.5 908.95 370.13 1143.21 370.13 1377.48 370.13 1493.31 300.32 1611.74 300.13" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M731.81 582.38C877.93 557.77 950.19 201.04 1183.91 199.07 1417.64 197.1 1517.29 342.89 1636.02 344.67" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M78.57 610.7C211.39 604.69 314.45 379.32 557.13 378.75 799.81 378.18 796.41 448.75 1035.69 448.75 1274.97 448.75 1393.34 378.93 1514.25 378.75" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+    <!-- Plano de fundo com círculos coloridos para a versão desktop -->
+    <g clip-path="url(&quot;#SvgjsClipPath1006&quot;)" fill="none">
+        <!-- Círculos difusos que criam o efeito visual -->
+        <circle r="14" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="10.5" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.13" filter="blur(6px)"></circle>
+        <circle r="7" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.27" filter="blur(3px)"></circle>
+        <circle r="3.5" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.89" filter="drop-shadow(0 0 14px rgba(148, 4, 222, 1))"></circle>
+        <circle r="6.45" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="4.8" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="3.15" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.27" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.9" filter="drop-shadow(0 0 6.6px rgba(148, 4, 222, 1))"></circle>
+        <circle r="6.5" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.1" filter="blur(9px)"></circle>
+        <circle r="5" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.15" filter="blur(6px)"></circle>
+        <circle r="3.5" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.3" filter="blur(3px)"></circle>
+        <circle r="2" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.99" filter="drop-shadow(0 0 6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="4" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="3" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.13" filter="blur(6px)"></circle>
+        <circle r="2" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.26" filter="blur(3px)"></circle>
+        <circle r="1" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.86" filter="drop-shadow(0 0 4px rgba(148, 4, 222, 1))"></circle>
+        <circle r="13.25" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.08" filter="blur(9px)"></circle>
+        <circle r="10.5" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="7.75" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.23" filter="blur(3px)"></circle>
+        <circle r="5" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.76" filter="drop-shadow(0 0 11px rgba(148, 4, 222, 1))"></circle>
+        <circle r="6.625" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="5.25" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="3.875" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.27" filter="blur(3px)"></circle>
+        <circle r="2.5" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.91" filter="drop-shadow(0 0 5.5px rgba(255, 97, 13, 1))"></circle>
+        <circle r="6.8" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="5.2" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.1" filter="blur(6px)"></circle>
+        <circle r="3.6" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.19" filter="blur(3px)"></circle>
+        <circle r="2" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.64" filter="drop-shadow(0 0 6.4px rgba(148, 4, 222, 1))"></circle>
+        <circle r="16.6" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="12.4" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="8.2" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="4" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.93" filter="drop-shadow(0 0 16.8px rgba(255, 97, 13, 1))"></circle>
+        <circle r="7.95" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="6.3" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(6px)"></circle>
+        <circle r="4.65" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.19" filter="blur(3px)"></circle>
+        <circle r="3" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.63" filter="drop-shadow(0 0 6.6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="5.325" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="4.05" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(6px)"></circle>
+        <circle r="2.775" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.18" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.6" filter="drop-shadow(0 0 5.1px rgba(148, 4, 222, 1))"></circle>
+        <circle r="7.125" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="5.25" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.1" filter="blur(6px)"></circle>
+        <circle r="3.375" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.2" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.65" filter="drop-shadow(0 0 7.5px rgba(255, 97, 13, 1))"></circle>
+        <circle r="12.95" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="9.8" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="6.65" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="3.5" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.93" filter="drop-shadow(0 0 12.6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="8.025" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="5.85" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="3.675" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.22" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.72" filter="drop-shadow(0 0 8.7px rgba(148, 4, 222, 1))"></circle>
+        <circle r="17.675" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="12.95" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="8.225" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.21" filter="blur(3px)"></circle>
+        <circle r="3.5" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.71" filter="drop-shadow(0 0 18.9px rgba(148, 4, 222, 1))"></circle>
+        <circle r="7.5" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="6" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.1" filter="blur(6px)"></circle>
+        <circle r="4.5" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.21" filter="blur(3px)"></circle>
+        <circle r="3" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.69" filter="drop-shadow(0 0 6px rgba(148, 4, 222, 1))"></circle>
+        <circle r="24.075" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="17.55" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="11.025" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="4.5" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.93" filter="drop-shadow(0 0 26.1px rgba(255, 97, 13, 1))"></circle>
+        <circle r="12.45" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.05" filter="blur(9px)"></circle>
+        <circle r="9.3" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.08" filter="blur(6px)"></circle>
+        <circle r="6.15" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.16" filter="blur(3px)"></circle>
+        <circle r="3" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.53" filter="drop-shadow(0 0 12.6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="23" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="17" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="11" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.22" filter="blur(3px)"></circle>
+        <circle r="5" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.72" filter="drop-shadow(0 0 24px rgba(255, 97, 13, 1))"></circle>
+        <circle r="12" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="9" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(6px)"></circle>
+        <circle r="6" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.18" filter="blur(3px)"></circle>
+        <circle r="3" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.59" filter="drop-shadow(0 0 12px rgba(148, 4, 222, 1))"></circle>
+        <circle r="7" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="5.5" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="4" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="2.5" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.95" filter="drop-shadow(0 0 6px rgba(148, 4, 222, 1))"></circle>
     </g>
     <defs>
-        <mask id="SvgjsMask1184">
-            <rect width="1440" height="560" fill="#ffffff"></rect>
-        </mask>
-        <linearGradient x1="84.72%" y1="-39.29%" x2="15.28%" y2="139.29%" gradientUnits="userSpaceOnUse" id="SvgjsLinearGradient1185">
-            <stop stop-color="#0e2a47" offset="0"></stop>
-            <stop stop-color="rgba(195, 0, 255, 1)" offset="1"></stop>
-        </linearGradient>
+        <!-- Recorte que limita a área do SVG -->
+        <clipPath id="SvgjsClipPath1006">
+            <rect width="1440" height="560" x="0" y="0"></rect>
+        </clipPath>
     </defs>
 </svg>

--- a/frontend/public/background-mobile.svg
+++ b/frontend/public/background-mobile.svg
@@ -1,19 +1,92 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.dev/svgjs" width="360" height="640" preserveAspectRatio="none" viewBox="0 0 1440 560">
-    <g mask="url(&quot;#SvgjsMask1184&quot;)" fill="none">
-        <rect width="1440" height="560" x="0" y="0" fill="url(&quot;#SvgjsLinearGradient1185&quot;)"></rect>
-        <path d="M271.8 659.62C408.11 646.49 493.35 360.13 729.27 358.35 965.19 356.57 958.01 428.35 1186.74 428.35 1415.48 428.35 1528.51 358.55 1644.21 358.35" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M457.47 644.28C644.74 596.56 702.33 94.44 991.72 85.57 1281.11 76.7 1389.51 196.97 1525.97 197.57" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M206.16 597.85C344.4 585.61 433.61 301.76 674.69 300.13 915.76 298.5 908.95 370.13 1143.21 370.13 1377.48 370.13 1493.31 300.32 1611.74 300.13" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M731.81 582.38C877.93 557.77 950.19 201.04 1183.91 199.07 1417.64 197.1 1517.29 342.89 1636.02 344.67" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
-        <path d="M78.57 610.7C211.39 604.69 314.45 379.32 557.13 378.75 799.81 378.18 796.41 448.75 1035.69 448.75 1274.97 448.75 1393.34 378.93 1514.25 378.75" stroke="rgba(246, 100, 0, 1)" stroke-width="2"></path>
+    <!-- Plano de fundo com círculos coloridos para a versão mobile -->
+    <g clip-path="url(&quot;#SvgjsClipPath1006&quot;)" fill="none">
+        <!-- Círculos difusos que criam o efeito visual -->
+        <circle r="14" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="10.5" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.13" filter="blur(6px)"></circle>
+        <circle r="7" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.27" filter="blur(3px)"></circle>
+        <circle r="3.5" cx="417" cy="348" fill="rgba(148, 4, 222, 1)" opacity="0.89" filter="drop-shadow(0 0 14px rgba(148, 4, 222, 1))"></circle>
+        <circle r="6.45" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="4.8" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="3.15" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.27" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="1304" cy="144" fill="rgba(148, 4, 222, 1)" opacity="0.9" filter="drop-shadow(0 0 6.6px rgba(148, 4, 222, 1))"></circle>
+        <circle r="6.5" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.1" filter="blur(9px)"></circle>
+        <circle r="5" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.15" filter="blur(6px)"></circle>
+        <circle r="3.5" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.3" filter="blur(3px)"></circle>
+        <circle r="2" cx="386" cy="313" fill="rgba(255, 97, 13, 1)" opacity="0.99" filter="drop-shadow(0 0 6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="4" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="3" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.13" filter="blur(6px)"></circle>
+        <circle r="2" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.26" filter="blur(3px)"></circle>
+        <circle r="1" cx="947" cy="556" fill="rgba(148, 4, 222, 1)" opacity="0.86" filter="drop-shadow(0 0 4px rgba(148, 4, 222, 1))"></circle>
+        <circle r="13.25" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.08" filter="blur(9px)"></circle>
+        <circle r="10.5" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="7.75" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.23" filter="blur(3px)"></circle>
+        <circle r="5" cx="592" cy="79" fill="rgba(148, 4, 222, 1)" opacity="0.76" filter="drop-shadow(0 0 11px rgba(148, 4, 222, 1))"></circle>
+        <circle r="6.625" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="5.25" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="3.875" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.27" filter="blur(3px)"></circle>
+        <circle r="2.5" cx="74" cy="155" fill="rgba(255, 97, 13, 1)" opacity="0.91" filter="drop-shadow(0 0 5.5px rgba(255, 97, 13, 1))"></circle>
+        <circle r="6.8" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="5.2" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.1" filter="blur(6px)"></circle>
+        <circle r="3.6" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.19" filter="blur(3px)"></circle>
+        <circle r="2" cx="132" cy="314" fill="rgba(148, 4, 222, 1)" opacity="0.64" filter="drop-shadow(0 0 6.4px rgba(148, 4, 222, 1))"></circle>
+        <circle r="16.6" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="12.4" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="8.2" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="4" cx="354" cy="193" fill="rgba(255, 97, 13, 1)" opacity="0.93" filter="drop-shadow(0 0 16.8px rgba(255, 97, 13, 1))"></circle>
+        <circle r="7.95" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="6.3" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(6px)"></circle>
+        <circle r="4.65" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.19" filter="blur(3px)"></circle>
+        <circle r="3" cx="36" cy="422" fill="rgba(255, 97, 13, 1)" opacity="0.63" filter="drop-shadow(0 0 6.6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="5.325" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="4.05" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(6px)"></circle>
+        <circle r="2.775" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.18" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="87" cy="426" fill="rgba(148, 4, 222, 1)" opacity="0.6" filter="drop-shadow(0 0 5.1px rgba(148, 4, 222, 1))"></circle>
+        <circle r="7.125" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="5.25" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.1" filter="blur(6px)"></circle>
+        <circle r="3.375" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.2" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="154" cy="230" fill="rgba(255, 97, 13, 1)" opacity="0.65" filter="drop-shadow(0 0 7.5px rgba(255, 97, 13, 1))"></circle>
+        <circle r="12.95" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="9.8" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="6.65" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="3.5" cx="313" cy="86" fill="rgba(255, 97, 13, 1)" opacity="0.93" filter="drop-shadow(0 0 12.6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="8.025" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="5.85" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="3.675" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.22" filter="blur(3px)"></circle>
+        <circle r="1.5" cx="154" cy="251" fill="rgba(148, 4, 222, 1)" opacity="0.72" filter="drop-shadow(0 0 8.7px rgba(148, 4, 222, 1))"></circle>
+        <circle r="17.675" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="12.95" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="8.225" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.21" filter="blur(3px)"></circle>
+        <circle r="3.5" cx="64" cy="301" fill="rgba(148, 4, 222, 1)" opacity="0.71" filter="drop-shadow(0 0 18.9px rgba(148, 4, 222, 1))"></circle>
+        <circle r="7.5" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="6" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.1" filter="blur(6px)"></circle>
+        <circle r="4.5" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.21" filter="blur(3px)"></circle>
+        <circle r="3" cx="1002" cy="36" fill="rgba(148, 4, 222, 1)" opacity="0.69" filter="drop-shadow(0 0 6px rgba(148, 4, 222, 1))"></circle>
+        <circle r="24.075" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="17.55" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="11.025" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="4.5" cx="333" cy="480" fill="rgba(255, 97, 13, 1)" opacity="0.93" filter="drop-shadow(0 0 26.1px rgba(255, 97, 13, 1))"></circle>
+        <circle r="12.45" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.05" filter="blur(9px)"></circle>
+        <circle r="9.3" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.08" filter="blur(6px)"></circle>
+        <circle r="6.15" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.16" filter="blur(3px)"></circle>
+        <circle r="3" cx="1201" cy="133" fill="rgba(255, 97, 13, 1)" opacity="0.53" filter="drop-shadow(0 0 12.6px rgba(255, 97, 13, 1))"></circle>
+        <circle r="23" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.07" filter="blur(9px)"></circle>
+        <circle r="17" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.11" filter="blur(6px)"></circle>
+        <circle r="11" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.22" filter="blur(3px)"></circle>
+        <circle r="5" cx="884" cy="228" fill="rgba(255, 97, 13, 1)" opacity="0.72" filter="drop-shadow(0 0 24px rgba(255, 97, 13, 1))"></circle>
+        <circle r="12" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.06" filter="blur(9px)"></circle>
+        <circle r="9" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(6px)"></circle>
+        <circle r="6" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.18" filter="blur(3px)"></circle>
+        <circle r="3" cx="344" cy="247" fill="rgba(148, 4, 222, 1)" opacity="0.59" filter="drop-shadow(0 0 12px rgba(148, 4, 222, 1))"></circle>
+        <circle r="7" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.09" filter="blur(9px)"></circle>
+        <circle r="5.5" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.14" filter="blur(6px)"></circle>
+        <circle r="4" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.28" filter="blur(3px)"></circle>
+        <circle r="2.5" cx="362" cy="463" fill="rgba(148, 4, 222, 1)" opacity="0.95" filter="drop-shadow(0 0 6px rgba(148, 4, 222, 1))"></circle>
     </g>
     <defs>
-        <mask id="SvgjsMask1184">
-            <rect width="1440" height="560" fill="#ffffff"></rect>
-        </mask>
-        <linearGradient x1="84.72%" y1="-39.29%" x2="15.28%" y2="139.29%" gradientUnits="userSpaceOnUse" id="SvgjsLinearGradient1185">
-            <stop stop-color="#0e2a47" offset="0"></stop>
-            <stop stop-color="rgba(195, 0, 255, 1)" offset="1"></stop>
-        </linearGradient>
+        <!-- Recorte que limita a área do SVG -->
+        <clipPath id="SvgjsClipPath1006">
+            <rect width="1440" height="560" x="0" y="0"></rect>
+        </clipPath>
     </defs>
 </svg>


### PR DESCRIPTION
## Summary
- swap linear-gradient background for blurred circle SVG images on desktop and mobile
- update global styles to load new SVG backgrounds

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdee5d6c40832eb6994f6b62c20d9c