### PR TITLE
Implement email confirmation and password recovery

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -2,6 +2,8 @@
 
 # Importa módulos padrão de tempo
 from datetime import datetime, timedelta, timezone
+import secrets
+from urllib.parse import urljoin
 
 # Importa classes e funções do FastAPI para gerir requests e respostas
 from fastapi import (
@@ -26,6 +28,7 @@ from fastapi.security import OAuth2PasswordBearer
 
 # Importa utilitários e modelos internos
 from database import SessionLocal
+from email_utils import send_email
 from models import User
 from schemas import (
     UserCreate,
@@ -33,6 +36,9 @@ from schemas import (
     UserLogin,
     UserUpdate,
     PaymentStatusUpdate,
+    PasswordForgotRequest,
+    PasswordResetRequest,
+    AccountConfirmationRequest,
 )
 
 # Importa configuração partilhada
@@ -41,6 +47,7 @@ from settings import (
     ALGORITHM,
     IS_DEV,
     SECRET_KEY,
+    FRONTEND_URL,
 )
 
 # ───────────────────────────── Router ─────────────────────────────
@@ -51,6 +58,51 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # Instância do esquema OAuth2 para permitir "Authorize" na documentação
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token", auto_error=False)
+
+# Tempo padrão de expiração do token de recuperação de password
+PASSWORD_RESET_TOKEN_EXPIRE_MINUTES = 60
+
+# URL base do frontend utilizada para construir links enviados nos e-mails
+_frontend_env = (FRONTEND_URL or "").strip()
+FRONTEND_BASE_URL = _frontend_env.rstrip("/") if _frontend_env else "https://clientemisterio.com"
+
+
+def generate_secure_token() -> str:
+    """Gera um token aleatório seguro para confirmação ou redefinição."""
+    return secrets.token_urlsafe(48)
+
+
+def build_frontend_link(path: str) -> str:
+    """Constrói um link absoluto para o frontend com base no caminho recebido."""
+    return urljoin(f"{FRONTEND_BASE_URL}/", path.lstrip("/"))
+
+
+def send_confirmation_email(user: User) -> None:
+    """Envia o e-mail com o link de confirmação de conta."""
+    confirmation_link = build_frontend_link(f"confirmar-conta/{user.confirmation_token}")
+    subject = "Confirme a sua conta Cliente Mistério"
+    body = (
+        f"Olá {user.name},\n\n"
+        "Obrigado por se registar na plataforma Cliente Mistério. "
+        "Para ativar a sua conta, confirme o endereço de e-mail através do link seguinte:\n\n"
+        f"{confirmation_link}\n\n"
+        "Se não efetuou este registo, ignore esta mensagem."
+    )
+    send_email(subject=subject, body=body, to=user.email)
+
+
+def send_password_reset_email(user: User) -> None:
+    """Envia o e-mail com o link para redefinir a palavra-passe."""
+    reset_link = build_frontend_link(f"entrar/redefinir-password/{user.reset_token}")
+    subject = "Redefinição da palavra-passe Cliente Mistério"
+    body = (
+        f"Olá {user.name},\n\n"
+        "Foi solicitado um pedido para redefinir a palavra-passe da sua conta. "
+        "Caso tenha sido você, utilize o link abaixo nas próximas horas:\n\n"
+        f"{reset_link}\n\n"
+        "Se não reconhece este pedido, ignore este e-mail."
+    )
+    send_email(subject=subject, body=body, to=user.email)
 
 
 class OAuth2EmailRequestForm:
@@ -90,9 +142,11 @@ def get_password_hash(password: str) -> str:
     """Gera o hash para a palavra-passe fornecida."""
     return pwd_context.hash(password)
 
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Compara palavra-passe em texto com o respetivo hash."""
     return pwd_context.verify(plain_password, hashed_password)
+
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
     """Cria um token JWT com dados e tempo de expiração definidos."""
@@ -100,6 +154,7 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None) -> s
     expire = datetime.now(timezone.utc) + (expires_delta or timedelta(minutes=15))
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
 
 def decode_access_token(token: str) -> dict:
     """Decodifica e valida um token JWT retornando o payload."""
@@ -112,11 +167,13 @@ def decode_access_token(token: str) -> dict:
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+
 def extract_bearer(authorization: str | None) -> str | None:
     """Extrai o token do cabeçalho Authorization se for do tipo Bearer."""
     if authorization and authorization.lower().startswith("bearer "):
         return authorization.split(" ", 1)[1].strip()
     return None
+
 
 def set_auth_cookie(response: Response, access_token: str, max_age_seconds: int) -> None:
     """
@@ -134,6 +191,7 @@ def set_auth_cookie(response: Response, access_token: str, max_age_seconds: int)
         path="/",
     )
 
+
 def clear_auth_cookie(response: Response) -> None:
     """Remove o cookie de autenticação do cliente."""
     response.delete_cookie("access_token", path="/")
@@ -148,6 +206,11 @@ def authenticate_credentials(db: Session, email: str, password: str) -> User:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Credenciais inválidas",
             headers={"WWW-Authenticate": "Bearer"},
+        )
+    if not user.is_confirmed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Conta ainda não confirmada. Verifique o e-mail de confirmação.",
         )
     return user
 
