### PR TITLE
Allow Vercel production domain through CORS

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,8 @@ except Exception as e:
 allowed_origins = [
     "https://clientemisterio.com",
     "https://www.clientemisterio.com",
+    # Domínio de produção alojado no Vercel
+    "https://clientemisterio.vercel.app",
     # Domínio legado alojado no Render (mantido para compatibilidade)
     "https://clientemisterio-frontend.onrender.com",
 ]


### PR DESCRIPTION
## Summary
- add the public Vercel deployment domain to the default list of allowed CORS origins so production logins succeed from clientemisterio.vercel.app

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c93e1c8428832eb1f4fcee030407ea