### PR TITLE
feat: add dashboard sidebar and settings pages

### DIFF
--- a/frontend/app/(private)/dashboard/account/page.tsx
+++ b/frontend/app/(private)/dashboard/account/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+// Página de gestão da conta do utilizador
+export default function AccountPage() {
+  // Secções para sessões ativas e apagar conta
+  return (
+    <section className="space-y-6">
+      {/* Título da página */}
+      <h3 className="text-xl font-bold">Conta</h3>
+
+      {/* Secção de sessões ativas (placeholder) */}
+      <div>
+        <h4 className="font-semibold">Sessões ativas</h4>
+        <p className="text-sm text-white/80">Funcionalidade em desenvolvimento.</p>
+      </div>
+
+      {/* Secção para apagar a conta (placeholder) */}
+      <div>
+        <h4 className="font-semibold">Apagar conta</h4>
+        <button className="join-button mt-2">Apagar</button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/app/(private)/dashboard/layout.tsx
+++ b/frontend/app/(private)/dashboard/layout.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+// Layout do dashboard com menu lateral
+import { ReactNode } from 'react'
+import Link from 'next/link'
+import { ProtectedClient } from '../../../components/ProtectedClient'
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  // Renderiza o layout com o menu e o conteúdo principal
+  return (
+    <ProtectedClient>
+      <div className="flex min-h-screen">
+        {/* Menu lateral com as opções do dashboard */}
+        <aside className="w-64 border-r border-white p-4">
+          <nav className="space-y-4">
+            <Link href="/dashboard/personal" className="block hover:underline">
+              Dados Pessoais
+            </Link>
+            <Link href="/dashboard/account" className="block hover:underline">
+              Conta
+            </Link>
+            <Link href="/dashboard/opportunities" className="block hover:underline">
+              Oportunidades &amp; Carreira
+            </Link>
+          </nav>
+        </aside>
+        {/* Área principal onde o conteúdo das páginas é apresentado */}
+        <main className="flex-1 p-8">{children}</main>
+      </div>
+    </ProtectedClient>
+  )
+}

--- a/frontend/app/(private)/dashboard/opportunities/page.tsx
+++ b/frontend/app/(private)/dashboard/opportunities/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+// Página com recursos de oportunidades e carreira
+import { useState } from 'react'
+import Link from 'next/link'
+
+export default function OpportunitiesPage() {
+  // Estado para controlar a partilha de perfil com parceiros
+  const [shareProfile, setShareProfile] = useState(false)
+
+  return (
+    <section className="space-y-6">
+      {/* Título da página */}
+      <h3 className="text-xl font-bold">Oportunidades &amp; Carreira</h3>
+
+      {/* Diretório de empresas com links de recursos */}
+      <div>
+        <h4 className="font-semibold">Diretório de empresas</h4>
+        <ul className="list-disc pl-5">
+          <li>
+            <Link href="#" className="underline">
+              Empresa A
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="underline">
+              Empresa B
+            </Link>
+          </li>
+        </ul>
+      </div>
+
+      {/* Opt-in/out para partilha de perfil com parceiros */}
+      <div>
+        <h4 className="font-semibold">Partilha de perfil com empresas parceiras</h4>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={shareProfile}
+            onChange={(e) => setShareProfile(e.target.checked)}
+          />
+          <span>Permitir partilha do meu perfil</span>
+        </label>
+      </div>
+
+      {/* Informação sobre alertas de oportunidades */}
+      <div>
+        <h4 className="font-semibold">Alertas de oportunidades</h4>
+        <p className="text-sm text-white/80">
+          Inscreva-se na nossa newsletter ou Telegram para receber novidades.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/frontend/app/(private)/dashboard/page.tsx
+++ b/frontend/app/(private)/dashboard/page.tsx
@@ -1,131 +1,56 @@
 'use client'
 
-// Página protegida que serve de dashboard do aluno
-// Importa hooks e funções necessárias
-import { useEffect, useState } from 'react'
+// Página principal do dashboard com o curso disponível
 import Link from 'next/link'
-import { ProtectedClient } from '../../../components/ProtectedClient'
-import { getCurrentUser, updateUser } from '@/lib/api'
 
 export default function DashboardPage() {
-  // Estados para os dados do utilizador e mensagens
-  const [name, setName] = useState('')
-  const [email, setEmail] = useState('')
-  const [message, setMessage] = useState('')
-
-  // Ao montar a página, obtém a sessão e carrega os dados do utilizador
-  useEffect(() => {
-    const session = localStorage.getItem('cm_session')
-    try {
-      const parsed = session ? JSON.parse(session) : null
-      if (parsed?.loggedIn) {
-        getCurrentUser()
-          .then((user) => {
-            setName(user.name)
-            setEmail(user.email)
-          })
-          .catch(() => setMessage('Erro ao carregar dados.'))
-      } else {
-        setMessage('Sessão inválida.')
-      }
-    } catch {
-      setMessage('Sessão inválida.')
-    }
-  }, [])
-
-  // Submete as alterações de perfil para a API
-  const handleUpdate = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setMessage('')
-    try {
-      await updateUser({ name, email })
-      setMessage('Dados atualizados com sucesso.')
-    } catch (err: unknown) {
-      if (err instanceof Error) setMessage(err.message)
-      else setMessage('Erro ao atualizar dados.')
-    }
-  }
-
+  // Apresenta o curso e opção de compra
   return (
-    <ProtectedClient>
-      {/* Secção principal do dashboard sem margem superior */}
-      <section className="pb-8">
-        {/* Título principal do dashboard */}
-        <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
-        {/* Frase motivacional para contextualizar o aluno */}
-        <p className="mb-8 text-white">Explore o conteúdo interativo do curso.</p>
+    <section className="pb-8">
+      {/* Título do curso */}
+      <h2 className="mb-4 text-center text-2xl font-bold">Curso Cliente Mistério</h2>
 
-        {/* Link para a página de compra do curso */}
-        <div className="mb-8 text-center">
-          <Link
-            href="/comprar"
-            className="rounded bg-white px-4 py-2 font-bold text-black hover:bg-white/80"
-          >
-            Comprar curso
-          </Link>
-        </div>
-
-        {/* Contêiner responsivo com o iframe do curso em tamanho reduzido */}
-        <div
-          className="mx-auto w-full max-w-3xl rounded-lg p-4"
-          style={{ backgroundColor: 'rgba(238, 105, 46, 0.25)' }}
+      {/* Botão para compra do curso */}
+      <div className="mb-8 text-center">
+        <Link
+          href="/comprar"
+          className="rounded bg-white px-4 py-2 font-bold text-black hover:bg-white/80"
         >
-          <div
-            style={{
-              position: 'relative',
-              paddingBottom: '56.25%',
-              paddingTop: 0,
-              height: 0,
-            }}
-          >
-            <iframe
-              title="Curso Completo Cliente Mistério"
-              frameBorder={0}
-              width={800}
-              height={450}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                height: '100%',
-              }}
-              src="https://view.genially.com/68b97653b3a4717fa5a9e8b1"
-              allowFullScreen
-              scrolling="yes"
-            />
-          </div>
-        </div>
+          Comprar curso
+        </Link>
+      </div>
 
-        {/* Formulário para atualizar dados pessoais */}
-        <h3 className="mt-8 text-xl font-bold">Atualizar dados pessoais</h3>
-        <form onSubmit={handleUpdate} className="mt-4 max-w-md space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-white">Nome</label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-white">Email</label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
-              required
-            />
-          </div>
-          {message && <p className="text-sm text-red-600">{message}</p>}
-          <button type="submit" className="join-button mt-2">
-            Guardar
-          </button>
-        </form>
-      </section>
-    </ProtectedClient>
+      {/* Contêiner responsivo com o iframe do curso */}
+      <div
+        className="mx-auto w-full max-w-3xl rounded-lg p-4"
+        style={{ backgroundColor: 'rgba(238, 105, 46, 0.25)' }}
+      >
+        <div
+          style={{
+            position: 'relative',
+            paddingBottom: '56.25%',
+            paddingTop: 0,
+            height: 0,
+          }}
+        >
+          <iframe
+            title="Curso Completo Cliente Mistério"
+            frameBorder={0}
+            width={800}
+            height={450}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+            }}
+            src="https://view.genially.com/68b97653b3a4717fa5a9e8b1"
+            allowFullScreen
+            scrolling="yes"
+          />
+        </div>
+      </div>
+    </section>
   )
 }

