### PR TITLE
fix: enable secure cookies by default for auth

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -43,9 +43,11 @@ router = APIRouter(prefix="/auth", tags=["Auth"])
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # Determina o ambiente em execução.
-# Por omissão assume "dev" para facilitar o desenvolvimento local
-# e evitar cookies "secure" que não funcionam em HTTP.
-ENV = os.getenv("ENV", "dev").lower()  # "dev" | "prod"
+# Por omissão assume "prod" para que os cookies sejam definidos
+# com `SameSite=None` e `Secure`, permitindo sessões entre domínios.
+# Em desenvolvimento local define ENV=dev para voltar a cookies sem
+# a flag `Secure`.
+ENV = os.getenv("ENV", "prod").lower()  # "dev" | "prod"
 IS_DEV = ENV in {"dev", "development", "local"}
 
 SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,9 +21,9 @@ except Exception as e:
 
 # ─────────────────────── CORS / Ambientes ───────────────────────
 # Determina o ambiente atual.
-# Assume "dev" por defeito para que o backend funcione em localhost
-# sem exigir HTTPS ou configuração extra.
-ENV = os.getenv("ENV", "dev").lower()  # "dev" | "prod"
+# Assume "prod" por omissão para permitir cookies seguros entre domínios.
+# Define ENV=dev apenas em desenvolvimento local, onde HTTPS não é usado.
+ENV = os.getenv("ENV", "prod").lower()  # "dev" | "prod"
 IS_DEV = ENV in {"dev", "development", "local"}
 
 # Domínio opcional vindo de ENV (ex.: FRONTEND_URL=https://app.meudominio.com)


### PR DESCRIPTION
## Summary
- default backend environment to production to send secure cookies across domains
- document how to switch to dev mode for local testing

## Testing
- `python -m py_compile backend/auth.py backend/main.py`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c6e31bf980832e9423b95ef54a7fc3