### PR TITLE
Rename project branding to Cliente Mistério

### DIFF
--- a/LAUNCH_SUCCESS_AUDIT.md
+++ b/LAUNCH_SUCCESS_AUDIT.md
@@ -1,4 +1,4 @@
-# Launch & Success Audit — PubliQuestão
+# Launch & Success Audit — Cliente Mistério
 
 ## Objetivo
 Checklist prático do que falta para o site estar pronto para lançamento e aumentar a probabilidade de sucesso de produto.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Defina estas variáveis no ambiente de execução:
 
 ```bash
 RESEND_API_KEY=<resend-api-key>
-RESEND_FROM="PubliQuestão <onboarding@resend.dev>"
+RESEND_FROM="Cliente Mistério <onboarding@resend.dev>"
 
 # Opcional: endpoint custom (útil para testes/integração interna)
 RESEND_API_URL=https://api.resend.com/emails

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -9,11 +9,11 @@ export default function AboutPage() {
           <div className="space-y-4">
             <h1 className="page-title">
               Sobre a{" "}
-              <span className="text-[color:var(--primary)]">PubliQuestão</span>
+              <span className="text-[color:var(--primary)]">Cliente Mistério</span>
             </h1>
             <p className="text-base leading-7 text-justify text-zinc-600">
               A{" "}
-              <span className="text-[color:var(--primary)]">PubliQuestão</span>{" "}
+              <span className="text-[color:var(--primary)]">Cliente Mistério</span>{" "}
               nasceu para
               dar espaço à opinião das pessoas. Acreditamos que todos devem
               poder participar, votar e acompanhar a opinião coletiva sobre os
@@ -28,14 +28,14 @@ export default function AboutPage() {
             </p>
             <p className="text-base leading-7 text-justify text-zinc-600">
               Ao mesmo tempo, a{" "}
-              <span className="text-[color:var(--primary)]">PubliQuestão</span>{" "}
+              <span className="text-[color:var(--primary)]">Cliente Mistério</span>{" "}
               transforma essa participação em conhecimento. As votações geram
               dados anónimos e agregados que permitem identificar tendências,
               padrões e sinais relevantes da sociedade.
             </p>
             <p className="text-base leading-7 text-justify text-zinc-600">
               É por isso que a{" "}
-              <span className="text-[color:var(--primary)]">PubliQuestão</span>{" "}
+              <span className="text-[color:var(--primary)]">Cliente Mistério</span>{" "}
               é também uma oportunidade para empresas, marcas e organizações.
               Através de estudos de opinião discretos e imparciais, ajudamos a
               compreender melhor públicos, perceções e comportamentos — sem

--- a/app/enterprise/page.tsx
+++ b/app/enterprise/page.tsx
@@ -14,7 +14,7 @@ export default function EnterprisePage() {
                 Insights reais a partir da opinião das pessoas.
               </h1>
               <p className="text-base leading-7 text-justify text-zinc-600">
-                A PubliQuestão ajuda marcas a compreender melhor o que as pessoas
+                A Cliente Mistério ajuda marcas a compreender melhor o que as pessoas
                 pensam, através de estudos de opinião rápidos, anónimos e baseados
                 em dados reais.
               </p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ const poppins = Poppins({
 
 // Define os metadados globais usados pelo Next.js.
 export const metadata: Metadata = {
-  title: "PubliQuestão",
+  title: "Cliente Mistério",
   description: "Portal de participação cidadã e informação pública.",
 };
 
@@ -46,7 +46,7 @@ export default function RootLayout({
             {/* Marca do site alinhada à esquerda em todas as resoluções. */}
             <div className="flex items-center">
               <span className="bg-gradient-to-r from-[#b67ee8] to-[#fea076] bg-clip-text text-2xl font-semibold text-transparent">
-                PubliQuestão
+                Cliente Mistério
               </span>
             </div>
             {/* Navegação principal com painel compacto em mobile e barra horizontal em desktop. */}

--- a/lib/authEmail.ts
+++ b/lib/authEmail.ts
@@ -46,7 +46,7 @@ export const createEmailConfirmationTemplate = (token: string) => {
   const confirmationUrl = `${appBaseUrl}/api/auth/confirm-email?token=${encodeURIComponent(token)}`;
 
   return {
-    subject: "Confirmação de conta - PubliQuestão",
+    subject: "Confirmação de conta - Cliente Mistério",
     html: createLayout(
       "Confirme a sua conta",
       "Obrigado pelo registo. Para concluir a criação da conta e poder iniciar sessão, confirme o seu e-mail.",
@@ -62,7 +62,7 @@ export const createPasswordResetTemplate = (token: string) => {
   const resetUrl = `${appBaseUrl}/reset-password?token=${encodeURIComponent(token)}`;
 
   return {
-    subject: "Reposição de password - PubliQuestão",
+    subject: "Reposição de password - Cliente Mistério",
     html: createLayout(
       "Reposição de password",
       "Recebemos um pedido para redefinir a sua password. Clique no botão abaixo para criar uma nova password.",

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -156,7 +156,7 @@ const initializeDatabase = async (): Promise<void> => {
           last_name = coalesce(
             nullif(last_name, ''),
             nullif(trim(regexp_replace(full_name, '^\\S+\\s*', '')), ''),
-            'PubliQuestão'
+            'Cliente Mistério'
           ),
           full_name = trim(
             coalesce(nullif(full_name, ''), '') ||
@@ -164,10 +164,10 @@ const initializeDatabase = async (): Promise<void> => {
               when coalesce(nullif(first_name, ''), '') <> '' and coalesce(nullif(last_name, ''), '') <> ''
                 then ''
               when coalesce(nullif(first_name, ''), '') <> ''
-                then ' ' || coalesce(nullif(last_name, ''), 'PubliQuestão')
+                then ' ' || coalesce(nullif(last_name, ''), 'Cliente Mistério')
               when coalesce(nullif(last_name, ''), '') <> ''
                 then coalesce(nullif(first_name, ''), 'Utilizador') || ' '
-              else 'Utilizador PubliQuestão'
+              else 'Utilizador Cliente Mistério'
             end
           )
       `);

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -13,7 +13,7 @@ type ResendConfig = {
   timeoutMs: number;
 };
 
