### PR TITLE
feat: usar fonte manuscrita no logotipo

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.cdnfonts.com/css/squarish-sans');
+@import url('https://fonts.googleapis.com/css2?family=Pacifico&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 
 @tailwind base;
@@ -31,9 +31,9 @@ html, body {
   overflow-y: auto;
 }
 
-/* Classe para aplicar a fonte Squarish Sans ao logótipo */
+/* Classe para aplicar a fonte manuscrita Pacifico ao logótipo */
 .logo-font {
-  font-family: 'Squarish Sans', sans-serif;
+  font-family: 'Pacifico', cursive;
 }
 
 /* Justifica o texto de todos os parágrafos */

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -81,7 +81,7 @@ export function Header() {
         {/* Logótipo alinhado à esquerda */}
         <Link
           href="/"
-          className="text-3xl font-bold text-white logo-font"
+          className="text-5xl font-bold text-white logo-font"
           aria-label="Página inicial"
         >
           CM

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
-  <!-- Logótipo com texto 'CM' em branco utilizando a fonte Squarish Sans -->
-  <text x="0" y="17" font-family="'Squarish Sans', sans-serif" font-size="20" fill="#ffffff">CM</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 30">
+  <!-- Logótipo com texto 'CM' em branco utilizando a fonte manuscrita Pacifico -->
+  <text x="0" y="24" font-family="'Pacifico', cursive" font-size="30" fill="#ffffff">CM</text>
 </svg>


### PR DESCRIPTION
## Summary
- usar fonte manuscrita Pacifico para o logótipo
- aumentar tamanho do texto "CM" no cabeçalho e SVG

## Testing
- `npm test` (falhou: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c034895d9c832eb286089f7d31e9d1