### PR TITLE
feat: ajustar caixa do curso ao tamanho do texto

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -6,8 +6,8 @@ export default function HomePage() {
     <main>
       {/* Secção inicial com título e botão de adesão */}
       <section className="mt-10 flex flex-col items-center gap-8 text-center text-white">
-        {/* Caixa laranja translúcida que destaca a secção do curso */}
-        <div className="w-full max-w-md rounded-lg bg-[#ee692e]/40 p-8">
+        {/* Caixa branca translúcida que se ajusta ao tamanho do conteúdo */}
+        <div className="w-fit rounded-lg bg-white/40 p-8">
           {/* Bloco com o título principal e botão de adesão */}
           <div className="flex flex-col items-center justify-center space-y-8">
             <h1 className="text-4xl font-bold leading-none md:text-8xl">


### PR DESCRIPTION
## Summary
- ajustar largura da caixa translúcida à largura do conteúdo da secção do curso
- alterar cor da caixa para branco translúcido

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bea624a004832e90e2a973c66f06c4