### PR TITLE
fix: ensure default API URL when env var missing

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,8 +2,10 @@
 // Funções para ligação ao backend de autenticação
 // (Comentários em português, código em inglês)
 
+// Detecta URL da API a partir da variável de ambiente ou usa valor padrão
 export const API_URL =
-  process.env.NEXT_PUBLIC_API_URL ?? 'https://clientemisterio-backend.onrender.com'
+  process.env.NEXT_PUBLIC_API_URL?.trim() ||
+  'https://clientemisterio-backend.onrender.com'
 
 // Tipos úteis (ajusta conforme o teu backend)
 export type ApiUser = {


### PR DESCRIPTION
## Summary
- handle empty NEXT_PUBLIC_API_URL by falling back to Render backend

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bffa947278832e9c04ea7375ab6e6e