### PR TITLE
fix: define typing placeholder width

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -14,6 +14,9 @@ const TYPING_SPEED = 120
 // Pausa antes de iniciar a próxima palavra em milissegundos
 const TYPING_PAUSE = 1500
 
+// Largura mínima do espaço reservado para evitar alterações bruscas no layout
+const TYPING_PLACEHOLDER_MIN_WIDTH = `${Math.max(...typingWords.map((word) => word.length))}ch`
+
 // Ícone de escudo representado apenas com linhas brancas
 function ShieldIcon(props: SVGProps<SVGSVGElement>) {
   return (


### PR DESCRIPTION
## Summary
- define a minimum width for the hero typing placeholder to avoid using an undefined constant

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbf0491b60832e884043fb7d765b33