### PR TITLE
feat: aplicar visual editorial (fashion) ao homepage e layout

### DIFF
--- a/app/components/HeaderActions.tsx
+++ b/app/components/HeaderActions.tsx
@@ -16,12 +16,12 @@ export default function HeaderActions() {
   const [sessionUser, setSessionUser] = useState<SessionUser | null>(null);
 
   const profileHref = useMemo(() => {
-    // Direciona utilizadores autenticados para o dashboard principal.
+    // Mantém destino único para utilizadores autenticados.
     return "/dashboard";
   }, []);
 
   useEffect(() => {
-    // Lê o estado da sessão no browser para decidir qual ação apresentar no cabeçalho.
+    // Lê a sessão guardada no browser para alternar ação entre login e dashboard.
     const storedSession = localStorage.getItem(sessionStorageKey);
     const storedUser = localStorage.getItem(userStorageKey);
 
@@ -44,28 +44,31 @@ export default function HeaderActions() {
     }
   }, []);
 
-  if (!sessionUser) {
-    return (
-      <div className="flex items-center justify-end">
-        {/* Aplica o botão primário arredondado para replicar o destaque visual da imagem de referência. */}
+  return (
+    <div className="flex items-center gap-3">
+      {/* Apresenta ícones minimalistas para simular a zona de utilitários do cabeçalho de moda. */}
+      <span aria-hidden className="hidden text-lg text-[color:var(--foreground)] md:inline">
+        ⌕
+      </span>
+      <span aria-hidden className="hidden text-lg text-[color:var(--foreground)] md:inline">
+        ♡
+      </span>
+
+      {!sessionUser ? (
         <Link
-          className="inline-flex items-center justify-center rounded-full bg-[color:var(--primary)] px-8 py-2 text-sm font-semibold text-white transition hover:brightness-95"
+          className="inline-flex items-center justify-center border border-[color:var(--foreground)] px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-[color:var(--foreground)] transition hover:bg-[color:var(--foreground)] hover:text-white"
           href="/login"
         >
           Sign up
         </Link>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex items-center justify-end">
-      <Link
-        className="inline-flex items-center justify-center rounded-full border border-[color:var(--primary)] px-6 py-2 text-sm font-semibold text-[color:var(--primary)] transition hover:bg-[color:var(--primary-soft)]"
-        href={profileHref}
-      >
-        Dashboard
-      </Link>
+      ) : (
+        <Link
+          className="inline-flex items-center justify-center border border-[color:var(--foreground)] px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-[color:var(--foreground)] transition hover:bg-[color:var(--foreground)] hover:text-white"
+          href={profileHref}
+        >
+          Dashboard
+        </Link>
+      )}
     </div>
   );
 }

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -13,16 +13,18 @@ export default function TopNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="hidden items-center gap-8 md:flex">
+    <nav className="hidden items-center gap-8 lg:flex">
       {navigationItems.map((item) => {
         const isActive = pathname === item.href;
 
         return (
-          // Mantém links sem peso visual excessivo para replicar a navegação discreta da referência.
+          // Mantém links em caixa alta para reproduzir a estética de revista da referência.
           <a
             key={item.href}
-            className={`text-sm font-medium transition ${
-              isActive ? "text-[#16152b]" : "text-slate-500 hover:text-[#16152b]"
+            className={`text-[11px] font-semibold uppercase tracking-[0.18em] transition ${
+              isActive
+                ? "text-[color:var(--accent)]"
+                : "text-[color:var(--foreground)] hover:text-[color:var(--accent)]"
             }`}
             href={item.href}
           >

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,13 +1,14 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8f8fb;
-  --foreground: #1f2937;
+  --background: #f4f4f4;
+  --foreground: #111111;
   --surface: #ffffff;
-  --surface-muted: #f2f3f8;
-  --primary: #6f58f6;
-  --primary-soft: #ece8ff;
-  --accent: #b67ee8;
+  --surface-muted: #ececec;
+  --primary: #111111;
+  --primary-soft: #f0f0f0;
+  --accent: #f44336;
+  --line: #d5d5d5;
   color-scheme: light;
 }
 
@@ -19,10 +20,10 @@
   --color-primary: var(--primary);
   --color-primary-soft: var(--primary-soft);
   --color-accent: var(--accent);
-  --font-sans: var(--font-poppins);
+  --color-line: var(--line);
+  --font-sans: var(--font-montserrat);
   --font-mono: var(--font-geist-mono);
 }
-
 
 body {
   background: var(--background);
@@ -30,8 +31,13 @@ body {
   font-family: var(--font-sans);
 }
 
+/* Gira texto para orientação vertical usada na barra lateral do hero. */
+.vertical-text {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
 
-/* Adiciona transição suave para o efeito visual de todos os botões interativos. */
+/* Adiciona transição consistente para elementos interativos de formulário. */
 button,
 [role="button"],
 input[type="button"],
@@ -40,7 +46,7 @@ input[type="reset"] {
   transition: box-shadow 0.2s ease-in-out;
 }
 
-/* Remove sombra no hover por padrão para evitar efeito em botões com fundo roxo. */
+/* Remove sombra padrão no hover para preservar visual limpo e plano. */
 button:hover,
 [role="button"]:hover,
 input[type="button"]:hover,
@@ -49,32 +55,18 @@ input[type="reset"]:hover {
   box-shadow: none;
 }
 
-/* Aplica sombra no hover apenas quando o botão usa fundo branco (inclui surface). */
-button.bg-white:hover,
-button.bg-\[color\:var\(--surface\)\]:hover,
-[role="button"].bg-white:hover,
-[role="button"].bg-\[color\:var\(--surface\)\]:hover,
-input[type="button"].bg-white:hover,
-input[type="button"].bg-\[color\:var\(--surface\)\]:hover,
-input[type="submit"].bg-white:hover,
-input[type="submit"].bg-\[color\:var\(--surface\)\]:hover,
-input[type="reset"].bg-white:hover,
-input[type="reset"].bg-\[color\:var\(--surface\)\]:hover {
-  box-shadow: 0 10px 24px #fea076;
-}
-
 @layer components {
-  /* Uniformiza a dimensão de todos os botões com base no botão de login da home. */
+  /* Mantém utilitário reutilizável para tamanho de botões secundários. */
   .button-size-login {
     @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold whitespace-nowrap;
   }
 
-  /* Aplica tipografia consistente para texto de botões fora do estilo principal arredondado. */
+  /* Mantém estilo textual consistente para botões em páginas internas. */
   .button-text-standard {
     @apply text-sm font-semibold;
   }
 
-  /* Define estilos consistentes para títulos e subtítulos em todo o site. */
+  /* Define tipografia padrão para títulos principais do site. */
   .page-title {
     @apply text-3xl font-semibold text-[color:var(--foreground)];
   }
@@ -83,7 +75,6 @@ input[type="reset"].bg-\[color\:var\(--surface\)\]:hover {
     @apply text-2xl font-semibold text-[color:var(--foreground)];
   }
 
-  /* Define o título para secções em fundos escuros mantendo a legibilidade. */
   .section-title-inverse {
     @apply text-2xl font-semibold text-white;
   }
@@ -96,104 +87,11 @@ input[type="reset"].bg-\[color\:var\(--surface\)\]:hover {
     @apply text-base font-semibold text-[color:var(--foreground)];
   }
 
-  /* Define o texto auxiliar com a cor primária para destacar secções. */
   .section-label {
     @apply text-sm font-semibold text-[color:var(--primary)];
   }
 
-  /* Define o texto auxiliar em maiúsculas para chamadas de destaque. */
   .section-label-uppercase {
     @apply text-sm font-semibold uppercase tracking-[0.3em] text-[color:var(--primary)];
-  }
-}
-
-
-/* Mantém o fundo das secções em destaque sem gradiente. */
-.soft-section-gradient {
-  background: var(--surface);
-}
-
-/* Define o cartão principal com sombra e alinhamento central. */
-.card {
-  position: relative;
-
-  width: min(100%, 240px);
-  height: 280px;
-
-  border-radius: 14px;
-  z-index: 1;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-
-  margin: 0 auto;
-
-  box-shadow: 20px 20px 60px #bebebe, -20px -20px 60px #ffffff;
-}
-
-/* Cria a camada translúcida com blur para o conteúdo do cartão. */
-.bg {
-  position: absolute;
-  top: 5px;
-  left: 5px;
-
-  width: calc(100% - 10px);
-  height: calc(100% - 10px);
-
-  z-index: 2;
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(24px);
-  border-radius: 10px;
-  overflow: hidden;
-  outline: 2px solid #ffffff;
-}
-
-/* Define a bolha com gradiente roxo e animação contínua. */
-.blob {
-  position: absolute;
-  z-index: 1;
-  top: 50%;
-  left: 50%;
-
-  width: 170px;
-  height: 170px;
-
-  border-radius: 50%;
-  background: radial-gradient(circle, #b67ee8 0%, #b67ee8 70%);
-  opacity: 1;
-  filter: blur(12px);
-  animation: blob-bounce 5s infinite ease;
-}
-
-/* Garante que o conteúdo fica justificado e legível no topo das camadas. */
-.card-content {
-  position: relative;
-  z-index: 3;
-  padding: 0 20px;
-  text-align: justify;
-}
-
-/* Controla o movimento da bolha para criar o efeito orbitado. */
-@keyframes blob-bounce {
-  0% {
-    transform: translate(-100%, -100%) translate3d(0, 0, 0);
-  }
-
-  25% {
-    transform: translate(-100%, -100%) translate3d(100%, 0, 0);
-  }
-
-  50% {
-    transform: translate(-100%, -100%) translate3d(100%, 100%, 0);
-  }
-
-  75% {
-    transform: translate(-100%, -100%) translate3d(0, 100%, 0);
-  }
-
-  100% {
-    transform: translate(-100%, -100%) translate3d(0, 0, 0);
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,29 +1,28 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Poppins } from "next/font/google";
+import { Geist, Geist_Mono, Montserrat } from "next/font/google";
 import TopNav from "./components/TopNav";
 import HeaderActions from "./components/HeaderActions";
 import "./globals.css";
 
-// Configura a fonte base para todo o layout da aplicação.
+// Define a fonte principal com estilo geométrico para reforçar o visual editorial.
+const montserrat = Montserrat({
+  variable: "--font-montserrat",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800", "900"],
+});
+
+// Mantém as fontes auxiliares para áreas técnicas sem quebrar compatibilidade.
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
 });
 
-// Mantém uma fonte monoespaçada disponível para áreas técnicas quando necessário.
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
 
-// Usa Poppins para aproximar a estética visual da referência enviada.
-const poppins = Poppins({
-  variable: "--font-poppins",
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700", "800"],
-});
-
-// Define metadados globais da aplicação.
+// Centraliza metadados globais do website.
 export const metadata: Metadata = {
   title: "Cliente Mistério",
   description: "Portal de participação cidadã e informação pública.",
@@ -37,21 +36,24 @@ export default function RootLayout({
   return (
     <html lang="pt">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${poppins.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
+        className={`${montserrat.variable} ${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
       >
-        {/* Cria a estrutura principal com cabeçalho fixo no topo visual e conteúdo centralizado. */}
-        <div className="min-h-screen bg-[color:var(--background)]">
-          {/* Organiza marca, navegação e ações com distribuição similar ao layout de referência. */}
-          <header className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-4 pb-8 pt-8 sm:px-6 lg:px-8">
-            <a className="text-2xl font-extrabold tracking-tight text-[#16152b]" href="/">
+        {/* Desenha o container principal com contorno fino para replicar a moldura da referência. */}
+        <div className="mx-auto min-h-screen w-full max-w-[1400px] border border-[color:var(--accent)] bg-[color:var(--background)]">
+          {/* Cria a faixa superior com navegação central e ações discretas à direita. */}
+          <header className="flex items-center justify-between px-6 py-6 md:px-10">
+            <a
+              className="text-xs font-black uppercase tracking-[0.35em] text-[color:var(--foreground)]"
+              href="/"
+            >
               Cliente Mistério
             </a>
             <TopNav />
             <HeaderActions />
           </header>
 
-          {/* Renderiza o conteúdo de cada página no centro com largura confortável. */}
-          <main className="mx-auto w-full max-w-6xl px-4 pb-16 sm:px-6 lg:px-8">{children}</main>
+          {/* Renderiza o conteúdo da página respeitando a largura do layout editorial. */}
+          <main className="px-6 pb-10 md:px-10">{children}</main>
         </div>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,33 +1,59 @@
+import Image from "next/image";
 import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <section className="pt-6 md:pt-10">
-      {/* Estrutura principal da hero com tipografia e espaçamento inspirados no layout enviado. */}
-      <div className="grid items-center gap-14">
-        <article className="max-w-xl">
-          {/* Rótulo pequeno para introduzir o bloco principal da página. */}
-          <p className="section-label-uppercase text-[color:var(--primary)]">Novo Curso</p>
+    <section className="grid min-h-[calc(100vh-120px)] gap-8 lg:grid-cols-[88px_1fr]">
+      {/* Constrói a coluna lateral com texto vertical e marcadores sociais para aproximar o layout original. */}
+      <aside className="hidden border-r border-[color:var(--line)] py-8 lg:flex lg:flex-col lg:items-center lg:justify-between">
+        <p className="vertical-text text-[10px] font-semibold uppercase tracking-[0.35em] text-[color:var(--foreground)]">
+          Bad Co.
+        </p>
 
-          {/* Mantém o conteúdo principal do site, ajustando apenas o estilo visual e hierarquia. */}
-          <h1 className="mt-4 text-5xl font-extrabold leading-[1.05] tracking-tight text-[#16152b] sm:text-6xl">
+        <div className="flex flex-col items-center gap-5 text-xs text-[color:var(--foreground)]">
+          <span aria-hidden>f</span>
+          <span aria-hidden>t</span>
+          <span aria-hidden>◎</span>
+        </div>
+      </aside>
+
+      {/* Mantém o conteúdo original e aplica uma composição visual inspirada em editorial de moda. */}
+      <div className="grid items-center gap-10 pb-8 lg:grid-cols-[minmax(320px,460px)_1fr]">
+        <article className="relative z-10 max-w-md lg:pl-6">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--accent)]">
+            Novo Curso
+          </p>
+
+          <h1 className="mt-5 text-5xl font-black uppercase leading-[0.95] tracking-tight text-[color:var(--foreground)] sm:text-6xl">
             O único curso de cliente mistério em Portugal
           </h1>
 
-          <p className="mt-6 max-w-md text-lg text-slate-500">
+          <p className="mt-6 text-base font-medium text-[#4a4a4a]">
             Sê dos primeiros Clientes Mistério certificados!
           </p>
 
-          {/* Ação principal da hero com foco em conversão para iniciar o curso. */}
-          <div className="mt-9 flex flex-wrap items-center gap-4">
+          <div className="mt-8">
             <Link
-              className="inline-flex items-center justify-center rounded-full bg-[color:var(--primary)] px-8 py-3 text-sm font-semibold uppercase tracking-wide text-white transition hover:brightness-95"
+              className="inline-flex items-center justify-center border border-[color:var(--foreground)] bg-white px-8 py-3 text-[11px] font-bold uppercase tracking-[0.18em] text-[color:var(--foreground)] transition hover:bg-[color:var(--foreground)] hover:text-white"
               href="/about"
             >
               Começa Já
             </Link>
           </div>
         </article>
+
+        <div className="relative min-h-[420px] overflow-hidden rounded-sm bg-[#efefef] lg:min-h-[620px]">
+          {/* Exibe imagem principal em preto e branco para reforçar o contraste com o acento vermelho. */}
+          <Image
+            alt="Pessoa em destaque no hero"
+            className="object-cover grayscale"
+            fill
+            priority
+            sizes="(max-width: 1024px) 100vw, 55vw"
+            src="/images/hero-illustration.png"
+          />
+          <div className="absolute inset-0 bg-gradient-to-r from-white/30 via-transparent to-transparent" />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Modernize the site visual to an editorial/fashion landing aesthetic while preserving existing textual content and navigation.
- Introduce a stronger typographic hierarchy and a neutral palette with a bold accent to match the provided design reference.
- Improve the header and hero composition to work responsively with a two-column editorial layout.

### Description
- Restyled the global layout in `app/layout.tsx` to use `Montserrat` as the main font, wrap the site in a framed container and simplify header structure for a magazine-like top bar.
- Reworked the homepage in `app/page.tsx` into a two-column hero with a vertical sidebar, bold uppercase headline, outlined CTA and a B/W hero image using `next/image` to match the visual reference.
- Updated `app/components/TopNav.tsx` to present uppercase navigation with increased letter-spacing and accent color for the active item; adjusted breakpoint visibility to `lg`.
- Replaced header actions in `app/components/HeaderActions.tsx` with minimal utility icons and a compact outlined login/dashboard button, keeping session logic intact.
- Revised theme and utilities in `app/globals.css` to a neutral background, red accent, added `--line` and `.vertical-text` utility and removed previous decorative blobs to simplify the visual system.

### Testing
- Ran `npm run lint` which failed because `next` is not available in the runtime (`sh: 1: next: not found`).
- Attempted `npm install` to install dependencies but it failed with `403 Forbidden` from the npm registry, preventing a full build in this environment.
- Tried an automated Playwright capture of `http://127.0.0.1:3000` which failed with `net::ERR_EMPTY_RESPONSE` because no local dev server was running; no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e08913c4832ebc246b1f79144d2b)