### PR TITLE
feat: improve responsive header

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -9,6 +9,19 @@ const mainLinks = [
   { href: '/enterprise', label: 'Enterprise' },
 ]
 
+// Componente reutilizável que gera as ligações principais
+function MainLinks({ linkClass }: { linkClass: string }) {
+  return (
+    <>
+      {mainLinks.map((link) => (
+        <Link key={link.href} href={link.href} className={linkClass}>
+          {link.label}
+        </Link>
+      ))}
+    </>
+  )
+}
+
 // Lista de ligações com ícones para ações rápidas
 const iconLinks = [
   {
@@ -63,61 +76,65 @@ export function Header() {
   return (
     // Cabeçalho aderente ao topo com fundo transparente e texto branco
     <header className="sticky top-0 z-50 bg-transparent text-white">
-      {/* Contêiner com três colunas para alinhar os elementos */}
-      <div className="mx-auto grid max-w-6xl grid-cols-3 items-center p-4 md:p-6">
-        {/* Menu hambúrguer no lado esquerdo */}
-        <details className="relative">
-          {/* Ícone do menu que abre as ligações principais */}
-          <summary className="flex cursor-pointer items-center justify-start list-none marker:content-none">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth="2"
-              className="h-6 w-6"
+      {/* Contêiner principal com espaçamento */}
+      <div className="mx-auto max-w-6xl p-4 md:p-6">
+        {/* Linha superior com menu hambúrguer (apenas mobile), logótipo e ícones */}
+        <div className="grid grid-cols-3 items-center">
+          {/* Menu hambúrguer exibido apenas em dispositivos móveis */}
+          <details className="relative md:hidden">
+            {/* Ícone do menu que abre as ligações principais */}
+            <summary className="flex cursor-pointer items-center justify-start list-none marker:content-none">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="h-6 w-6"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
+            </summary>
+            {/* Lista de ligações exibida ao abrir o menu com fundo branco translúcido e texto branco */}
+            <nav className="absolute left-0 mt-2 flex flex-col space-y-2 bg-white/40 p-4 text-white shadow">
+              <MainLinks linkClass="hover:underline" />
+            </nav>
+          </details>
+
+          {/* Logótipo central com texto 'CM' em branco e fonte Squarish Sans */}
+          <div className="text-center">
+            <Link
+              href="/"
+              className="text-3xl font-bold text-white logo-font"
+              aria-label="Página inicial"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </summary>
-          {/* Lista de ligações exibida ao abrir o menu com fundo branco e texto preto */}
-          <nav className="absolute left-0 mt-2 flex flex-col space-y-2 bg-white p-4 text-black shadow">
-            {mainLinks.map((link) => (
-              <Link key={link.href} href={link.href} className="hover:underline">
-                {link.label}
+              CM
+            </Link>
+          </div>
+
+          {/* Ícones de pesquisa e perfil no lado direito */}
+          <div className="flex items-center justify-end space-x-4">
+            {iconLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-label={link.label}
+                className="inline-flex"
+              >
+                {link.icon}
               </Link>
             ))}
-          </nav>
-        </details>
-
-        {/* Logótipo central com texto 'CM' em branco e fonte Squarish Sans */}
-        <div className="text-center">
-          <Link
-            href="/"
-            className="text-3xl font-bold text-white logo-font"
-            aria-label="Página inicial"
-          >
-            CM
-          </Link>
+          </div>
         </div>
 
-        {/* Ícones de pesquisa e perfil no lado direito */}
-        <div className="flex items-center justify-end space-x-4">
-          {iconLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              aria-label={link.label}
-              className="inline-flex"
-            >
-              {link.icon}
-            </Link>
-          ))}
-        </div>
+        {/* Menu principal exibido horizontalmente abaixo do logótipo em ecrãs maiores */}
+        <nav className="mt-4 hidden justify-center space-x-6 md:flex">
+          <MainLinks linkClass="hover:underline" />
+        </nav>
       </div>
     </header>
   )


### PR DESCRIPTION
## Summary
- refactor header navigation links into reusable component
- display horizontal menu on desktop and hamburger with translucent background on mobile

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beea71d828832e97cb974034841603