### PR TITLE
Add admin management endpoints for account deletion

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -1,0 +1,125 @@
+"""Rotas administrativas para gerir pedidos sensíveis do Cliente Mistério."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from auth import get_db, get_current_admin, delete_user_account
+from models import AccountDeletionRequest, User
+from schemas import (
+    AccountDeletionRequestRead,
+    AccountDeletionRequestAdminUpdate,
+    ACCOUNT_DELETION_ALLOWED_STATUSES,
+)
+
+# Conjunto de estados finais onde o pedido deixa de estar ativo
+FINAL_DELETION_STATUSES = {"completed", "rejected"}
+# Conjunto de estados ativos (com o pedido ainda em tratamento)
+ACTIVE_DELETION_STATUSES = ACCOUNT_DELETION_ALLOWED_STATUSES - FINAL_DELETION_STATUSES
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+@router.get("/deletion-requests", response_model=list[AccountDeletionRequestRead])
+def list_deletion_requests(
+    status_filter: str | None = Query(
+        default=None,
+        alias="status",
+        description="Filtra os pedidos pelo estado atual.",
+    ),
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin),
+) -> list[AccountDeletionRequestRead]:
+    """Lista pedidos de eliminação ordenados do mais recente para o mais antigo."""
+
+    # Dependência acima garante que apenas administradores acedem a esta rota
+    _ = current_admin
+
+    query = db.query(AccountDeletionRequest).order_by(AccountDeletionRequest.created_at.desc())
+
+    if status_filter:
+        if status_filter not in ACCOUNT_DELETION_ALLOWED_STATUSES:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Estado inválido")
+        query = query.filter(AccountDeletionRequest.status == status_filter)
+
+    return query.all()
+
+
+@router.get("/deletion-requests/{request_id}", response_model=AccountDeletionRequestRead)
+def get_deletion_request(
+    request_id: int,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin),
+) -> AccountDeletionRequestRead:
+    """Devolve os detalhes de um pedido de eliminação específico."""
+
+    # Dependência garante acesso apenas a administradores
+    _ = current_admin
+
+    deletion_request = db.get(AccountDeletionRequest, request_id)
+    if not deletion_request:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Pedido não encontrado")
+
+    return deletion_request
+
+
+@router.put("/deletion-requests/{request_id}", response_model=AccountDeletionRequestRead)
+def update_deletion_request(
+    request_id: int,
+    payload: AccountDeletionRequestAdminUpdate,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin),
+) -> AccountDeletionRequestRead:
+    """Atualiza estado, notas e, opcionalmente, elimina a conta associada."""
+
+    deletion_request = db.get(AccountDeletionRequest, request_id)
+    if not deletion_request:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Pedido não encontrado")
+
+    now = datetime.now(timezone.utc)
+
+    # Atualiza notas quando fornecidas
+    if payload.admin_notes is not None:
+        cleaned_notes = payload.admin_notes.strip()
+        deletion_request.admin_notes = cleaned_notes or None
+
+    desired_status = payload.status
+
+    if payload.delete_user:
+        if payload.status is not None and payload.status != "completed":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Para eliminar a conta defina o estado como 'completed'.",
+            )
+        if deletion_request.user_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="A conta associada a este pedido já foi removida.",
+            )
+        # Elimina a conta do utilizador na mesma transação
+        delete_user_account(db, deletion_request.user_id, commit=False)
+        desired_status = "completed"
+        deletion_request.processed_at = now
+        deletion_request.processed_by_user_id = current_admin.id
+
+    if desired_status is not None:
+        if desired_status not in ACCOUNT_DELETION_ALLOWED_STATUSES:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Estado inválido")
+
+        deletion_request.status = desired_status
+
+        if desired_status in FINAL_DELETION_STATUSES:
+            # Marca o pedido como concluído e regista quem tratou
+            deletion_request.processed_at = now
+            deletion_request.processed_by_user_id = current_admin.id
+        elif desired_status in ACTIVE_DELETION_STATUSES:
+            # Reabre o pedido retirando informação de processamento
+            deletion_request.processed_at = None
+            deletion_request.processed_by_user_id = None
+
+    db.add(deletion_request)
+    db.commit()
+    db.refresh(deletion_request)
+
+    return deletion_request

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -29,7 +29,7 @@ from fastapi.security import OAuth2PasswordBearer
 # Importa utilitários e modelos internos
 from database import SessionLocal
 from email_utils import send_email
-from models import User
+from models import User, AccountDeletionRequest
 from schemas import (
     UserCreate,
     UserRead,
@@ -39,6 +39,7 @@ from schemas import (
     PasswordForgotRequest,
     PasswordResetRequest,
     AccountConfirmationRequest,
+    ACCOUNT_DELETION_ALLOWED_STATUSES,
 )
 
 # Importa configuração partilhada
@@ -64,6 +65,9 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token", auto_error=False)
 
 # Tempo padrão de expiração do token de recuperação de password
 PASSWORD_RESET_TOKEN_EXPIRE_MINUTES = 60
+
+# Conjunto de estados ativos que impedem novos pedidos de eliminação
+ACTIVE_DELETION_STATUSES = ACCOUNT_DELETION_ALLOWED_STATUSES.intersection({"pending", "in_progress"})
 
 # URL base do frontend utilizada para construir links enviados nos e-mails
 _frontend_env = (FRONTEND_URL or "").strip()
@@ -217,7 +221,7 @@ def clear_auth_cookie(response: Response) -> None:
     response.delete_cookie("access_token", path="/")
 
 
-def delete_user_account(db: Session, user: User | int) -> None:
+def delete_user_account(db: Session, user: User | int, *, commit: bool = True) -> None:
     """Remove definitivamente a conta do utilizador e confirma a operação na base de dados."""
 
     # Aceita o objeto completo ou apenas o identificador numérico
@@ -226,8 +230,18 @@ def delete_user_account(db: Session, user: User | int) -> None:
     if not instance:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilizador não encontrado")
 
+    # Desassocia pedidos de eliminação para manter o histórico após remover a conta
+    db.query(AccountDeletionRequest).filter(AccountDeletionRequest.user_id == instance.id).update(
+        {"user_id": None},
+        synchronize_session=False,
+    )
+
     db.delete(instance)
-    db.commit()
+
+    if commit:
+        db.commit()
+    else:
+        db.flush()
 
 
 def authenticate_credentials(db: Session, email: str, password: str) -> User:
@@ -303,6 +317,16 @@ def get_current_user(
         )
 
     return user
+
+
+def get_current_admin(current_user: User = Depends(get_current_user)) -> User:
+    """Garante que o utilizador autenticado tem privilégios de administrador."""
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Acesso reservado a administradores",
+        )
+    return current_user
 
 # ───────────────────────────── Rotas ──────────────────────────────
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
@@ -439,19 +463,50 @@ def update_my_payment_status(
 
 
 @router.post("/me/delete-request", status_code=status.HTTP_202_ACCEPTED)
-def request_account_deletion(current_user: User = Depends(get_current_user)) -> dict[str, str]:
-    """Envia um e-mail ao suporte a informar que o utilizador pediu eliminar a conta."""
+def request_account_deletion(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict[str, str]:
+    """Regista o pedido de eliminação de conta e notifica o suporte."""
+
+    # Verifica se o utilizador já tem um pedido ativo
+    existing_request = (
+        db.query(AccountDeletionRequest)
+        .filter(
+            AccountDeletionRequest.user_id == current_user.id,
+            AccountDeletionRequest.status.in_(ACTIVE_DELETION_STATUSES),
+        )
+        .first()
+    )
+    if existing_request:
+        return {
+            "message": "Já existe um pedido de eliminação em análise. Receberá novidades em breve."
+        }
+
+    deletion_request = AccountDeletionRequest(
+        user_id=current_user.id,
+        user_id_snapshot=current_user.id,
+        user_name_snapshot=current_user.name.strip(),
+        user_email_snapshot=current_user.email.strip(),
+    )
+    db.add(deletion_request)
 
     try:
+        db.flush()
         send_account_deletion_request_email(current_user)
     except Exception as exc:
+        db.rollback()
         print(f"Erro ao enviar email de eliminação: {exc}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Não foi possível enviar o pedido de eliminação. Tente novamente mais tarde.",
         ) from exc
 
+    db.commit()
+    db.refresh(deletion_request)
+
     return {"message": "Pedido de eliminação registado. Entraremos em contacto em breve."}
+
 
 
 @router.put("/users/{user_id}/payment", response_model=UserRead)

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,5 +1,3 @@
-"""Conexão e ferramentas de sessão para a base de dados PostgreSQL."""
-
 import os
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import sessionmaker, declarative_base
@@ -63,6 +61,11 @@ def ensure_has_paid_column() -> None:
     if "reset_token_expires_at" not in columns:
         statements.append(
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token_expires_at TIMESTAMPTZ"
+        )
+
+    if "is_admin" not in columns:
+        statements.append(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE"
         )
 
     if statements:

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from database import Base, engine, ensure_has_paid_column
 from auth import router as auth_router
 from contact import router as contact_router
+from admin import router as admin_router
 
 # Importa configuração partilhada
 from settings import FRONTEND_URL, IS_DEV
@@ -17,7 +18,7 @@ app = FastAPI(title="Cliente Mistério API")
 # (temporário até usares Alembic) criar tabelas no arranque
 try:
     Base.metadata.create_all(bind=engine)  # cria tabelas se não existirem
-    ensure_has_paid_column()  # garante a coluna has_paid
+    ensure_has_paid_column()  # garante colunas adicionais em falta
 except Exception as e:
     print(f"⚠️ Erro ao criar tabelas: {e}")
 
@@ -66,6 +67,10 @@ def health():
 # ─────────────────────── Rotas de autenticação ───────────────────────
 # O router já tem prefixo "/auth" no próprio ficheiro; não repetir aqui.
 app.include_router(auth_router, tags=["Auth"])
+
+# ─────────────────────── Rotas administrativas ───────────────────────
+# Permite gerir pedidos internos como pedidos de eliminação de conta
+app.include_router(admin_router, tags=["Admin"])
 
 # ───────────────────────── Rotas de contacto ─────────────────────────
 # Lida com mensagens enviadas através do formulário de contacto

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,8 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from datetime import datetime, timezone
 
-# ✅ import absoluto (sem o ponto)
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, Text
+from sqlalchemy.orm import relationship
+
 from database import Base
 
 
@@ -18,3 +20,40 @@ class User(Base):
     confirmation_sent_at = Column(DateTime(timezone=True), nullable=True)  # data de envio do e-mail de confirmação
     reset_token = Column(String, nullable=True)          # token temporário para redefinição da palavra-passe
     reset_token_expires_at = Column(DateTime(timezone=True), nullable=True)  # expiração do token de redefinição
+    is_admin = Column(Boolean, default=False, nullable=False)  # indica se o utilizador é administrador
+
+    # Relacionamento com pedidos de eliminação efetuados pelo utilizador (sem eliminar registos históricos)
+    deletion_requests = relationship(
+        "AccountDeletionRequest",
+        back_populates="user",
+        passive_deletes=True,
+    )
+
+
+# Modelo que guarda pedidos de eliminação de conta
+class AccountDeletionRequest(Base):
+    __tablename__ = "account_deletion_requests"
+
+    id = Column(Integer, primary_key=True, index=True)  # identificador único do pedido
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)  # FK (pode ficar a NULL após eliminação)
+    user_id_snapshot = Column(Integer, nullable=False)  # identificador do utilizador no momento do pedido
+    user_name_snapshot = Column(String, nullable=False)  # nome registado no momento do pedido
+    user_email_snapshot = Column(String, nullable=False)  # e-mail registado no momento do pedido
+    status = Column(String, nullable=False, default="pending")  # estado atual do pedido
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )  # instante em que o pedido foi criado
+    processed_at = Column(DateTime(timezone=True), nullable=True)  # instante em que o pedido foi tratado
+    processed_by_user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )  # administrador responsável
+    admin_notes = Column(Text, nullable=True)  # notas internas sobre o pedido
+
+    # Relacionamento com o utilizador que fez o pedido
+    user = relationship("User", back_populates="deletion_requests", foreign_keys=[user_id])
+    # Relacionamento com o administrador que tratou o pedido
+    processed_by = relationship("User", foreign_keys=[processed_by_user_id])

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,10 +1,13 @@
-"""Esquemas Pydantic usados para validação de dados."""
-
 import re
+from datetime import datetime
+
 from pydantic import BaseModel, field_validator
 
 # Expressão regular partilhada para validação de emails
 EMAIL_PATTERN = re.compile(r"^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$")
+
+# Conjunto de estados válidos para os pedidos de eliminação de conta
+ACCOUNT_DELETION_ALLOWED_STATUSES = {"pending", "in_progress", "completed", "rejected"}
 
 
 def _validate_email(value: str) -> str:
@@ -43,6 +46,8 @@ class UserRead(BaseModel):
     has_paid: bool
     # Indica se o e-mail do utilizador já foi confirmado
     is_confirmed: bool
+    # Indica se o utilizador tem privilégios administrativos
+    is_admin: bool
 
     class Config:
         # Permitir conversão a partir de objetos ORM
@@ -161,4 +166,53 @@ class AccountConfirmationRequest(BaseModel):
         """Garante que o token não vem vazio."""
         if not value.strip():
             raise ValueError("Token is required")
+        return value
+
+
+class AccountDeletionRequestRead(BaseModel):
+    """Representação dos pedidos de eliminação de conta para o painel administrativo."""
+
+    # Identificador interno do pedido
+    id: int
+    # Identificador do utilizador associado (None se a conta já foi removida)
+    user_id: int | None
+    # Identificador original do utilizador guardado para auditoria
+    user_id_snapshot: int
+    # Nome registado no momento do pedido
+    user_name_snapshot: str
+    # E-mail registado no momento do pedido
+    user_email_snapshot: str
+    # Estado atual do pedido
+    status: str
+    # Instante de criação do pedido
+    created_at: datetime
+    # Instante em que o pedido foi processado (quando aplicável)
+    processed_at: datetime | None
+    # Identificador do administrador que tratou o pedido
+    processed_by_user_id: int | None
+    # Notas internas associadas ao pedido
+    admin_notes: str | None
+
+    class Config:
+        # Permitir conversão a partir de objetos ORM
+        from_attributes = True
+
+
+class AccountDeletionRequestAdminUpdate(BaseModel):
+    """Dados enviados pelo administrador para atualizar um pedido de eliminação."""
+
+    # Novo estado pretendido (opcional)
+    status: str | None = None
+    # Notas a registar (opcional)
+    admin_notes: str | None = None
+    # Indica se o utilizador deve ser eliminado imediatamente
+    delete_user: bool = False
+
+    @field_validator("status")
+    def validate_status(cls, value: str | None) -> str | None:
+        """Garante que o estado fornecido pertence à lista permitida."""
+        if value is None:
+            return value
+        if value not in ACCOUNT_DELETION_ALLOWED_STATUSES:
+            raise ValueError("Invalid status")
         return value


### PR DESCRIPTION
## Summary
- criar modelo `AccountDeletionRequest` e coluna `is_admin` para suportar gestão administrativa
- registar pedidos de eliminação quando o utilizador os solicita e impedir duplicados enquanto estiverem ativos
- expor rotas `/admin/deletion-requests` para listar, consultar e atualizar pedidos (incluindo eliminação da conta)

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c92893c2b0832eb2db5af42039bbc2