### PR TITLE
Adjust hero typing color and copy

### DIFF
--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -132,7 +132,7 @@ export default function HomePage() {
     {
       Icon: ClockIcon,
       label: 'relógio',
-      text: 'Aprendizagem ao seu ritmo',
+      text: 'Ao teu ritmo',
     },
   ]
 
@@ -148,7 +148,7 @@ export default function HomePage() {
             Avalia marcas, recebe{' '}
             <span
               aria-live="polite"
-              className="inline-block whitespace-nowrap align-baseline font-extrabold text-[#F3A183]"
+              className="inline-block whitespace-nowrap align-baseline font-extrabold text-[#ec6f66]"
               style={{ minWidth: TYPING_PLACEHOLDER_MIN_WIDTH, textAlign: 'left' }}
             >
               {typedText}


### PR DESCRIPTION
## Summary
- change the hero typing effect color to #ec6f66
- update the feature description text to "Ao teu ritmo"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc39f40640832e816dfa876c238b0f