### PR TITLE
Fix auth route prefix and use env API URL

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -41,4 +41,5 @@ def health():
     return {"status": "ok"}
 
 # rotas de autenticação
-app.include_router(auth_router, prefix="/auth", tags=["Auth"])
+# O router já inclui o prefixo "/auth", por isso não o repetimos
+app.include_router(auth_router, tags=["Auth"])

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,6 @@ NEXTAUTH_SECRET="gera-um-uuid-aleatorio"
 
 # URL base da aplicação
 NEXTAUTH_URL="http://localhost:3000"
+
+# URL base do backend usado pelo frontend
+NEXT_PUBLIC_API_URL="http://localhost:8000"

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,12 +1,13 @@
 /** Configuração do Next.js com headers de segurança e modo estrito */
-const BACKEND = "https://clientemisterio-backend.onrender.com";
+// URL do backend, lida das variáveis de ambiente em tempo de build
+const BACKEND = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
 
 const csp = [
   "default-src 'self'",
   "img-src 'self' data:",
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
-  // permitir fetch/XHR ao backend:
+  // permitir fetch/XHR ao backend definido em BACKEND
   `connect-src 'self' ${BACKEND}`,
   // permitir o embed do Genially:
   "frame-src https://view.genially.com",


### PR DESCRIPTION
## Summary
- avoid duplicate `/auth` prefix in backend routes
- read API URL from env in Next.js CSP
- document `NEXT_PUBLIC_API_URL` in frontend env example

## Testing
- `pytest`
- `npm run build`
- `curl -i http://localhost:8000/health`
- `curl -i http://localhost:8000/auth/register`
- `curl -i http://localhost:8000/auth/auth/register`

------
https://chatgpt.com/codex/tasks/task_e_68bf08d66db4832e9a0f87fd10a35c13