### PR TITLE
Remove profile, security and contact summary cards from homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ export default function HomePage() {
   return (
     <section className="pt-6 md:pt-10">
       {/* Estrutura principal da hero com tipografia e espaçamento inspirados no layout enviado. */}
-      <div className="grid items-center gap-14 md:grid-cols-[1fr_0.9fr]">
+      <div className="grid items-center gap-14">
         <article className="max-w-xl">
           {/* Rótulo pequeno para introduzir o bloco principal da página. */}
           <p className="section-label-uppercase text-[color:var(--primary)]">Novo Curso</p>
@@ -28,30 +28,6 @@ export default function HomePage() {
             </Link>
           </div>
         </article>
-
-        {/* Bloco lateral para preservar o conteúdo atual da home em formato de cartões resumidos. */}
-        <section className="grid gap-4 sm:grid-cols-2 md:grid-cols-1">
-          <article className="rounded-3xl border border-slate-100 bg-white p-6 shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
-            <h2 className="subsection-title">Conta pessoal</h2>
-            <p className="mt-2 text-sm text-slate-600">
-              Atualize os seus dados de perfil, preferências e informação essencial de acesso.
-            </p>
-          </article>
-
-          <article className="rounded-3xl border border-slate-100 bg-white p-6 shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
-            <h2 className="subsection-title">Segurança</h2>
-            <p className="mt-2 text-sm text-slate-600">
-              Altere a palavra-passe e mantenha a sua conta protegida com boas práticas de autenticação.
-            </p>
-          </article>
-
-          <article className="rounded-3xl border border-slate-100 bg-white p-6 shadow-[0_10px_24px_rgba(15,23,42,0.06)] sm:col-span-2 md:col-span-1">
-            <h2 className="subsection-title">Contacto</h2>
-            <p className="mt-2 text-sm text-slate-600">
-              Fale com a equipa através do formulário de contacto para suporte e informações.
-            </p>
-          </article>
-        </section>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Remover os cartões de resumo laterais ("Conta pessoal", "Segurança", "Contacto") da hero da homepage e simplificar o layout para uma única coluna.

### Description
- Atualizado `app/page.tsx` para eliminar a secção lateral contendo os três `article` dos cartões e removi a classe `md:grid-cols-[1fr_0.9fr]` para usar uma grelha de coluna única.

### Testing
- Executei `npm run lint` que falhou por faltar o binário `next` no ambiente; `npm install` falhou com `403 Forbidden` ao aceder ao registry; e uma tentativa de captura com Playwright falhou porque a aplicação não estava a responder em `:3000`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1db101aa8832e900350978e1fe570)