### PR TITLE
Handle expired auth token

### DIFF
--- a/frontend/app/(public)/entrar/page.tsx
+++ b/frontend/app/(public)/entrar/page.tsx
@@ -36,9 +36,12 @@ export default function LoginPage() {
     }
 
     try {
-      await loginUser({ email, password })
-      // Guarda apenas a flag de sessão autenticada
-      localStorage.setItem('cm_session', JSON.stringify({ loggedIn: true }))
+      const res = await loginUser({ email, password })
+      // Guarda token de acesso e flag de sessão autenticada
+      localStorage.setItem(
+        'cm_session',
+        JSON.stringify({ loggedIn: true, token: res.access_token }),
+      )
       // Notifica a aplicação que a sessão foi alterada
       window.dispatchEvent(new Event('cm-session'))
       // Redireciona para o dashboard do aluno

--- a/frontend/components/ProtectedClient.tsx
+++ b/frontend/components/ProtectedClient.tsx
@@ -15,18 +15,26 @@ export function ProtectedClient({ children }: Props) {
   const [allowed, setAllowed] = useState(false)
 
   useEffect(() => {
-    // Verifica se existe uma sessão válida no localStorage
-    const session = localStorage.getItem('cm_session')
-    try {
-      const parsed = session ? JSON.parse(session) : null
-      if (parsed && parsed.loggedIn === true) {
-        setAllowed(true)
-      } else {
+    // Função que valida a sessão atual
+    const checkSession = () => {
+      const session = localStorage.getItem('cm_session')
+      try {
+        const parsed = session ? JSON.parse(session) : null
+        if (parsed && parsed.loggedIn === true) {
+          setAllowed(true)
+        } else {
+          router.replace('/entrar')
+        }
+      } catch {
         router.replace('/entrar')
       }
-    } catch {
-      router.replace('/entrar')
     }
+
+    // Verifica sessão inicial
+    checkSession()
+    // Ouve alterações posteriores de sessão
+    window.addEventListener('cm-session', checkSession)
+    return () => window.removeEventListener('cm-session', checkSession)
   }, [router])
 
   // Enquanto não for verificado, não renderiza nada

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -41,9 +41,27 @@ async function request<T>(
   const { json, headers, ...rest } = init
 
   const withJson = json !== undefined
-  const finalHeaders = withJson
+  // Cabeçalho final que inclui JSON e token de autorização quando disponível
+  const finalHeaders: Record<string, string> = withJson
     ? { 'Content-Type': 'application/json', ...(headers || {}) }
     : { ...(headers || {}) }
+
+  // Procura token de sessão guardado no localStorage
+  let token: string | null = null
+  if (typeof window !== 'undefined') {
+    try {
+      const session = localStorage.getItem('cm_session')
+      const parsed = session ? JSON.parse(session) : null
+      token = parsed?.token ?? null
+    } catch {
+      // ignora erros ao ler/parsing do localStorage
+    }
+  }
+
+  // Se existir token, inclui-o no cabeçalho Authorization
+  if (token) {
+    finalHeaders['Authorization'] = `Bearer ${token}`
+  }
 
   const res = await fetch(`${API_URL}${path}`, {
     credentials: 'include', // 👈 necessário para cookie httponly cross-site
@@ -63,9 +81,24 @@ async function request<T>(
     try {
       data = await parseBody()
     } catch {
-      // ignore parsing errors
+      // ignora falhas ao analisar a resposta
     }
+
+    // Extrai mensagem de erro devolvida pelo backend
     const msg = extractError(data, `${res.status} ${res.statusText}`)
+
+    // Em caso de 401, limpa sessão e notifica a aplicação
+    if (res.status === 401 && typeof window !== 'undefined') {
+      try {
+        localStorage.removeItem('cm_session')
+      } catch {
+        // ignora falhas ao aceder ao localStorage
+      }
+      window.dispatchEvent(new Event('cm-session'))
+      throw new Error('Sessão expirada. Faça login novamente.')
+    }
+
+    // Para outros erros, lança a mensagem obtida
     throw new Error(msg)
   }
 


### PR DESCRIPTION
## Summary
- persist access token and attach Authorization header on API requests
- save access token during login for subsequent authenticated calls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6031ac934832ebe3258905b5719a9