@@ -199,6 +262,13 @@ def get_current_user(
             detail="Utilizador não existe",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    if not user.is_confirmed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Conta ainda não confirmada. Verifique o e-mail enviado no registo.",
+        )
+
     return user
 
 # ───────────────────────────── Rotas ──────────────────────────────
@@ -210,6 +280,7 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)):
       - email em lowercase
       - password >= 6 chars
       - email único
+      - envio obrigatório de e-mail de confirmação
     """
     email = user_in.email.strip().lower()
     if db.query(User).filter(User.email == email).first():
@@ -222,11 +293,27 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)):
         name=user_in.name.strip(),
         email=email,
         password_hash=get_password_hash(user_in.password),
+        is_confirmed=False,
+        confirmation_token=generate_secure_token(),
+        confirmation_sent_at=datetime.now(timezone.utc),
     )
     db.add(user)
+
+    try:
+        db.flush()
+        send_confirmation_email(user)
+    except Exception as exc:  # em caso de falha no envio cancela o registo
+        db.rollback()
+        print(f"Erro ao enviar email de confirmação: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Não foi possível enviar o e-mail de confirmação. Tente novamente.",
+        )
+
     db.commit()
     db.refresh(user)
     return user
+
 
 @router.post("/login")
 def login(user_in: UserLogin, response: Response, db: Session = Depends(get_db)):
@@ -251,16 +338,19 @@ def login_token(
 
     return create_login_response(user, response)
 
+
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 def logout(response: Response):
     """Limpa o cookie de sessão (se estiveres a usar cookies)."""
     clear_auth_cookie(response)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
+
 @router.get("/me", response_model=UserRead)
 def me(current_user: User = Depends(get_current_user)):
     """Devolve o utilizador atual (para validar sessão no frontend)."""
     return current_user
+
 
 @router.put("/me", response_model=UserRead)
 def update_me(
@@ -281,11 +371,16 @@ def update_me(
             raise HTTPException(status_code=400, detail="Email já registado")
         current_user.email = email
 
-    # Atualiza a palavra-passe, se fornecida
-    if user_in.password is not None:
-        if len(user_in.password) < 6:
-            raise HTTPException(status_code=400, detail="Password demasiado curta (>= 6)")
-        current_user.password_hash = get_password_hash(user_in.password)
+    # Atualiza a palavra-passe apenas quando o pedido inclui ambos os campos
+    if user_in.new_password is not None:
+        if not user_in.current_password:
+            raise HTTPException(
+                status_code=400,
+                detail="É necessário indicar a password atual para a alterar.",
+            )
+        if not verify_password(user_in.current_password, current_user.password_hash):
+            raise HTTPException(status_code=400, detail="Password atual incorreta")
+        current_user.password_hash = get_password_hash(user_in.new_password)
 
     db.add(current_user)
     db.commit()
@@ -327,6 +422,73 @@ def update_payment_status(
     user.has_paid = payment_in.has_paid
 
     # Guarda a alteração na base de dados
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.post("/password/forgot", status_code=status.HTTP_202_ACCEPTED)
+def request_password_reset(
+    payload: PasswordForgotRequest, db: Session = Depends(get_db)
+) -> dict[str, str]:
+    """Gera um token de redefinição e envia o respetivo e-mail."""
+    email = payload.email.strip().lower()
+    user = db.query(User).filter(User.email == email).first()
+
+    if user and user.is_confirmed:
+        user.reset_token = generate_secure_token()
+        user.reset_token_expires_at = datetime.now(timezone.utc) + timedelta(
+            minutes=PASSWORD_RESET_TOKEN_EXPIRE_MINUTES
+        )
+        db.add(user)
+        db.commit()
+        try:
+            send_password_reset_email(user)
+        except Exception as exc:
+            print(f"Erro ao enviar email de recuperação: {exc}")
+            # Mesmo que o envio falhe, mantém o token para permitir nova tentativa
+
+    # Resposta neutra para evitar divulgar existência da conta
+    return {"message": "Se o email existir, receberá instruções para redefinir a password."}
+
+
+@router.post("/password/reset")
+def reset_password(
+    payload: PasswordResetRequest, db: Session = Depends(get_db)
+) -> dict[str, str]:
+    """Valida o token recebido e atualiza a palavra-passe do utilizador."""
+    user = db.query(User).filter(User.reset_token == payload.token).first()
+    if not user:
+        raise HTTPException(status_code=400, detail="Token inválido")
+
+    if not user.reset_token_expires_at:
+        raise HTTPException(status_code=400, detail="Token inválido")
+
+    if user.reset_token_expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=400, detail="Token expirado")
+
+    user.password_hash = get_password_hash(payload.new_password)
+    user.reset_token = None
+    user.reset_token_expires_at = None
+    db.add(user)
+    db.commit()
+    return {"message": "Password atualizada com sucesso."}
+
+
+@router.post("/confirm", response_model=UserRead)
+def confirm_account(
+    payload: AccountConfirmationRequest, db: Session = Depends(get_db)
+):
+    """Confirma a conta associada ao token enviado por e-mail."""
+    token = payload.token.strip()
+    user = db.query(User).filter(User.confirmation_token == token).first()
+    if not user:
+        raise HTTPException(status_code=400, detail="Token inválido")
+
+    user.is_confirmed = True
+    user.confirmation_token = None
+    user.confirmation_sent_at = None
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/backend/contact.py
+++ b/backend/contact.py
@@ -1,11 +1,8 @@
 """Endpoints relacionados com o formulário de contacto."""
 
-import os
-import smtplib
-from email.message import EmailMessage
-
 from fastapi import APIRouter, HTTPException, status
 
+from email_utils import send_email
 from schemas import ContactMessage
 
 router = APIRouter()
@@ -14,43 +11,27 @@ router = APIRouter()
 SUPPORT_EMAIL = "clientemisterio.suporte@gmail.com"
 
 
-def send_email(message: ContactMessage) -> None:
-    """Envia a mensagem de contacto via SMTP."""
-    host = os.getenv("SMTP_HOST", "smtp.gmail.com")
-    port = int(os.getenv("SMTP_PORT", "587"))
-    user = os.getenv("SMTP_USER")
-    password = os.getenv("SMTP_PASSWORD")
-
+def send_contact_email(message: ContactMessage) -> None:
+    """Envia a mensagem de contacto usando o servidor SMTP configurado."""
     body = (
         f"Nome: {message.name}\n"
         f"Email: {message.email}\n\n"
         f"Mensagem:\n{message.message}"
     )
 
-    if not user or not password:
-        # Caso não existam credenciais, apenas regista a mensagem e não tenta enviar
-        print("SMTP credentials not configured; printing message:")
-        print(body)
-        return
-
-    email_message = EmailMessage()
-    email_message["From"] = user
-    email_message["To"] = SUPPORT_EMAIL
-    email_message["Subject"] = "Nova mensagem de contacto"
-    email_message["Reply-To"] = message.email
-    email_message.set_content(body)
-
-    with smtplib.SMTP(host, port) as smtp:
-        smtp.starttls()
-        smtp.login(user, password)
-        smtp.send_message(email_message)
+    send_email(
+        subject="Nova mensagem de contacto",
+        body=body,
+        to=SUPPORT_EMAIL,
+        reply_to=message.email,
+    )
 
 
 @router.post("/contact", status_code=status.HTTP_204_NO_CONTENT)
 def contact_endpoint(contact: ContactMessage) -> None:
     """Recebe dados do formulário de contacto e envia um e-mail."""
     try:
-        send_email(contact)
+        send_contact_email(contact)
     except Exception as exc:  # Retorna erro genérico em caso de falha
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/database.py
+++ b/backend/database.py
@@ -23,17 +23,55 @@ Base = declarative_base()
 
 
 def ensure_has_paid_column() -> None:
-    """Garante que a coluna "has_paid" existe na tabela de utilizadores."""
+    """Garante que as colunas necessárias existem na tabela de utilizadores."""
 
-    # Inspeciona as colunas actuais da tabela
     inspector = inspect(engine)
+    if not inspector.has_table("users"):
+        return
+
     columns = {col["name"] for col in inspector.get_columns("users")}
 
-    # Se a coluna não existir, adiciona-a com valor padrão
+    statements: list[str] = []
+    added_is_confirmed = False
+
     if "has_paid" not in columns:
+        statements.append(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS has_paid BOOLEAN NOT NULL DEFAULT FALSE"
+        )
+
+    if "is_confirmed" not in columns:
+        statements.append(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_confirmed BOOLEAN NOT NULL DEFAULT TRUE"
+        )
+        added_is_confirmed = True
+
+    if "confirmation_token" not in columns:
+        statements.append(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS confirmation_token TEXT"
+        )
+
+    if "confirmation_sent_at" not in columns:
+        statements.append(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS confirmation_sent_at TIMESTAMPTZ"
+        )
+
+    if "reset_token" not in columns:
+        statements.append(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token TEXT"
+        )
+
+    if "reset_token_expires_at" not in columns:
+        statements.append(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token_expires_at TIMESTAMPTZ"
+        )
+
+    if statements:
         with engine.begin() as connection:  # inicia transacção
+            for statement in statements:
+                connection.execute(text(statement))
+
+    if added_is_confirmed:
+        with engine.begin() as connection:
             connection.execute(
-                text(
-                    "ALTER TABLE users ADD COLUMN IF NOT EXISTS has_paid BOOLEAN NOT NULL DEFAULT FALSE"
-                )
+                text("UPDATE users SET is_confirmed = TRUE WHERE is_confirmed IS NULL")
             )

--- a/backend/email_utils.py
+++ b/backend/email_utils.py
@@ -1,0 +1,58 @@
+"""Ferramentas auxiliares para envio de e-mails via SMTP."""
+
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Iterable
+
+# Lê configurações do servidor SMTP a partir de variáveis de ambiente
+SMTP_HOST = os.getenv("SMTP_HOST", "smtp.gmail.com")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_USER = os.getenv("SMTP_USER")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+
+
+def _normalize_recipients(addresses: str | Iterable[str]) -> list[str]:
+    """Garante que a lista de destinatários está normalizada num array de strings."""
+    if isinstance(addresses, str):
+        return [addresses]
+    return [address for address in addresses if address]
+
+
+def build_email_message(
+    *, subject: str, body: str, to: str | Iterable[str], reply_to: str | None = None
+) -> EmailMessage:
+    """Cria a mensagem de e-mail com cabeçalhos básicos e corpo em texto simples."""
+    recipients = _normalize_recipients(to)
+    if not recipients:
+        raise ValueError("É necessário fornecer pelo menos um destinatário.")
+
+    message = EmailMessage()
+    # Define remetente (usa o utilizador SMTP como origem principal)
+    message["From"] = SMTP_USER or "no-reply@clientemisterio.com"
+    message["To"] = ", ".join(recipients)
+    message["Subject"] = subject
+    if reply_to:
+        message["Reply-To"] = reply_to
+    message.set_content(body)
+    return message
+
+
+def send_email(
+    *, subject: str, body: str, to: str | Iterable[str], reply_to: str | None = None
+) -> None:
+    """Envia um e-mail através do servidor SMTP configurado."""
+    # Se não existirem credenciais configuradas, regista a mensagem e termina.
+    if not SMTP_USER or not SMTP_PASSWORD:
+        print("SMTP credentials not configured; skipping real send.")
+        print(f"Subject: {subject}")
+        print(body)
+        return
+
+    message = build_email_message(subject=subject, body=body, to=to, reply_to=reply_to)
+
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as smtp:
+        # Estabelece ligação segura e autentica com o servidor
+        smtp.starttls()
+        smtp.login(SMTP_USER, SMTP_PASSWORD)
+        smtp.send_message(message)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy import Column, Integer, String, Boolean, DateTime
 
 # ✅ import absoluto (sem o ponto)
 from database import Base
@@ -13,3 +13,8 @@ class User(Base):
     email = Column(String, unique=True, index=True, nullable=False)  # e-mail
     password_hash = Column(String, nullable=False)       # hash da palavra-passe
     has_paid = Column(Boolean, default=False, nullable=False)  # indica se o curso foi pago
+    is_confirmed = Column(Boolean, default=True, nullable=False)  # indica se o e-mail foi confirmado
+    confirmation_token = Column(String, nullable=True)   # token temporário para confirmar conta
+    confirmation_sent_at = Column(DateTime(timezone=True), nullable=True)  # data de envio do e-mail de confirmação
+    reset_token = Column(String, nullable=True)          # token temporário para redefinição da palavra-passe
+    reset_token_expires_at = Column(DateTime(timezone=True), nullable=True)  # expiração do token de redefinição

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -3,6 +3,16 @@
 import re
 from pydantic import BaseModel, field_validator
 
+# Expressão regular partilhada para validação de emails
+EMAIL_PATTERN = re.compile(r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$")
+
+
+def _validate_email(value: str) -> str:
+    """Valida formato básico do e-mail utilizando o padrão partilhado."""
+    if not EMAIL_PATTERN.match(value):
+        raise ValueError("Invalid email format")
+    return value
+
 
 class UserCreate(BaseModel):
     """Dados recebidos aquando do registo de um novo utilizador."""
@@ -15,12 +25,9 @@ class UserCreate(BaseModel):
     password: str
 
     @field_validator("email")
-    def validate_email(cls, v: str) -> str:
+    def validate_email(cls, value: str) -> str:
         """Valida formato básico do e-mail."""
-        pattern = r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$"
-        if not re.match(pattern, v):
-            raise ValueError("Invalid email format")
-        return v
+        return _validate_email(value)
 
 
 class UserRead(BaseModel):
@@ -34,6 +41,8 @@ class UserRead(BaseModel):
     email: str
     # Indica se o utilizador já efetuou o pagamento do curso
     has_paid: bool
+    # Indica se o e-mail do utilizador já foi confirmado
+    is_confirmed: bool
 
     class Config:
         # Permitir conversão a partir de objetos ORM
@@ -49,12 +58,9 @@ class UserLogin(BaseModel):
     password: str
 
     @field_validator("email")
-    def validate_email(cls, v: str) -> str:
+    def validate_email(cls, value: str) -> str:
         """Valida formato básico do e-mail."""
-        pattern = r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$"
-        if not re.match(pattern, v):
-            raise ValueError("Invalid email format")
-        return v
+        return _validate_email(value)
 
 
 class UserUpdate(BaseModel):
@@ -64,27 +70,26 @@ class UserUpdate(BaseModel):
     name: str | None = None
     # Novo e-mail do utilizador (opcional)
     email: str | None = None
-    # Nova palavra-passe do utilizador (opcional)
-    password: str | None = None
+    # Palavra-passe atual necessária para alteração (opcional)
+    current_password: str | None = None
+    # Nova palavra-passe pretendida (opcional)
+    new_password: str | None = None
 
     @field_validator("email")
-    def validate_email(cls, v: str | None) -> str | None:
+    def validate_email(cls, value: str | None) -> str | None:
         """Valida formato básico do e-mail quando fornecido."""
-        if v is None:
-            return v
-        pattern = r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$"
-        if not re.match(pattern, v):
-            raise ValueError("Invalid email format")
-        return v
+        if value is None:
+            return value
+        return _validate_email(value)
 
-    @field_validator("password")
-    def validate_password(cls, v: str | None) -> str | None:
-        """Garante que a password tem pelo menos 6 caracteres."""
-        if v is None:
-            return v
-        if len(v) < 6:
+    @field_validator("new_password")
+    def validate_new_password(cls, value: str | None) -> str | None:
+        """Garante que a nova password tem pelo menos 6 caracteres."""
+        if value is None:
+            return value
+        if len(value) < 6:
             raise ValueError("Password too short (>= 6)")
-        return v
+        return value
 
 
 class PaymentStatusUpdate(BaseModel):
@@ -105,9 +110,55 @@ class ContactMessage(BaseModel):
     message: str
 
     @field_validator("email")
-    def validate_email(cls, v: str) -> str:
+    def validate_email(cls, value: str) -> str:
         """Valida formato básico do e-mail."""
-        pattern = r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$"
-        if not re.match(pattern, v):
-            raise ValueError("Invalid email format")
-        return v
+        return _validate_email(value)
+
+
+class PasswordForgotRequest(BaseModel):
+    """Dados recebidos para iniciar a recuperação da palavra-passe."""
+
+    # Endereço de e-mail associado à conta
+    email: str
+
+    @field_validator("email")
+    def validate_email(cls, value: str) -> str:
+        """Valida formato básico do e-mail."""
+        return _validate_email(value)
+
+
+class PasswordResetRequest(BaseModel):
+    """Dados necessários para concluir a redefinição da palavra-passe."""
+
+    # Token recebido por e-mail
+    token: str
+    # Nova palavra-passe escolhida
+    new_password: str
+
+    @field_validator("token")
+    def validate_token(cls, value: str) -> str:
+        """Garante que o token não vem vazio."""
+        if not value.strip():
+            raise ValueError("Token is required")
+        return value
+
+    @field_validator("new_password")
+    def validate_new_password(cls, value: str) -> str:
+        """Garante que a palavra-passe tem pelo menos 6 caracteres."""
+        if len(value) < 6:
+            raise ValueError("Password too short (>= 6)")
+        return value
+
+
+class AccountConfirmationRequest(BaseModel):
+    """Dados necessários para confirmar uma conta recém-criada."""
+
+    # Token de confirmação recebido no e-mail
+    token: str
+
+    @field_validator("token")
+    def validate_token(cls, value: str) -> str:
+        """Garante que o token não vem vazio."""
+        if not value.strip():
+            raise ValueError("Token is required")
+        return value

--- a/frontend/app/(private)/dashboard/personal/page.tsx
+++ b/frontend/app/(private)/dashboard/personal/page.tsx
@@ -5,12 +5,15 @@ import { useEffect, useState } from 'react'
 import { getCurrentUser, updateUser } from '@/lib/api'
 import PasswordInput from '@/components/PasswordInput'
 
+type Feedback = { text: string; tone: 'success' | 'error' } | null
+
 export default function PersonalPage() {
-  // Estados para armazenar nome, email, password e mensagens de feedback
+  // Estados para armazenar nome, email, passwords e mensagens de feedback
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [message, setMessage] = useState('')
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [feedback, setFeedback] = useState<Feedback>(null)
 
   // Ao carregar a página, obtém os dados atuais do utilizador
   useEffect(() => {
@@ -21,28 +24,53 @@ export default function PersonalPage() {
       })
       .catch((err: unknown) => {
         // Mostra mensagem de erro sem redirecionar o utilizador
-        if (err instanceof Error) setMessage(err.message)
-        else setMessage('Erro ao obter dados do utilizador.')
+        if (err instanceof Error)
+          setFeedback({ text: err.message, tone: 'error' })
+        else setFeedback({ text: 'Erro ao obter dados do utilizador.', tone: 'error' })
       })
   }, [])
 
   // Envia as alterações para a API
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault()
-    setMessage('')
+    setFeedback(null)
+
     try {
-      // Prepara os dados a enviar (apenas nome e password)
-      const data: { name: string; password?: string } = { name }
-      if (password) data.password = password
+      const data: {
+        name: string
+        currentPassword?: string
+        newPassword?: string
+      } = { name }
+
+      const wantsPasswordChange = currentPassword || newPassword
+
+      if (wantsPasswordChange) {
+        if (!currentPassword || !newPassword) {
+          setFeedback({
+            text: 'Para alterar a password indique a atual e a nova password.',
+            tone: 'error',
+          })
+          return
+        }
+        if (newPassword.length < 6) {
+          setFeedback({ text: 'A nova password deve ter pelo menos 6 caracteres.', tone: 'error' })
+          return
+        }
+        data.currentPassword = currentPassword
+        data.newPassword = newPassword
+      }
+
       const updated = await updateUser(data)
       // Atualiza os estados com os dados devolvidos pela base de dados
       setName(updated.name)
       setEmail(updated.email)
-      setMessage('Dados atualizados com sucesso.')
-      setPassword('')
+      setFeedback({ text: 'Dados atualizados com sucesso.', tone: 'success' })
+      setCurrentPassword('')
+      setNewPassword('')
     } catch (err: unknown) {
-      if (err instanceof Error) setMessage(err.message)
-      else setMessage('Erro ao atualizar dados.')
+      if (err instanceof Error)
+        setFeedback({ text: err.message, tone: 'error' })
+      else setFeedback({ text: 'Erro ao atualizar dados.', tone: 'error' })
     }
   }
 
@@ -73,14 +101,30 @@ export default function PersonalPage() {
           />
         </div>
         <div className="relative">
-          <label className="block text-sm font-medium text-white">Password</label>
+          <label className="block text-sm font-medium text-white">Password atual</label>
           <PasswordInput
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
             className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
           />
         </div>
-        {message && <p className="text-sm text-red-600">{message}</p>}
+        <div className="relative">
+          <label className="block text-sm font-medium text-white">Nova password</label>
+          <PasswordInput
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            className="mt-1 w-full rounded border border-white bg-black p-2 text-white"
+          />
+        </div>
+        {feedback && (
+          <p
+            className={`text-sm ${
+              feedback.tone === 'success' ? 'text-green-500' : 'text-red-600'
+            }`}
+          >
+            {feedback.text}
+          </p>
+        )}
         <button type="submit" className="btn mt-2">
           Guardar
         </button>

--- a/frontend/app/(public)/confirmar-conta/[token]/page.tsx
+++ b/frontend/app/(public)/confirmar-conta/[token]/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+// Página que confirma a conta usando o token enviado por email
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { confirmAccount } from '@/lib/api'
+
+type Status = 'loading' | 'success' | 'error'
+
+export default function ConfirmAccountPage({ params }: { params: { token: string } }) {
+  // Estado para controlar a mensagem apresentada ao utilizador
+  const [status, setStatus] = useState<Status>('loading')
+  const [message, setMessage] = useState('A confirmar conta...')
+
+  // Ao montar o componente tenta confirmar a conta
+  useEffect(() => {
+    confirmAccount(params.token)
+      .then((user) => {
+        setStatus('success')
+        setMessage(
+          `Conta confirmada com sucesso para ${user.name}. Já pode iniciar sessão na plataforma.`,
+        )
+      })
+      .catch((err: unknown) => {
+        setStatus('error')
+        if (err instanceof Error) setMessage(err.message)
+        else setMessage('Não foi possível confirmar a conta.')
+      })
+  }, [params.token])
+
+  return (
+    <section className="flex min-h-screen flex-col items-center justify-center space-y-6 pb-20 text-center">
+      <h1 className="text-2xl font-bold">Confirmação de conta</h1>
+      <p className={`max-w-md ${status === 'error' ? 'text-red-600' : 'text-green-500'}`}>{message}</p>
+      <Link href="/entrar" className="btn">
+        Ir para login
+      </Link>
+    </section>
+  )
+}

--- a/frontend/app/(public)/entrar/esqueci-password/page.tsx
+++ b/frontend/app/(public)/entrar/esqueci-password/page.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+// Página para solicitar recuperação de password
+import Link from 'next/link'
+import { useState } from 'react'
+import { requestPasswordReset } from '@/lib/api'
+
+export default function ForgotPasswordPage() {
+  // Estados para controlar email e mensagem de feedback
+  const [email, setEmail] = useState('')
+  const [feedback, setFeedback] = useState<{ text: string; tone: 'success' | 'error' } | null>(
+    null,
+  )
+  const [submitting, setSubmitting] = useState(false)
+
+  // Submete pedido de recuperação para a API
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setFeedback(null)
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      setFeedback({ text: 'Introduza um email válido.', tone: 'error' })
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const response = await requestPasswordReset({ email })
+      setFeedback({ text: response.message, tone: 'success' })
+      setEmail('')
+    } catch (err: unknown) {
+      if (err instanceof Error) setFeedback({ text: err.message, tone: 'error' })
+      else setFeedback({ text: 'Erro ao solicitar recuperação.', tone: 'error' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="flex min-h-screen items-center justify-center pb-20">
+      <form onSubmit={handleSubmit} className="form-control">
+        {/* Título do formulário */}
+        <p className="title">Recuperar password</p>
+
+        {/* Campo do email */}
+        <div className="input-field">
+          <input
+            type="email"
+            className="input"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder=" "
+            required
+          />
+          <label className="label">Email</label>
+        </div>
+
+        {/* Mensagem de feedback */}
+        {feedback && (
+          <p
+            className={`text-sm ${
+              feedback.tone === 'success' ? 'text-green-500' : 'text-red-600'
+            }`}
+          >
+            {feedback.text}
+          </p>
+        )}
+
+        {/* Botão de envio */}
+        <button type="submit" className="btn mt-8 self-center" disabled={submitting}>
+          {submitting ? 'A enviar...' : 'Enviar instruções'}
+        </button>
+
+        <div className="mt-4 text-center text-sm text-white">
+          <Link href="/entrar" className="hover:underline">
+            Voltar ao login
+          </Link>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/frontend/app/(public)/entrar/page.tsx
+++ b/frontend/app/(public)/entrar/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 // Página de login para alunos com formulário formatado
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { loginUser } from '@/lib/api'
@@ -90,6 +91,13 @@ export default function LoginPage() {
         {/* Mensagem de erro, se existir */}
         {error && <p className="text-sm text-red-600">{error}</p>}
 
+        <div className="mt-4 text-sm text-white">
+          {/* Link para recuperação de password */}
+          <Link href="/entrar/esqueci-password" className="hover:underline">
+            Esqueci-me da password
+          </Link>
+        </div>
+
         {/* Botão de submissão centrado dentro do formulário */}
         <button type="submit" className="btn mt-8 self-center">
           Entrar
@@ -98,4 +106,3 @@ export default function LoginPage() {
     </section>
   )
 }
-

--- a/frontend/app/(public)/entrar/redefinir-password/[token]/page.tsx
+++ b/frontend/app/(public)/entrar/redefinir-password/[token]/page.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+// Página para definir nova password a partir do token enviado por email
+import Link from 'next/link'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import PasswordInput from '@/components/PasswordInput'
+import { resetPassword } from '@/lib/api'
+
+export default function ResetPasswordPage({ params }: { params: { token: string } }) {
+  // Estados para controlar password, feedback e carregamento
+  const [newPassword, setNewPassword] = useState('')
+  const [feedback, setFeedback] = useState<{ text: string; tone: 'success' | 'error' } | null>(
+    null,
+  )
+  const [submitting, setSubmitting] = useState(false)
+  const router = useRouter()
+
+  // Submete nova password para a API
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setFeedback(null)
+
+    if (newPassword.length < 6) {
+      setFeedback({ text: 'A password deve ter pelo menos 6 caracteres.', tone: 'error' })
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const response = await resetPassword({ token: params.token, newPassword })
+      setFeedback({ text: response.message, tone: 'success' })
+      setNewPassword('')
+      // Após alguns segundos redireciona para o login
+      setTimeout(() => router.push('/entrar'), 1500)
+    } catch (err: unknown) {
+      if (err instanceof Error) setFeedback({ text: err.message, tone: 'error' })
+      else setFeedback({ text: 'Erro ao redefinir password.', tone: 'error' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="flex min-h-screen items-center justify-center pb-20">
+      <form onSubmit={handleSubmit} className="form-control">
+        {/* Título da página */}
+        <p className="title">Definir nova password</p>
+
+        {/* Campo da nova password */}
+        <div className="input-field">
+          <PasswordInput
+            className="input"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder=" "
+            required
+          />
+          <label className="label">Nova password</label>
+        </div>
+
+        {/* Mensagem de feedback */}
+        {feedback && (
+          <p
+            className={`text-sm ${
+              feedback.tone === 'success' ? 'text-green-500' : 'text-red-600'
+            }`}
+          >
+            {feedback.text}
+          </p>
+        )}
+
+        {/* Botão de submissão */}
+        <button type="submit" className="btn mt-8 self-center" disabled={submitting}>
+          {submitting ? 'A atualizar...' : 'Guardar nova password'}
+        </button>
+
+        <div className="mt-4 text-center text-sm text-white">
+          <Link href="/entrar" className="hover:underline">
+            Voltar ao login
+          </Link>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/frontend/app/(public)/inscrever-se/page.tsx
+++ b/frontend/app/(public)/inscrever-se/page.tsx
@@ -11,15 +11,17 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
 
   // Função chamada ao submeter o formulário
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
     setError('')
+    setSuccess('')
 
     try {
       await registerUser({ name, email, password })
-      alert(`Conta criada para ${name} (${email})`)
+      setSuccess('Conta criada. Verifique o e-mail para confirmar a conta antes de iniciar sessão.')
       setName('')
       setEmail('')
       setPassword('')
@@ -75,8 +77,9 @@ export default function RegisterPage() {
           <label className="label">Palavra-passe</label>
         </div>
 
-        {/* Mensagem de erro, se existir */}
+        {/* Mensagens de feedback */}
         {error && <p className="text-sm text-red-600">{error}</p>}
+        {success && <p className="text-sm text-green-500">{success}</p>}
 
         {/* Botão de submissão centrado dentro do formulário */}
         <button type="submit" className="btn mt-8 self-center">
@@ -86,4 +89,3 @@ export default function RegisterPage() {
     </section>
   )
 }
-

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -13,6 +13,7 @@ export type ApiUser = {
   name: string
   email: string
   has_paid: boolean
+  is_confirmed: boolean
   created_at?: string
   updated_at?: string
 }
@@ -115,7 +116,6 @@ async function request<T>(
       // ignora falhas ao analisar a resposta
     }
 
-
     // Extrai mensagem de erro devolvida pelo backend
     const msg = extractError(data, `${res.status} ${res.statusText}`)
 
@@ -168,9 +168,17 @@ export async function getCurrentUser(): Promise<ApiUser> {
 export async function updateUser(data: {
   name?: string
   email?: string
-  password?: string // password opcional para permitir alteração
+  currentPassword?: string
+  newPassword?: string
 }): Promise<ApiUser> {
-  return request<ApiUser>('/auth/me', { method: 'PUT', json: data })
+  // Converte as chaves opcionais para o formato esperado pelo backend
+  const payload: Record<string, unknown> = {}
+  if (data.name !== undefined) payload.name = data.name
+  if (data.email !== undefined) payload.email = data.email
+  if (data.currentPassword !== undefined) payload.current_password = data.currentPassword
+  if (data.newPassword !== undefined) payload.new_password = data.newPassword
+
+  return request<ApiUser>('/auth/me', { method: 'PUT', json: payload })
 }
 
 // Atualiza o estado de pagamento do utilizador autenticado
@@ -178,6 +186,23 @@ export async function updatePaymentStatus(data: {
   has_paid: boolean
 }): Promise<ApiUser> {
   return request<ApiUser>('/auth/me/payment', { method: 'PUT', json: data })
+}
+
+export async function requestPasswordReset(data: { email: string }): Promise<{ message: string }> {
+  return request<{ message: string }>('/auth/password/forgot', { json: data })
+}
+
+export async function resetPassword(data: {
+  token: string
+  newPassword: string
+}): Promise<{ message: string }> {
+  return request<{ message: string }>('/auth/password/reset', {
+    json: { token: data.token, new_password: data.newPassword },
+  })
+}
+
+export async function confirmAccount(token: string): Promise<ApiUser> {
+  return request<ApiUser>('/auth/confirm', { json: { token } })
 }
 
 // ────────────────────────── Contact Endpoint ─────────────────────────

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## Summary
- add reusable SMTP helper and extend authentication to require email confirmation, send confirmation emails, and support password reset tokens
- require the current password when updating credentials and expose reset/confirm endpoints through the frontend API
- add public pages for forgotten password, password reset, and account confirmation plus update login and registration messaging

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c84efb5904832e84bbd4a7834ad398