### PR TITLE
Add rotating animation to home page feature icons

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -144,11 +144,11 @@ export default function HomePage() {
             key={index}
             className="mx-auto flex w-full flex-col items-center rounded-lg bg-white/40 p-6 text-center"
           >
-            {/* Símbolo representativo da característica */}
+            {/* Símbolo representativo da característica com animação cíclica */}
             <feature.Icon
               role="img"
               aria-label={feature.label}
-              className="mb-4 h-12 w-12 text-white"
+              className="feature-icon mb-4 h-12 w-12 text-white"
             />
             {/* Texto descritivo da característica */}
             <p className="text-base font-bold">{feature.text}</p>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -186,3 +186,19 @@ p {
   padding-right: 5px;
 }
 
+/* Animação suave que roda os ícones informativos a cada 3 segundos */
+@keyframes feature-icon-rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/* Classe aplicada aos ícones para executar a animação de rotação contínua */
+.feature-icon {
+  animation: feature-icon-rotation 3s linear infinite;
+  will-change: transform;
+}
+


### PR DESCRIPTION
## Summary
- add a reusable CSS animation that rotates the feature icons every three seconds
- apply the rotating class to the home page informational icons with updated comments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca71b042c4832e8319f7682d4790fe