### PR TITLE
fix: ensure background covers without white lines

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -20,6 +20,8 @@ html, body {
   background: url('/background-desktop.svg') no-repeat center center fixed;
   /* Ajusta a imagem para cobrir toda a área */
   background-size: cover;
+  /* Define a cor de fundo base para evitar linhas brancas nas margens */
+  background-color: #000000;
   /* Impede rolagem horizontal mantendo a vertical */
   overflow-x: hidden;
   overflow-y: auto;
@@ -143,6 +145,8 @@ button {
     background: url('/background-mobile.svg') no-repeat center center;
     /* Ajusta a imagem para cobrir toda a área */
     background-size: cover;
+    /* Define cor de fundo para impedir linhas brancas em ecrãs pequenos */
+    background-color: #000000;
     /* Permite rolagem suave no mobile */
     background-attachment: scroll;
   }


### PR DESCRIPTION
## Summary
- set base and mobile background colors to black to prevent white margins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc3a8c70832e9437c05a6f2b41c0