### PR TITLE
style: set hamburger menu background to white

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -84,8 +84,8 @@ export function Header() {
               />
             </svg>
           </summary>
-          {/* Lista de ligações exibida ao abrir o menu */}
-          <nav className="absolute left-0 mt-2 flex flex-col space-y-2 bg-black p-4 shadow">
+          {/* Lista de ligações exibida ao abrir o menu com fundo branco e texto preto */}
+          <nav className="absolute left-0 mt-2 flex flex-col space-y-2 bg-white p-4 text-black shadow">
             {mainLinks.map((link) => (
               <Link key={link.href} href={link.href} className="hover:underline">
                 {link.label}


### PR DESCRIPTION
## Summary
- make hamburger menu background white with black text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be0d64906c832ea201c7e7b99f3b7e