### PR TITLE
Fix Next.js prerender DB access and default Postgres SSL handling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,9 @@ import Link from "next/link";
 
 import { query } from "@/lib/database";
 
+// Força renderização dinâmica para evitar acesso à base de dados durante o processo de build.
+export const dynamic = "force-dynamic";
+
 type ClosedPollRow = {
   id: string;
   title: string;

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -6,8 +6,11 @@ if (!databaseUrl) {
   throw new Error("DATABASE_URL não está definida nas variáveis de ambiente.");
 }
 
-// Decide se deve usar SSL com base no parâmetro sslmode do URL.
-const shouldUseSsl = databaseUrl.includes("sslmode=require");
+// Lê o parâmetro sslmode para respeitar configurações explícitas na connection string.
+const sslMode = new URL(databaseUrl).searchParams.get("sslmode")?.toLowerCase();
+
+// Ativa SSL por omissão em ambientes remotos e desativa apenas quando sslmode=disable.
+const shouldUseSsl = sslMode !== "disable";
 
 // Cria um pool de ligações para reutilizar conexões com a base de dados.
 const pool = new Pool({


### PR DESCRIPTION
### Motivation

- The Next.js build failed when prerendering `/` because server-side code attempted to connect to Postgres during static prerender and the DB rejected the connection with `SSL/TLS required`.
- Preventing build-time database access and making SSL handling more robust avoids deploy-time failures on platforms that require TLS by default.

### Description

- Added `export const dynamic = "force-dynamic";` to `app/page.tsx` to force runtime rendering of the homepage and avoid executing database queries during the static build.
- Updated `lib/database.ts` to parse `sslmode` from the `DATABASE_URL` and enable SSL by default, only disabling it when `sslmode=disable` is explicitly set.
- Committed both changes so the homepage no longer triggers DB access at build-time and the DB client honors explicit `sslmode` configuration.

### Testing

- Ran `git status`/commit verification and confirmed the two files were modified and committed successfully (commit present in repo).
- Attempted `npm run build` but the local environment could not complete a full build (`sh: 1: next: not found`) so a full build verification did not complete.
- Attempted dependency installs with `npm install`/`npm ci` and `npm audit` but installs were unstable in this environment (package install/process hangs and filesystem errors), so end-to-end verification on `next build` could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a4cfd4d4832e8a865f61d364b4ad)