### PR TITLE
Change header auth button label to Login

### DIFF
--- a/app/components/HeaderActions.tsx
+++ b/app/components/HeaderActions.tsx
@@ -59,7 +59,7 @@ export default function HeaderActions() {
           className="inline-flex items-center justify-center border border-[color:var(--foreground)] px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--foreground)] transition hover:bg-[color:var(--foreground)] hover:text-white sm:px-4 sm:text-[11px] sm:tracking-[0.15em]"
           href="/login"
         >
-          Sign up
+          Login
         </Link>
       ) : (
         <Link


### PR DESCRIPTION
### Motivation
- Replace the unauthenticated header action label from `Sign up` to `Login` so the button text reflects the intended authentication action.

### Description
- Updated `app/components/HeaderActions.tsx` to change the button text for unauthenticated users from `Sign up` to `Login`, leaving `href="/login"`, styling, and behavior unchanged.

### Testing
- Ran `npm run lint` and `npm run dev` and attempted `npm install`, but these automated checks failed in this environment because dependencies could not be installed (`npm install` returned a `403 Forbidden` for registry packages) and `next` is not available, so linting and dev start could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2340f1a34832e8110c1e9486e1418)