--- a/frontend/app/(private)/dashboard/personal/page.tsx
+++ b/frontend/app/(private)/dashboard/personal/page.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+// Página para atualização de dados pessoais
+import { useEffect, useState } from 'react'
+import { getCurrentUser, updateUser } from '@/lib/api'
+
+export default function PersonalPage() {
+  // Estados para armazenar nome, email, password e mensagens de feedback
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [message, setMessage] = useState('')
+
+  // Ao carregar a página, obtém os dados atuais do utilizador
+  useEffect(() => {
+    getCurrentUser()
+      .then((user) => {
+        setName(user.name)
+        setEmail(user.email)
+      })
+      .catch(() => setMessage('Erro ao carregar dados.'))
+  }, [])
+
+  // Envia as alterações para a API
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setMessage('')
+    try {
+      await updateUser({ name, email, password })
+      setMessage('Dados atualizados com sucesso.')
+      setPassword('')
+    } catch (err: unknown) {
+      if (err instanceof Error) setMessage(err.message)
+      else setMessage('Erro ao atualizar dados.')
+    }
+  }
+
+  return (
+    <section>
+      {/* Título da secção */}
+      <h3 className="text-xl font-bold">Dados pessoais</h3>
+      {/* Formulário para alteração de nome, email e password */}
+      <form onSubmit={handleUpdate} className="mt-4 max-w-md space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-white">Nome</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-white">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-white">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
+          />
+        </div>
+        {message && <p className="text-sm text-red-600">{message}</p>}
+        <button type="submit" className="join-button mt-2">
+          Guardar
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -35,7 +35,7 @@ function extractError(errorData: any, fallback: string) {
 // Helper genérico para requests com cookies incluídos
 async function request<T>(
   path: string,
-  init: RequestInit & { json?: unknown } = {}
+  init: RequestInit & { json?: unknown } = {},
 ): Promise<T> {
   const { json, headers, ...rest } = init
 
@@ -100,6 +100,7 @@ export async function getCurrentUser(): Promise<ApiUser> {
 export async function updateUser(data: {
   name?: string
   email?: string
+  password?: string // password opcional para permitir alteração
 }): Promise<ApiUser> {
   return request<ApiUser>('/auth/me', { method: 'PUT', json: data })
 }


### PR DESCRIPTION
## Summary
- add sidebar navigation to dashboard
- move personal data form to dedicated page and add account and opportunities sections
- allow password updates via API

## Testing
- `npm run build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c180756e4c832e9afad9e0efda6935