### PR TITLE
feat: use white text across pages

### DIFF
--- a/frontend/app/(private)/dashboard/page.tsx
+++ b/frontend/app/(private)/dashboard/page.tsx
@@ -53,13 +53,13 @@ export default function DashboardPage() {
         {/* Título principal do dashboard */}
         <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
         {/* Frase motivacional para contextualizar o aluno */}
-        <p className="mb-8 text-black">Explore o conteúdo interativo do curso.</p>
+        <p className="mb-8 text-white">Explore o conteúdo interativo do curso.</p>
 
         {/* Link para a página de compra do curso */}
         <div className="mb-8 text-center">
           <Link
             href="/comprar"
-            className="rounded bg-black px-4 py-2 text-white hover:bg-black/80"
+            className="rounded bg-white px-4 py-2 text-black hover:bg-white/80"
           >
             Comprar curso
           </Link>
@@ -101,22 +101,22 @@ export default function DashboardPage() {
         <h3 className="mt-8 text-xl font-bold">Atualizar dados pessoais</h3>
         <form onSubmit={handleUpdate} className="mt-4 max-w-md space-y-4">
           <div>
-            <label className="block text-sm font-medium text-black">Nome</label>
+            <label className="block text-sm font-medium text-white">Nome</label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="mt-1 w-full rounded border p-2"
+              className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
               required
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-black">Email</label>
+            <label className="block text-sm font-medium text-white">Email</label>
             <input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 w-full rounded border p-2"
+              className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
               required
             />
           </div>

--- a/frontend/app/(public)/comprar/page.tsx
+++ b/frontend/app/(public)/comprar/page.tsx
@@ -6,13 +6,13 @@ export default function BuyPage() {
       {/* Título da página */}
       <h2 className="text-3xl font-bold">Comprar curso</h2>
       {/* Explicação do processo de compra */}
-      <p className="mt-4 text-black">Pague com segurança através do Stripe.</p>
+      <p className="mt-4 text-white">Pague com segurança através do Stripe.</p>
       {/* Link que abre o pagamento em nova aba */}
       <a
         href="https://stripe.com/pagar/SEU_LINK"
         target="_blank"
         rel="noopener noreferrer"
-        className="mt-8 inline-block rounded bg-black px-4 py-2 text-white hover:bg-black/80"
+        className="mt-8 inline-block rounded bg-white px-4 py-2 text-black hover:bg-white/80"
       >
         Comprar agora
       </a>

--- a/frontend/app/(public)/curso/page.tsx
+++ b/frontend/app/(public)/curso/page.tsx
@@ -7,11 +7,11 @@ export default function CoursePage() {
       <h2 className="text-3xl font-bold">Sobre o curso</h2>
 
       {/* Parágrafos introdutórios sobre o curso */}
-      <p className="mt-4 text-black">
+      <p className="mt-4 text-white">
         O Curso de Cliente Mistério foi criado para todos os que querem descobrir como funciona esta
         atividade e aprender a realizar avaliações profissionais de qualidade.
       </p>
-      <p className="mt-4 text-black">
+      <p className="mt-4 text-white">
         Baseado em experiência prática em projetos reais em Portugal, o curso apresenta de forma
         simples e objetiva tudo o que precisa de saber para começar ou evoluir nesta área.
       </p>
@@ -19,9 +19,9 @@ export default function CoursePage() {
       {/* Contêiner com divisão dos temas em caixas */}
       <div className="mt-10 grid gap-8 md:grid-cols-2">
         {/* Caixa: O que vai aprender */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border bg-black/70 p-6 shadow">
           <h3 className="text-xl font-semibold">O que vai aprender</h3>
-          <ul className="mt-4 list-disc list-inside text-black space-y-2">
+          <ul className="mt-4 list-disc list-inside text-white space-y-2">
             <li>O que é um Cliente Mistério e qual o seu papel.</li>
             <li>Como avaliar o atendimento, a experiência do cliente e o cumprimento de standards de serviço.</li>
             <li>Como realizar visitas de forma discreta e profissional.</li>
@@ -30,18 +30,18 @@ export default function CoursePage() {
         </div>
 
         {/* Caixa: Estrutura do curso */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border bg-black/70 p-6 shadow">
           <h3 className="text-xl font-semibold">Estrutura do curso</h3>
-          <p className="mt-4 text-black">
+          <p className="mt-4 text-white">
             O curso está organizado em módulos curtos e diretos, com exemplos práticos e questionários no
             final de cada tema, para consolidar os conhecimentos.
           </p>
         </div>
 
         {/* Caixa: Para quem é este curso */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border bg-black/70 p-6 shadow">
           <h3 className="text-xl font-semibold">Para quem é este curso</h3>
-          <ul className="mt-4 list-disc list-inside text-black space-y-2">
+          <ul className="mt-4 list-disc list-inside text-white space-y-2">
             <li>Pessoas que querem iniciar-se como Clientes Mistério.</li>
             <li>Profissionais que já atuam em áreas como comércio, hotelaria ou automóvel e pretendem melhorar a sua capacidade de análise.</li>
             <li>Empresas que desejam formar colaboradores nesta metodologia de avaliação.</li>
@@ -49,9 +49,9 @@ export default function CoursePage() {
         </div>
 
         {/* Caixa: Benefícios do curso */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border bg-black/70 p-6 shadow">
           <h3 className="text-xl font-semibold">Benefícios</h3>
-          <ul className="mt-4 list-disc list-inside text-black space-y-2">
+          <ul className="mt-4 list-disc list-inside text-white space-y-2">
             <li>100% online, pode aprender ao seu ritmo.</li>
             <li>Acesso imediato após inscrição.</li>
             <li>Conteúdos claros e aplicáveis a situações reais.</li>

--- a/frontend/app/(public)/enterprise/page.tsx
+++ b/frontend/app/(public)/enterprise/page.tsx
@@ -158,7 +158,7 @@ export default function EnterprisePage() {
             {ctaButtons.map((label) => (
               <button
                 key={label}
-                className="bg-transparent border border-white px-4 py-2 rounded-md"
+                className="rounded-md border border-black bg-white px-4 py-2 text-black hover:bg-white/80"
               >
                 {label}
               </button>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -11,7 +11,7 @@ html, body {
   /* Aplica o tipo de letra Roboto em todo o site */
   font-family: 'Roboto', sans-serif;
   /* Define a cor padrão do texto em todo o site */
-  color: #000000;
+  color: #ffffff;
   /* Remove margens e preenchimentos padrão */
   margin: 0;
   padding: 0;
@@ -44,13 +44,11 @@ p {
   text-align: justify;
 }
 
-/* Torna o texto de todos os botões em negrito */
+/* Torna o texto de todos os botões em negrito e com cor preta */
 button {
   font-weight: 700;
-  /* Fundo preto para todos os botões */
-  background-color: #000000;
-  /* Texto branco para contraste */
-  color: #ffffff;
+  /* Texto preto para contrastar com o fundo */
+  color: #000000;
 }
 
 /* Estilo personalizado do botão "Adere já" */
@@ -77,7 +75,7 @@ button {
 .join-button:hover {
   background-color: #5e6ce7;
   box-shadow: 0 0 0 5px #3b83f65f;
-  color: #ffffff;
+  color: #000000;
 }
 
 /* Contêiner principal do formulário */
@@ -164,46 +162,4 @@ button {
   padding-left: 5px;
   padding-right: 5px;
 }
-
-/* Botão de submissão do formulário */
-.submit-btn {
-  margin-top: 30px;
-  height: 55px;
-  /* Fundo preto do botão de submissão */
-  background: #000000;
-  border-radius: 11px;
-  border: 0;
-  outline: none;
-  /* Texto branco para visibilidade */
-  color: #ffffff;
-  font-size: 18px;
-  font-weight: 700;
-  transition: all 0.3s cubic-bezier(0.15, 0.83, 0.66, 1);
-  cursor: pointer;
-}
-
-/* Efeito ao passar o rato sobre o botão */
-.submit-btn:hover {
-  background: #000000cc;
-}
-
-/* Botão de adesão com estilo personalizado */
-.join-button {
-  background-color: #f3f7fE;
-  color: #C645F9;
-  border: none;
-  cursor: pointer;
-  border-radius: 8px;
-  width: 100px;
-  height: 45px;
-  transition: 0.3s;
-}
-
-/* Efeito de foco para o botão de adesão */
-.join-button:hover {
-  background-color: #5E6CE7;
-  box-shadow: 0 0 0 5px #3b83f65f;
-  color: #fff;
-}
-
 

--- a/frontend/components/CookieBar.tsx
+++ b/frontend/components/CookieBar.tsx
@@ -24,12 +24,12 @@ export function CookieBar() {
   if (accepted) return null
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 border-t border-black bg-white p-4 text-center text-black">
+    <div className="fixed bottom-0 left-0 right-0 border-t border-white bg-black p-4 text-center text-white">
       {/* Mensagem informativa sobre cookies */}
       <p className="mb-2">Usamos cookies para melhorar a experiência.</p>
       <button
         onClick={handleAccept}
-        className="rounded bg-black px-4 py-2 font-bold text-white hover:bg-black/80"
+        className="rounded bg-white px-4 py-2 font-bold text-black hover:bg-white/80"
       >
         Aceitar
       </button>

--- a/frontend/components/Faq.tsx
+++ b/frontend/components/Faq.tsx
@@ -57,7 +57,7 @@ export function Faq() {
             className="rounded-lg bg-white/20 p-4 shadow"
           >
               {/* Pergunta visível em negrito que pode ser clicada */}
-              <summary className="cursor-pointer font-bold text-black">{item.question}</summary>
+              <summary className="cursor-pointer font-bold text-white">{item.question}</summary>
             {/* Resposta apresentada ao clicar na pergunta com texto branco */}
             <p className="mt-2 text-white">{item.answer}</p>
           </details>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -133,7 +133,7 @@ export function Header() {
             // Botão de logout visível quando autenticado
             <button
               onClick={handleLogout}
-              className="rounded bg-black px-4 py-1 text-white hover:bg-black/80"
+              className="rounded bg-white px-4 py-1 text-black hover:bg-white/80"
             >
               Logout
             </button>


### PR DESCRIPTION
## Summary
- set white as default text color
- show black text on buttons and fix duplicated styles
- adjust pages and components to honour new color scheme

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0470ed578832eaf12989eb39e937a