### PR TITLE
Update home hero messaging and simplify primary CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,31 +7,24 @@ export default function HomePage() {
       <div className="grid items-center gap-14 md:grid-cols-[1fr_0.9fr]">
         <article className="max-w-xl">
           {/* Rótulo pequeno para introduzir o bloco principal da página. */}
-          <p className="section-label-uppercase text-[color:var(--primary)]">Nova plataforma</p>
+          <p className="section-label-uppercase text-[color:var(--primary)]">Novo Curso</p>
 
           {/* Mantém o conteúdo principal do site, ajustando apenas o estilo visual e hierarquia. */}
           <h1 className="mt-4 text-5xl font-extrabold leading-[1.05] tracking-tight text-[#16152b] sm:text-6xl">
-            A tua conta, dados e contacto num só lugar.
+            O único curso de cliente mistério em Portugal
           </h1>
 
           <p className="mt-6 max-w-md text-lg text-slate-500">
-            Gere informação pessoal, segurança e comunicação com a equipa através de uma experiência simples e
-            consistente.
+            Sê dos primeiros Clientes Mistério certificados!
           </p>
 
-          {/* Ações principais com botão primário e secundário conforme organização da referência. */}
+          {/* Ação principal da hero com foco em conversão para iniciar o curso. */}
           <div className="mt-9 flex flex-wrap items-center gap-4">
             <Link
               className="inline-flex items-center justify-center rounded-full bg-[color:var(--primary)] px-8 py-3 text-sm font-semibold uppercase tracking-wide text-white transition hover:brightness-95"
               href="/about"
             >
-              Saber mais
-            </Link>
-            <Link
-              className="inline-flex h-11 w-11 items-center justify-center rounded-full border-2 border-[color:var(--primary)] text-[color:var(--primary)] transition hover:bg-[color:var(--primary-soft)]"
-              href="/dashboard"
-            >
-              ▶
+              Começa Já
             </Link>
           </div>
         </article>


### PR DESCRIPTION
### Motivation
- Replace the generic home hero content with course-focused messaging and remove the secondary play CTA so the primary action emphasizes enrollment.

### Description
- Updated `app/page.tsx` to change the eyebrow to "Novo Curso", headline to "O único curso de cliente mistério em Portugal", supporting text to "Sê dos primeiros Clientes Mistério certificados!", changed the primary CTA label to `Começa Já`, and removed the secondary circular play button; the full updated file was committed.

### Testing
- Ran `npm run lint` which failed because `next` is not installed in the environment; `npm install` failed with a 403 error when accessing the npm registry; and `npm run dev` failed due to the missing `next` dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ba7d9edc832e8b0de72d5b4008d3)