### PR TITLE
chore: simplify enterprise page

### DIFF
--- a/frontend/app/(public)/enterprise/page.tsx
+++ b/frontend/app/(public)/enterprise/page.tsx
@@ -1,4 +1,4 @@
-// Página "Enterprise" com todo o conteúdo solicitado
+// Página "Enterprise" simplificada após remoções
 import type { ReactNode } from "react"
 
 // Componente reutilizável para caixas translúcidas
@@ -30,7 +30,7 @@ export default function EnterprisePage() {
     "Divulgação da sua empresa junto da nossa comunidade (site, newsletter e redes).",
     "Ponto de ligação entre as suas necessidades de recrutamento e os nossos alunos certificados.",
     "Listas por perfil (região, disponibilidade, mobilidade, experiência) para acelerar o recrutamento.",
-    "Divulgação de estudos e vagas para atrair candidatos qualificados rapidamente."
+    "Divulgação de estudos e vagas para atrair candidatos qualificados rapidamente.",
   ]
 
   // Passos do processo de funcionamento
@@ -38,69 +38,19 @@ export default function EnterprisePage() {
     "Briefing → Diz-nos o perfil que precisas (localidades, prazos, requisitos).",
     "Matching → Selecionamos alunos certificados que encaixam no perfil.",
     "Entrega → Enviamos lista de candidatos qualificados para contacto/convite.",
-    "Acompanhamento → Fechamos feedback e ajustamos perfis conforme os resultados."
+    "Acompanhamento → Fechamos feedback e ajustamos perfis conforme os resultados.",
   ]
 
   // Contrapartidas pedidas às empresas
   const exchange = [
-    "Divulgação do nosso curso (link/menção nas suas comunicações ou página de recrutamento)."
-  ]
-
-  // Filtros disponíveis para perfis
-  const profiles = [
-    "Localização (distritos/concelhos)",
-    "Disponibilidade (dias/horários)",
-    "Mobilidade (viatura própria/TP)",
-    "Experiência (iniciante/experiente)",
-    "Segmentos (retalho, automóvel, restauração, serviços, etc.)"
+    "Divulgação do nosso curso (link/menção nas suas comunicações ou página de recrutamento).",
   ]
 
   // Compromissos e conformidade
   const commitments = [
     "RGPD: partilha de dados apenas com consentimento e para finalidade de recrutamento.",
     "Qualidade: todos os candidatos completaram o curso e conhecem boas práticas.",
-    "Flexibilidade: sem exclusividade; modelo de colaboração ajustável ao seu processo."
-  ]
-
-  // Botões de call-to-action
-  const ctaButtons = [
-    "Pedir lista de candidatos",
-    "Agendar conversa de 15 min",
-    "Divulgar um estudo / vaga"
-  ]
-
-  // Campos sugeridos para formulários
-  const formFields = [
-    "Nome e Empresa",
-    "E-mail e Telefone",
-    "Tipo de estudo / cliente",
-    "Localidades e prazos",
-    "Requisitos do perfil (idade, mobilidade, experiência, outros)",
-    "Observações / NDA (opcional)"
-  ]
-
-  // Perguntas frequentes com respostas
-  const faq = [
-    {
-      question: "Quanto custa?",
-      answer:
-        "A parceria é simples e flexível. Em contrapartida, pedimos a divulgação do nosso curso. Condições específicas podem ser combinadas caso a caso."
-    },
-    {
-      question: "Têm cobertura nacional?",
-      answer:
-        "Sim, com foco em Portugal. Indicando os concelhos, ajustamos a lista ao território necessário."
-    },
-    {
-      question: "Como garantem a qualidade?",
-      answer:
-        "Os candidatos concluíram o nosso curso e recebem instruções claras por estudo. Podemos recolher feedback pós-missão para melhoria contínua."
-    },
-    {
-      question: "Em quanto tempo enviam perfis?",
-      answer:
-        "Normalmente 24–72h após recebermos o briefing com requisitos e localidades."
-    }
+    "Flexibilidade: sem exclusividade; modelo de colaboração ajustável ao seu processo.",
   ]
 
   return (
@@ -112,14 +62,6 @@ export default function EnterprisePage() {
         <div className="text-center space-y-2">
           <h1 className="text-4xl font-bold">Empresas & Marcas</h1>
         </div>
-
-        {/* Descrição inicial */}
-        <TransparentBox>
-          <p>
-            Treinamos pessoas para serem Clientes Mistério e ligamo-las a empresas de estudos de mercado.
-            Recebe perfis validados, motivados e prontos a executar avaliações — quando e onde precisa.
-          </p>
-        </TransparentBox>
 
         {/* O que oferecemos */}
         <TransparentBox>
@@ -139,53 +81,12 @@ export default function EnterprisePage() {
           <BulletList items={exchange} />
         </TransparentBox>
 
-        {/* Perfis disponíveis */}
-        <TransparentBox>
-          <h2 className="text-2xl font-semibold mb-4">Perfis disponíveis (exemplos de filtros)</h2>
-          <BulletList items={profiles} />
-        </TransparentBox>
-
         {/* Compromissos e conformidade */}
         <TransparentBox>
           <h2 className="text-2xl font-semibold mb-4">Compromissos e conformidade</h2>
           <BulletList items={commitments} />
         </TransparentBox>
-
-        {/* Call-to-Action */}
-        <TransparentBox>
-          <h2 className="text-2xl font-semibold mb-4">Call-to-Action</h2>
-          <div className="flex flex-col gap-4 sm:flex-row">
-            {ctaButtons.map((label) => (
-              <button
-                key={label}
-                className="rounded-md border border-black bg-white px-4 py-2 font-bold text-black hover:bg-white/80"
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </TransparentBox>
-
-        {/* Campos do formulário */}
-        <TransparentBox>
-          <h2 className="text-2xl font-semibold mb-4">Campos do formulário (sugestão)</h2>
-          <BulletList items={formFields} />
-        </TransparentBox>
-
-        {/* FAQ rápido */}
-        <TransparentBox>
-          <h2 className="text-2xl font-semibold mb-4">FAQ rápido</h2>
-          <ul className="space-y-4">
-            {faq.map((item) => (
-              <li key={item.question}>
-                <p className="font-semibold">{item.question}</p>
-                <p>{item.answer}</p>
-              </li>
-            ))}
-          </ul>
-        </TransparentBox>
       </div>
     </section>
   )
 }
-


### PR DESCRIPTION
## Summary
- remove introductory description, profile filters, CTA, form fields, and FAQ from enterprise page
- keep core offering, process, exchange, and commitment sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c17b97f8b0832e9053bb37e15a6d44