### PR TITLE
fix: enable dev cookies by default

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,7 +1,6 @@
 """Funções e rotas relacionadas com autenticação de utilizadores."""
 
-# Importa módulos padrão de sistema e tempo
-import os
+# Importa módulos padrão de tempo
 from datetime import datetime, timedelta, timezone
 
 # Importa classes e funções do FastAPI para gerir requests e respostas
@@ -36,31 +35,19 @@ from schemas import (
     PaymentStatusUpdate,
 )
 
+# Importa configuração partilhada
+from settings import (
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+    ALGORITHM,
+    IS_DEV,
+    SECRET_KEY,
+)
+
 # ───────────────────────────── Router ─────────────────────────────
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
-# ─────────────── Segurança / Configuração de ambiente ─────────────
+# ─────────────── Segurança / Configuração ─────────────
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-# Determina o ambiente em execução.
-# Por omissão assume "prod" para que os cookies sejam definidos
-# com `SameSite=None` e `Secure`, permitindo sessões entre domínios.
-# Em desenvolvimento local define ENV=dev para voltar a cookies sem
-# a flag `Secure`.
-ENV = os.getenv("ENV", "prod").lower()  # "dev" | "prod"
-IS_DEV = ENV in {"dev", "development", "local"}
-
-SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")
-# Em produção, falhar cedo se não estiver definida
-if (not SECRET_KEY or SECRET_KEY == "CHANGE_ME") and not IS_DEV:
-    raise RuntimeError("SECRET_KEY não definida nas variáveis de ambiente.")
-
-# Em DEV, permite chave fallback explícita (apenas para testes)
-if IS_DEV and (not SECRET_KEY or SECRET_KEY == "CHANGE_ME"):
-    SECRET_KEY = "DEV_ONLY__CHANGE_ME_IN_PROD"
-
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
 
 # Instância do esquema OAuth2 para permitir "Authorize" na documentação
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token", auto_error=False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,4 @@
 """Ponto de entrada principal da API Cliente Mistério."""
-import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +7,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from database import Base, engine, ensure_has_paid_column
 from auth import router as auth_router
 from contact import router as contact_router
+
+# Importa configuração partilhada
+from settings import FRONTEND_URL, IS_DEV
 
 # ───────────────────────────── App ─────────────────────────────
 app = FastAPI(title="Cliente Mistério API")
@@ -20,15 +22,6 @@ except Exception as e:
     print(f"⚠️ Erro ao criar tabelas: {e}")
 
 # ─────────────────────── CORS / Ambientes ───────────────────────
-# Determina o ambiente atual.
-# Assume "prod" por omissão para permitir cookies seguros entre domínios.
-# Define ENV=dev apenas em desenvolvimento local, onde HTTPS não é usado.
-ENV = os.getenv("ENV", "prod").lower()  # "dev" | "prod"
-IS_DEV = ENV in {"dev", "development", "local"}
-
-# Domínio opcional vindo de ENV (ex.: FRONTEND_URL=https://app.meudominio.com)
-FRONTEND_URL = (os.getenv("FRONTEND_URL") or "").strip()
-
 # Lista base de origens permitidas (produção)
 allowed_origins = [
     "https://clientemisterio.com",

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,29 @@
+"""Configuração global da aplicação."""
+
+# Importa o módulo os para ler variáveis de ambiente
+import os
+
+# ────────────────────── Ambiente ──────────────────────
+# Determina o ambiente atual, assumindo "dev" por omissão
+# para facilitar o desenvolvimento local sem HTTPS.
+ENV = os.getenv("ENV", "dev").lower()  # "dev" | "prod"
+IS_DEV = ENV in {"dev", "development", "local"}
+
+# ─────────────────── Segurança / Tokens ───────────────────
+# Chave secreta utilizada para assinar os tokens JWT
+SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")
+# Em produção, falhar cedo se a chave não estiver definida
+if (not SECRET_KEY or SECRET_KEY == "CHANGE_ME") and not IS_DEV:
+    raise RuntimeError("SECRET_KEY não definida nas variáveis de ambiente.")
+# Em desenvolvimento, define uma chave de teste explícita
+if IS_DEV and (not SECRET_KEY or SECRET_KEY == "CHANGE_ME"):
+    SECRET_KEY = "DEV_ONLY__CHANGE_ME_IN_PROD"
+
+# Algoritmo de assinatura JWT
+ALGORITHM = "HS256"
+# Duração do token em minutos
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+
+# ────────────────────── Configuração Web ──────────────────────
+# URL opcional do frontend para CORS
+FRONTEND_URL = (os.getenv("FRONTEND_URL") or "").strip()


### PR DESCRIPTION
## Summary
- centralize environment configuration in new `settings` module with development defaults
- use shared settings in auth and main modules so cookies are non-secure in dev and sessions persist

## Testing
- `python -m py_compile backend/*.py`
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7333da894832e9671fdb7210d4bbc