### PR TITLE
Improve session handling and course styling

### DIFF
--- a/frontend/app/(public)/curso/page.tsx
+++ b/frontend/app/(public)/curso/page.tsx
@@ -1,17 +1,17 @@
 // Página com informação detalhada sobre o curso
 export default function CoursePage() {
   return (
-    // Secção principal com conteúdos do curso sem espaço superior
-    <section className="mx-auto max-w-5xl pb-20 text-justify">
+    // Secção principal com conteúdos do curso sem espaço superior e texto a branco
+    <section className="mx-auto max-w-5xl pb-20 text-justify text-white">
       {/* Título principal da página */}
-      <h2 className="text-3xl font-bold">Sobre o curso</h2>
+      <h2 className="text-3xl font-bold text-center">Sobre o curso</h2>
 
       {/* Parágrafos introdutórios sobre o curso */}
-      <p className="mt-4 text-black">
+      <p className="mt-4">
         O Curso de Cliente Mistério foi criado para todos os que querem descobrir como funciona esta
         atividade e aprender a realizar avaliações profissionais de qualidade.
       </p>
-      <p className="mt-4 text-black">
+      <p className="mt-4">
         Baseado em experiência prática em projetos reais em Portugal, o curso apresenta de forma
         simples e objetiva tudo o que precisa de saber para começar ou evoluir nesta área.
       </p>
@@ -19,9 +19,9 @@ export default function CoursePage() {
       {/* Contêiner com divisão dos temas em caixas */}
       <div className="mt-10 grid gap-8 md:grid-cols-2">
         {/* Caixa: O que vai aprender */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border border-white/30 bg-white/10 p-6 shadow text-white">
           <h3 className="text-xl font-semibold">O que vai aprender</h3>
-          <ul className="mt-4 list-disc list-inside text-black space-y-2">
+          <ul className="mt-4 list-disc list-inside space-y-2">
             <li>O que é um Cliente Mistério e qual o seu papel.</li>
             <li>Como avaliar o atendimento, a experiência do cliente e o cumprimento de standards de serviço.</li>
             <li>Como realizar visitas de forma discreta e profissional.</li>
@@ -30,28 +30,31 @@ export default function CoursePage() {
         </div>
 
         {/* Caixa: Estrutura do curso */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border border-white/30 bg-white/10 p-6 shadow text-white">
           <h3 className="text-xl font-semibold">Estrutura do curso</h3>
-          <p className="mt-4 text-black">
+          <p className="mt-4">
             O curso está organizado em módulos curtos e diretos, com exemplos práticos e questionários no
             final de cada tema, para consolidar os conhecimentos.
           </p>
         </div>
 
         {/* Caixa: Para quem é este curso */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border border-white/30 bg-white/10 p-6 shadow text-white">
           <h3 className="text-xl font-semibold">Para quem é este curso</h3>
-          <ul className="mt-4 list-disc list-inside text-black space-y-2">
+          <ul className="mt-4 list-disc list-inside space-y-2">
             <li>Pessoas que querem iniciar-se como Clientes Mistério.</li>
-            <li>Profissionais que já atuam em áreas como comércio, hotelaria ou automóvel e pretendem melhorar a sua capacidade de análise.</li>
+            <li>
+              Profissionais que já atuam em áreas como comércio, hotelaria ou automóvel e pretendem melhorar a sua capacidade
+              de análise.
+            </li>
             <li>Empresas que desejam formar colaboradores nesta metodologia de avaliação.</li>
           </ul>
         </div>
 
         {/* Caixa: Benefícios do curso */}
-        <div className="rounded-lg border bg-white/70 p-6 shadow">
+        <div className="rounded-lg border border-white/30 bg-white/10 p-6 shadow text-white">
           <h3 className="text-xl font-semibold">Benefícios</h3>
-          <ul className="mt-4 list-disc list-inside text-black space-y-2">
+          <ul className="mt-4 list-disc list-inside space-y-2">
             <li>100% online, pode aprender ao seu ritmo.</li>
             <li>Acesso imediato após inscrição.</li>
             <li>Conteúdos claros e aplicáveis a situações reais.</li>
@@ -59,7 +62,6 @@ export default function CoursePage() {
           </ul>
         </div>
       </div>
-
     </section>
   )
 }

--- a/frontend/app/(public)/entrar/page.tsx
+++ b/frontend/app/(public)/entrar/page.tsx
@@ -39,6 +39,8 @@ export default function LoginPage() {
       await loginUser({ email, password })
       // Guarda apenas a flag de sessão autenticada
       localStorage.setItem('cm_session', JSON.stringify({ loggedIn: true }))
+      // Notifica a aplicação que a sessão foi alterada
+      window.dispatchEvent(new Event('cm-session'))
       // Redireciona para o dashboard do aluno
       router.push('/dashboard')
     } catch (err: unknown) {

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -28,27 +28,6 @@ function MainLinks({ linkClass }: { linkClass: string }) {
   )
 }
 
-// Ícone de pesquisa reutilizável
-const searchIcon = (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeWidth="2"
-    className="h-6 w-6"
-  >
-    <circle cx="11" cy="11" r="8" />
-    <line
-      x1="21"
-      y1="21"
-      x2="16.65"
-      y2="16.65"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-)
 
 // Ícone de utilizador para o botão de login
 const loginIcon = (
@@ -76,8 +55,8 @@ export function Header() {
   // Router para redirecionar após logout
   const router = useRouter()
 
-  // Verifica no localStorage se existe sessão ativa
-  useEffect(() => {
+  // Função que verifica a sessão no localStorage
+  const checkSession = () => {
     const session = localStorage.getItem('cm_session')
     try {
       const parsed = session ? JSON.parse(session) : null
@@ -85,6 +64,14 @@ export function Header() {
     } catch {
       setIsLoggedIn(false)
     }
+  }
+
+  // Verifica sessão inicial e ouve alterações através de evento personalizado
+  useEffect(() => {
+    checkSession()
+    const handleSessionEvent = () => checkSession()
+    window.addEventListener('cm-session', handleSessionEvent)
+    return () => window.removeEventListener('cm-session', handleSessionEvent)
   }, [])
 
   // Termina a sessão ao clicar no botão de logout
@@ -96,6 +83,8 @@ export function Header() {
     } finally {
       localStorage.removeItem('cm_session')
       setIsLoggedIn(false)
+      // Dispara evento para informar outros componentes da alteração
+      window.dispatchEvent(new Event('cm-session'))
       router.push('/')
     }
   }
@@ -124,19 +113,17 @@ export function Header() {
 
         {/* Área de ações no canto superior direito */}
         <div className="flex items-center space-x-4">
-          {/* Link para pesquisa (não funcional) */}
-          <Link href="#" aria-label="Pesquisar" className="inline-flex">
-            {searchIcon}
-          </Link>
-
           {isLoggedIn ? (
-            // Botão de logout visível quando autenticado
-            <button
-              onClick={handleLogout}
-              className="join-button"
-            >
-              Logout
-            </button>
+            <>
+              {/* Liga o aluno ao dashboard pessoal */}
+              <Link href="/dashboard" className="join-button">
+                Área Pessoal
+              </Link>
+              {/* Botão de logout visível quando autenticado */}
+              <button onClick={handleLogout} className="join-button">
+                Logout
+              </button>
+            </>
           ) : (
             // Ícone de login quando não autenticado
             <Link


### PR DESCRIPTION
## Summary
- update header session listener and add personal area button
- dispatch session event after login
- restyle course page with centered white text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c04f8516c8832eb276981acb1f689c