### PR TITLE
Fix contact form submission by handling empty API responses

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -95,6 +95,15 @@ async function request<T>(
   })
 
   const contentType = res.headers.get('Content-Type') || ''
+
+  // Determina se existe corpo na resposta (evita parse em respostas 204/205/304)
+  const hasBody = ![204, 205, 304].includes(res.status)
+
+  // Respostas sem corpo devolvem undefined para evitar erros de parse
+  if (!hasBody) {
+    return undefined as T
+  }
+
   const parseBody = async () =>
     contentType.includes('application/json') ? res.json() : res.text()
 


### PR DESCRIPTION
## Summary
- avoid parsing response bodies for 204/205/304 statuses in the shared API helper to prevent JSON parsing errors

## Testing
- npm run lint *(fails: missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c841401b20832ea4bffe8738b5a7c7