### PR TITLE
Add vibrating animation to home page feature icons

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -57,6 +57,14 @@ function ClockIcon(props: SVGProps<SVGSVGElement>) {
   )
 }
 
+// Tipo que descreve cada bloco informativo apresentado na secção inferior
+type Feature = {
+  Icon: (props: SVGProps<SVGSVGElement>) => JSX.Element
+  label: string
+  text: string
+  delay: number
+}
+
 // Página inicial com título destacado e texto informativo
 export default function HomePage() {
   // Estado que indica se o utilizador está autenticado
@@ -73,22 +81,25 @@ export default function HomePage() {
     }
   }, [])
 
-  // Lista de caixas a apresentar na secção informativa
-  const features = [
+  // Lista de caixas a apresentar na secção informativa, incluindo o atraso da animação
+  const features: Feature[] = [
     {
       Icon: ShieldIcon,
       label: 'escudo',
       text: 'Equipa experiente',
+      delay: 0,
     },
     {
       Icon: PhoneIcon,
       label: 'telemóvel',
       text: '100% online',
+      delay: 0.5,
     },
     {
       Icon: ClockIcon,
       label: 'relógio',
       text: 'Aprendizagem ao seu ritmo',
+      delay: 1,
     },
   ]
 
@@ -139,16 +150,17 @@ export default function HomePage() {
 
       {/* Secção informativa com três caixas e símbolos associados */}
       <section className="mx-auto mt-12 grid gap-8 p-4 text-white max-w-3xl md:grid-cols-3">
-        {features.map((feature, index) => (
+        {features.map((feature) => (
           <div
-            key={index}
+            key={feature.label}
             className="mx-auto flex w-full flex-col items-center rounded-lg bg-white/40 p-6 text-center"
           >
-            {/* Símbolo representativo da característica */}
+            {/* Símbolo representativo da característica com animação de vibração e atraso individual */}
             <feature.Icon
               role="img"
               aria-label={feature.label}
-              className="mb-4 h-12 w-12 text-white"
+              className="feature-icon mb-4 h-12 w-12 text-white"
+              style={{ animationDelay: `${feature.delay}s` }}
             />
             {/* Texto descritivo da característica */}
             <p className="text-base font-bold">{feature.text}</p>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -186,3 +186,32 @@ p {
   padding-right: 5px;
 }
 
+/* Animação suave que faz os ícones informativos vibrarem sem rodar */
+@keyframes feature-icon-vibration {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  20% {
+    transform: translate3d(-2px, 1px, 0) scale(1.02);
+  }
+  40% {
+    transform: translate3d(2px, -1px, 0) scale(1);
+  }
+  60% {
+    transform: translate3d(-1px, 0, 0) scale(0.98);
+  }
+  80% {
+    transform: translate3d(1px, -1px, 0) scale(1.01);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+/* Classe aplicada aos ícones para executar a animação de vibração contínua; o atraso é definido inline para alternar o efeito */
+.feature-icon {
+  animation: feature-icon-vibration 1.5s ease-in-out infinite;
+  transform-origin: center;
+  will-change: transform;
+}
+


### PR DESCRIPTION
## Summary
- replace the rotating keyframes with a subtle vibration animation for the feature icons
- stagger the vibration animation so each feature icon starts at a different time and alternates the effect
- keep the home page informational icons using the shared animated class with updated documentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca71b042c4832e8319f7682d4790fe