### PR TITLE
Remove health check endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -53,15 +53,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# ─────────────────────────── Health ───────────────────────────
+# ──────────── Rota principal para verificação rápida ────────────
 @app.get("/")
 def read_root():
     return {"message": "API is running"}
-
-@app.get("/health")
-def health():
-    """Endpoint para verificação de vida utilizado pelo Render."""
-    return {"ok": True}
 
 # ─────────────────────── Rotas de autenticação ───────────────────────
 # O router já tem prefixo "/auth" no próprio ficheiro; não repetir aqui.


### PR DESCRIPTION
## Summary
- remove the deprecated `/health` endpoint from the FastAPI application
- retain only the root endpoint for simple availability checks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c939476f84832eaa066d04d26006e3