### PR TITLE
Adjust home sections spacing and highlight typing word

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -137,18 +137,18 @@ export default function HomePage() {
   ]
 
   return (
-    // Container principal com espaçamento uniforme entre secções
-    <main className="space-y-12">
+    // Container principal com espaçamento uniforme de 1rem entre secções
+    <main className="space-y-4">
       {/* Secção introdutória com texto informativo sobre Cliente Mistério */}
       <section className="p-4">
         {/* Caixa branca translúcida contendo o texto explicativo */}
         <div className="mx-auto w-full max-w-3xl rounded-lg bg-white/40 p-8 text-center text-white">
-          {/* Texto principal com efeito de escrita nas palavras finais e tamanho destacado */}
+          {/* Texto principal com efeito de escrita nas palavras finais, destacado a negrito e com a cor do fundo */}
           <p className="text-2xl font-extrabold text-center leading-tight md:text-4xl">
             Avalia marcas, recebe{' '}
             <span
               aria-live="polite"
-              className="inline-block whitespace-nowrap align-baseline"
+              className="inline-block whitespace-nowrap align-baseline font-extrabold text-[#F3A183]"
               style={{ minWidth: TYPING_PLACEHOLDER_MIN_WIDTH, textAlign: 'left' }}
             >
               {typedText}


### PR DESCRIPTION
## Summary
- reduce the vertical spacing between homepage sections to a compact 1rem
- highlight the typing animation word with bold weight and the site's background color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc25939fac832e9ecd4160319d4d78