### PR TITLE
fix: allow Vercel feedback script and configure favicon

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,6 +7,10 @@ import { CookieBar } from '../components/CookieBar'
 export const metadata = {
   title: 'Cliente Mistério',
   description: 'Plataforma de curso para clientes mistério',
+  // definir o favicon para evitar pedidos de /favicon.ico inexistente
+  icons: {
+    icon: '/logo.svg',
+  },
 }
 
 // Meta tag de viewport para adaptação mobile

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -8,7 +8,8 @@ const BACKEND =
 const csp = [
   "default-src 'self'",
   "img-src 'self' data:",
-  "script-src 'self' 'unsafe-inline'",
+  // permitir scripts locais e o script de feedback do Vercel
+  "script-src 'self' 'unsafe-inline' https://vercel.live",
   // permitir folhas de estilo locais e externas necessárias para as fontes
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.cdnfonts.com",
   // permitir carregamento de fontes externas


### PR DESCRIPTION
## Summary
- allow Vercel live feedback script in CSP
- define favicon to avoid missing file request

## Testing
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68c03855e0b4832e83cc81aff8795d66