-const defaultSender = "PubliQuestão <onboarding@resend.dev>";
+const defaultSender = "Cliente Mistério <onboarding@resend.dev>";
 const defaultApiUrl = "https://api.resend.com/emails";
 
 const getResendConfig = (): ResendConfig => {


### PR DESCRIPTION
### Motivation
- Standardize the site branding by replacing occurrences of the old name with the new public name "Cliente Mistério" across the application and docs.

### Description
- Updated global site metadata title and the header brand label in `app/layout.tsx` to `Cliente Mistério`.
- Replaced visible brand mentions on the About and Enterprise pages in `app/about/page.tsx` and `app/enterprise/page.tsx` to keep UI copy consistent.
- Updated transactional email sender and subjects in `lib/email.ts` and `lib/authEmail.ts` to use the new brand name.
- Updated user name fallback strings in the database initialization SQL inside `lib/database.ts` and synchronized documentation in `README.md` and `LAUNCH_SUCCESS_AUDIT.md`.

### Testing
- Ran `npm run lint`, which failed because the `next` binary is unavailable without installing dependencies (dependencies not installed). 
- Ran `npm install`, which failed with a registry error `403 Forbidden` preventing dependency installation. 
- Attempted to capture a live screenshot via Playwright, which failed because the application server was not reachable at `http://127.0.0.1:3000` (net::ERR_EMPTY_RESPONSE). 
- No further automated tests were executed due to the environment limitations above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a9eee8f8832ea98dcfa71ea5371c)