### PR TITLE
feat: use uploaded IMG_2622 as home hero background

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,23 +3,23 @@ import Link from "next/link";
 export default function HomePage() {
   return (
     <section className="relative grid min-h-[calc(100vh-120px)] gap-8 overflow-hidden px-4 lg:grid-cols-[88px_1fr]">
-      {/* Cria uma camada visual fixa do lado direito para garantir que a imagem aparece sempre no hero. */}
+      {/* Cria uma camada visual fixa do lado direito para garantir que a nova foto aparece sempre no hero. */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-y-0 right-0 hidden w-[min(46vw,620px)] bg-contain bg-right-bottom bg-no-repeat lg:block"
         style={{
           backgroundImage:
-            "linear-gradient(to left, rgba(244, 244, 244, 0.15) 0%, rgba(244, 244, 244, 0.45) 24%, rgba(244, 244, 244, 0.88) 100%), url('/images/hero-illustration.svg')",
+            "linear-gradient(to left, rgba(244, 244, 244, 0.15) 0%, rgba(244, 244, 244, 0.45) 24%, rgba(244, 244, 244, 0.88) 100%), url('/images/IMG_2622.png')",
         }}
       />
 
-      {/* Adiciona uma versão mobile da imagem de fundo para manter destaque visual em ecrãs pequenos. */}
+      {/* Adiciona uma versão mobile da foto de fundo para manter destaque visual em ecrãs pequenos. */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-x-0 bottom-0 h-[46vh] bg-contain bg-center bg-no-repeat lg:hidden"
         style={{
           backgroundImage:
-            "linear-gradient(to top, rgba(244, 244, 244, 0.72) 18%, rgba(244, 244, 244, 0.92) 100%), url('/images/hero-illustration.svg')",
+            "linear-gradient(to top, rgba(244, 244, 244, 0.72) 18%, rgba(244, 244, 244, 0.92) 100%), url('/images/IMG_2622.png')",
         }}
       />
 


### PR DESCRIPTION
### Motivation
- Replace the current hero illustration with the user-uploaded photo so the homepage shows the provided image in the right-side background on desktop and in the bottom background on mobile.
- Preserve existing gradient overlays to maintain text legibility over the new photo.
- Keep hero content, layout and accessibility attributes unchanged to avoid affecting business logic.

### Description
- Updated `app/page.tsx` to change the desktop hero background image URL from `/images/hero-illustration.svg` to `/images/IMG_2622.png` and applied the same image for the mobile background variant.
- Preserved the existing linear-gradient overlays and CSS utility classes so visual contrast and responsive behavior remain intact.
- No other files or styles were modified and the change is purely presentational in the homepage component.

### Testing
- Ran `npm run lint` which failed because `next` is not installed in the execution environment, so linting could not complete. 
- Attempted `npm install` which failed with a `403 Forbidden` error fetching `pg` from the registry, so dependencies were not installed. 
- Executed a Playwright script to capture a homepage screenshot which failed with `ERR_EMPTY_RESPONSE` because the local server was not reachable, so visual verification could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a223c54164832eb284ca1c7754182d)