### PR TITLE
Handle expired auth token

### DIFF
--- a/frontend/components/ProtectedClient.tsx
+++ b/frontend/components/ProtectedClient.tsx
@@ -15,18 +15,26 @@ export function ProtectedClient({ children }: Props) {
   const [allowed, setAllowed] = useState(false)
 
   useEffect(() => {
-    // Verifica se existe uma sessão válida no localStorage
-    const session = localStorage.getItem('cm_session')
-    try {
-      const parsed = session ? JSON.parse(session) : null
-      if (parsed && parsed.loggedIn === true) {
-        setAllowed(true)
-      } else {
+    // Função que valida a sessão atual
+    const checkSession = () => {
+      const session = localStorage.getItem('cm_session')
+      try {
+        const parsed = session ? JSON.parse(session) : null
+        if (parsed && parsed.loggedIn === true) {
+          setAllowed(true)
+        } else {
+          router.replace('/entrar')
+        }
+      } catch {
         router.replace('/entrar')
       }
-    } catch {
-      router.replace('/entrar')
     }
+
+    // Verifica sessão inicial
+    checkSession()
+    // Ouve alterações posteriores de sessão
+    window.addEventListener('cm-session', checkSession)
+    return () => window.removeEventListener('cm-session', checkSession)
   }, [router])
 
   // Enquanto não for verificado, não renderiza nada

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -65,8 +65,24 @@ async function request<T>(
     } catch {
       // ignore parsing errors
     }
+    // Se o token estiver ausente ou expirado, remove a sessão local e informa a app
+    if (res.status === 401 && typeof window !== 'undefined') {
+      try {
+        localStorage.removeItem('cm_session')
+      } catch {
+        // ignora falhas ao aceder ao localStorage
+      }
+      // Notifica outros componentes sobre a alteração da sessão
+      window.dispatchEvent(new Event('cm-session'))
+    }
+    // Extrai mensagem de erro devolvida pelo backend
     const msg = extractError(data, `${res.status} ${res.statusText}`)
-    throw new Error(msg)
+    // Para erros de autenticação devolve mensagem amigável
+    throw new Error(
+      res.status === 401
+        ? 'Sessão expirada. Faça login novamente.'
+        : msg,
+    )
   }
 
   // Sucesso: devolve o body como T (JSON na maioria dos casos)


### PR DESCRIPTION
## Summary
- clean up session and notify app when backend returns 401
- listen for session changes in ProtectedClient to redirect on logout/expiry

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c6031ac934832ebe3258905b5719a9