### PR TITLE
Hero: set image as right-side background and highlight 'cliente mistério'

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -31,6 +31,26 @@ body {
   font-family: var(--font-sans);
 }
 
+
+/* Aplica a fotografia como fundo no lado direito da homepage para reforçar o hero. */
+.hero-background {
+  background-image:
+    linear-gradient(to right, rgba(244, 244, 244, 1) 45%, rgba(244, 244, 244, 0.72) 68%, rgba(244, 244, 244, 0.32) 100%),
+    url("/images/hero-illustration.png");
+  background-position: left top, right bottom;
+  background-size: cover, min(46vw, 620px) auto;
+}
+
+@media (max-width: 1023px) {
+  .hero-background {
+    background-image:
+      linear-gradient(to bottom, rgba(244, 244, 244, 0.96) 56%, rgba(244, 244, 244, 0.82) 100%),
+      url("/images/hero-illustration.png");
+    background-position: left top, center bottom;
+    background-size: cover, min(80vw, 460px) auto;
+  }
+}
+
 /* Gira texto para orientação vertical usada na barra lateral do hero. */
 .vertical-text {
   writing-mode: vertical-rl;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,8 @@
-import Image from "next/image";
 import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <section className="grid min-h-[calc(100vh-120px)] gap-8 lg:grid-cols-[88px_1fr]">
+    <section className="hero-background grid min-h-[calc(100vh-120px)] gap-8 bg-no-repeat px-4 lg:grid-cols-[88px_1fr] lg:bg-[length:min(46vw,620px)_auto] lg:bg-[position:right_bottom]">
       {/* Constrói a coluna lateral com texto vertical e marcadores sociais para aproximar o layout original. */}
       <aside className="hidden border-r border-[color:var(--line)] py-8 lg:flex lg:flex-col lg:items-center lg:justify-between">
         <p className="vertical-text text-[10px] font-semibold uppercase tracking-[0.35em] text-[color:var(--foreground)]">
@@ -17,15 +16,15 @@ export default function HomePage() {
         </div>
       </aside>
 
-      {/* Mantém o conteúdo original e aplica uma composição visual inspirada em editorial de moda. */}
-      <div className="grid items-center gap-10 pb-8 lg:grid-cols-[minmax(320px,460px)_1fr]">
-        <article className="relative z-10 max-w-md lg:pl-6">
+      {/* Mantém o conteúdo textual em destaque e deixa a imagem como fundo no lado direito. */}
+      <div className="grid items-center gap-10 pb-8">
+        <article className="relative z-10 max-w-md bg-white/75 p-4 backdrop-blur-[1px] sm:p-5 lg:ml-6 lg:bg-transparent lg:p-0 lg:backdrop-blur-none">
           <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--accent)]">
             Novo Curso
           </p>
 
           <h1 className="mt-5 text-5xl font-black uppercase leading-[0.95] tracking-tight text-[color:var(--foreground)] sm:text-6xl">
-            O único curso de cliente mistério em Portugal
+            O único curso de <span className="text-[color:var(--accent)]">cliente mistério</span> em Portugal
           </h1>
 
           <p className="mt-6 text-base font-medium text-[#4a4a4a]">
@@ -41,19 +40,6 @@ export default function HomePage() {
             </Link>
           </div>
         </article>
-
-        <div className="relative min-h-[420px] overflow-hidden rounded-sm bg-[#efefef] lg:min-h-[620px]">
-          {/* Exibe imagem principal em preto e branco para reforçar o contraste com o acento vermelho. */}
-          <Image
-            alt="Pessoa em destaque no hero"
-            className="object-cover grayscale"
-            fill
-            priority
-            sizes="(max-width: 1024px) 100vw, 55vw"
-            src="/images/hero-illustration.png"
-          />
-          <div className="absolute inset-0 bg-gradient-to-r from-white/30 via-transparent to-transparent" />
-        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Add the provided photo as the hero background positioned on the right side of the homepage to match the requested visual layout. 
- Emphasise the words "cliente mistério" in the main heading using the site accent color to meet the styling request. 
- Keep text legibility by adding gradient overlays and responsive rules so the background works across viewports.

### Description
- Updated `app/page.tsx` to remove the separate `<Image>` block and make the hero section use a `hero-background` container, and wrapped the text `cliente mistério` in a `<span>` that uses the accent color (`var(--accent)`).
- Updated `app/globals.css` to add the `.hero-background` class with a layered gradient and `url("/images/hero-illustration.png")` background, plus a responsive `@media (max-width: 1023px)` override for mobile sizing and positioning.
- Kept the textual content in the foreground by adding a semi-transparent bg/backdrop on the article for small viewports and making it transparent on larger screens to preserve contrast.

### Testing
- Ran `npm run lint`, which failed because the `next` binary is not available in the environment (tooling missing). 
- Ran `npm ci`, which failed with `403 Forbidden` when attempting to fetch dependencies from the npm registry. 
- Attempted a Playwright screenshot by visiting `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because no local server was responding at that address.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e259d660832e9e3fb817675dee1b)