### PR TITLE
Add vibrating animation to home page feature icons

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -144,11 +144,11 @@ export default function HomePage() {
             key={index}
             className="mx-auto flex w-full flex-col items-center rounded-lg bg-white/40 p-6 text-center"
           >
-            {/* Símbolo representativo da característica */}
+            {/* Símbolo representativo da característica com animação de vibração */}
             <feature.Icon
               role="img"
               aria-label={feature.label}
-              className="mb-4 h-12 w-12 text-white"
+              className="feature-icon mb-4 h-12 w-12 text-white"
             />
             {/* Texto descritivo da característica */}
             <p className="text-base font-bold">{feature.text}</p>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -186,3 +186,32 @@ p {
   padding-right: 5px;
 }
 
+/* Animação suave que faz os ícones informativos vibrarem sem rodar */
+@keyframes feature-icon-vibration {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  20% {
+    transform: translate3d(-2px, 1px, 0) scale(1.02);
+  }
+  40% {
+    transform: translate3d(2px, -1px, 0) scale(1);
+  }
+  60% {
+    transform: translate3d(-1px, 0, 0) scale(0.98);
+  }
+  80% {
+    transform: translate3d(1px, -1px, 0) scale(1.01);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+/* Classe aplicada aos ícones para executar a animação de vibração contínua */
+.feature-icon {
+  animation: feature-icon-vibration 1.5s ease-in-out infinite;
+  transform-origin: center;
+  will-change: transform;
+}
+


### PR DESCRIPTION
## Summary
- replace the rotating keyframes with a subtle vibration animation for the feature icons
- keep the home page informational icons using the shared animated class with updated documentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca71b042c4832e8319f7682d4790fe