### PR TITLE
refactor: remove deprecated patterns

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -71,7 +71,8 @@ def get_current_user(request: Request, db: Session = Depends(get_db)) -> User:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token sem subject",
         )
-    user = db.query(User).get(int(user_id))
+    # Recupera o utilizador pelo ID diretamente
+    user = db.get(User, int(user_id))
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,20 +1,11 @@
 import type { Config } from 'tailwindcss'
-import colors from 'tailwindcss/colors'
 
-// Configuração do TailwindCSS com cores preto e branco padrão
+// Configuração do TailwindCSS utilizando a paleta padrão
 const config: Config = {
   // Diretórios onde o TailwindCSS procura por classes a serem compiladas
   content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './lib/**/*.{ts,tsx}'],
   theme: {
-    // Definição das cores preto e branco sem substituições
-    colors: {
-      ...colors, // Mantém todas as cores padrão do TailwindCSS
-      inherit: 'inherit', // Mantém a herança de cor padrão
-      transparent: 'transparent', // Preserva a opção de transparência
-      current: 'currentColor', // Mantém a cor atual do elemento
-      white: '#ffffff', // Cor branca padrão
-      black: '#000000', // Cor preta padrão
-    },
+    // Mantém todas as cores padrão sem redefini-las
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- replace deprecated SQLAlchemy `Query.get` with `Session.get`
- simplify Tailwind configuration to silence deprecated color warnings

## Testing
- `python -m py_compile backend/*.py`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf553a77a4832e8ab9f668ad1a5587