### PR TITLE
Aplicar transparência nas FAQs

### DIFF
--- a/frontend/components/Faq.tsx
+++ b/frontend/components/Faq.tsx
@@ -51,15 +51,15 @@ export function Faq() {
       {/* Lista de perguntas */}
       <div className="space-y-4">
         {faqItems.map((item) => (
-          // Cada item expansível com pergunta e resposta
+          // Cada item expansível com fundo translúcido
           <details
             key={item.question}
-            className="rounded-lg bg-white p-4 text-black shadow"
+            className="rounded-lg bg-white/20 p-4 shadow"
           >
               {/* Pergunta visível em negrito que pode ser clicada */}
-              <summary className="cursor-pointer font-bold">{item.question}</summary>
-            {/* Resposta apresentada ao clicar na pergunta */}
-            <p className="mt-2 text-black">{item.answer}</p>
+              <summary className="cursor-pointer font-bold text-black">{item.question}</summary>
+            {/* Resposta apresentada ao clicar na pergunta com texto branco */}
+            <p className="mt-2 text-white">{item.answer}</p>
           </details>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- make FAQ boxes translucent
- display questions in black and answers in white

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bef8440bc4832e92c747c697c072bd