### PR TITLE
Add translucent orange box to course section

### DIFF
--- a/frontend/app/(private)/dashboard/page.tsx
+++ b/frontend/app/(private)/dashboard/page.tsx
@@ -13,8 +13,11 @@ export default function DashboardPage() {
         <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
         {/* Frase motivacional para contextualizar o aluno */}
         <p className="mb-8 text-black">Explore o conteúdo interativo do curso.</p>
-        {/* Contêiner responsivo com o iframe do curso (código fornecido) */}
-        <div style={{ width: '100%' }}>
+        {/* Contêiner responsivo com o iframe dentro de uma caixa laranja translúcida */}
+        <div
+          className="w-full rounded-lg p-4"
+          style={{ backgroundColor: 'rgba(238, 105, 46, 0.25)' }}
+        >
           <div
             style={{
               position: 'relative',

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -6,18 +6,21 @@ export default function HomePage() {
     <main>
       {/* Secção inicial com título e botão de adesão */}
       <section className="mt-10 flex flex-col items-center gap-8 text-center text-white">
-        {/* Bloco com o título principal e botão de adesão */}
-        <div className="flex flex-col items-center justify-center space-y-8">
-          <h1 className="text-4xl font-bold leading-none md:text-8xl">
-            <span className="block">CURSO</span>
-            <span className="block">COMPLETO</span>
-          </h1>
-          <Link
-            href="/inscrever-se"
-            className="rounded bg-white px-10 py-4 font-bold text-black hover:bg-gray-200"
-          >
-            Adere já!
-          </Link>
+        {/* Caixa laranja translúcida que destaca a secção do curso */}
+        <div className="w-full max-w-md rounded-lg bg-[#ee692e]/40 p-8">
+          {/* Bloco com o título principal e botão de adesão */}
+          <div className="flex flex-col items-center justify-center space-y-8">
+            <h1 className="text-4xl font-bold leading-none md:text-8xl">
+              <span className="block">CURSO</span>
+              <span className="block">COMPLETO</span>
+            </h1>
+            <Link
+              href="/inscrever-se"
+              className="rounded bg-white px-10 py-4 font-bold text-black hover:bg-gray-200"
+            >
+              Adere já!
+            </Link>
+          </div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- wrap home page course section with translucent orange background to match site theme

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be10489940832e889db001666182ef