### PR TITLE
Add translucent orange box to course section

### DIFF
--- a/frontend/app/(private)/dashboard/page.tsx
+++ b/frontend/app/(private)/dashboard/page.tsx
@@ -13,8 +13,11 @@ export default function DashboardPage() {
         <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
         {/* Frase motivacional para contextualizar o aluno */}
         <p className="mb-8 text-black">Explore o conteúdo interativo do curso.</p>
-        {/* Contêiner responsivo com o iframe do curso (código fornecido) */}
-        <div style={{ width: '100%' }}>
+        {/* Contêiner responsivo com o iframe dentro de uma caixa laranja translúcida */}
+        <div
+          className="w-full rounded-lg p-4"
+          style={{ backgroundColor: 'rgba(238, 105, 46, 0.25)' }}
+        >
           <div
             style={{
               position: 'relative',


### PR DESCRIPTION
## Summary
- style course iframe container in dashboard with translucent orange background using inline RGBA color

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be10489940832e889db001666182ef