### PR TITLE
Add inline SVG background to global styles

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -15,12 +15,14 @@ html, body {
   padding: 0;
   /* Garante altura mínima sem bloquear a rolagem */
   min-height: 100vh;
-  /* Define uma cor de fundo branca */
-  background-color: #ffffff;
-  /* Aplica imagem SVG como fundo com gradiente */
+  /* Define a imagem de fundo em SVG */
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' version='1.1' xmlns:xlink='http://www.w3.org/1999/xlink' xmlns:svgjs='http://svgjs.dev/svgjs' width='1920' height='1080' preserveAspectRatio='none' viewBox='0 0 1920 1080'%3e%3cg mask='url(%26quot%3b%23SvgjsMask3201%26quot%3b)' fill='none'%3e%3crect width='1920' height='1080' x='0' y='0' fill='url(%26quot%3b%23SvgjsLinearGradient3202%26quot%3b)'%3e%3c/rect%3e%3cpath d='M7 1080L1087 0L1538.5 0L458.5 1080z' fill='url(%26quot%3b%23SvgjsLinearGradient3203%26quot%3b)'%3e%3c/path%3e%3cpath d='M740.6 1080L1820.6 0L2645.6 0L1565.6 1080z' fill='url(%26quot%3b%23SvgjsLinearGradient3203%26quot%3b)'%3e%3c/path%3e%3cpath d='M1796 1080L716 0L495.5 0L1575.5 1080z' fill='url(%26quot%3b%23SvgjsLinearGradient3204%26quot%3b)'%3e%3c/path%3e%3cpath d='M1217.4 1080L137.4000000000001 0L14.400000000000091 0L1094.4 1080z' fill='url(%26quot%3b%23SvgjsLinearGradient3204%26quot%3b)'%3e%3c/path%3e%3cpath d='M852.3284965823686 1080L1920 12.328496582368643L1920 1080z' fill='url(%26quot%3b%23SvgjsLinearGradient3203%26quot%3b)'%3e%3c/path%3e%3cpath d='M0 1080L1067.6715034176314 1080L 0 12.328496582368643z' fill='url(%26quot%3b%23SvgjsLinearGradient3204%26quot%3b)'%3e%3c/path%3e%3c/g%3e%3cdefs%3e%3cmask id='SvgjsMask3201'%3e%3crect width='1920' height='1080' fill='white'%3e%3c/rect%3e%3c/mask%3e%3clinearGradient x1='50%25' y1='0%25' x2='50%25' y2='100%25' gradientUnits='userSpaceOnUse' id='SvgjsLinearGradient3202'%3e%3cstop stop-color='rgba(170%2c 47%2c 213%2c 1)' offset='0'%3e%3c/stop%3e%3cstop stop-color='rgba(96%2c 43%2c 135%2c 1)' offset='0'%3e%3c/stop%3e%3c/linearGradient%3e%3clinearGradient x1='0%25' y1='100%25' x2='100%25' y2='0%25' id='SvgjsLinearGradient3203'%3e%3cstop stop-color='rgba(238%2c 105%2c 46%2c 1)' offset='0'%3e%3c/stop%3e%3cstop stop-opacity='0' stop-color='rgba(238%2c 105%2c 46%2c 1)' offset='0.66'%3e%3c/stop%3e%3c/linearGradient%3e%3clinearGradient x1='100%25' y1='100%25' x2='0%25' y2='0%25' id='SvgjsLinearGradient3204'%3e%3cstop stop-color='rgba(238%2c 105%2c 46%2c 1)' offset='0'%3e%3c/stop%3e%3cstop stop-opacity='0' stop-color='rgba(238%2c 105%2c 46%2c 1)' offset='0.66'%3e%3c/stop%3e%3c/linearGradient%3e%3c/defs%3e%3c/svg%3e");
+  /* Ajusta o tamanho da imagem para cobrir todo o ecrã */
   background-size: cover;
+  /* Impede a repetição da imagem de fundo */
   background-repeat: no-repeat;
+  /* Cor de fundo de apoio caso a imagem não carregue */
+  background-color: #ffffff;
   /* Impede rolagem horizontal mantendo a vertical */
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add SVG background image to global styles with cover sizing and no-repeat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be05e80d44832e9c41c4c20ad8b62d