### PR TITLE
Add `.site-pill-button` component styles and apply to header, nav and hero CTAs

### DIFF
--- a/app/components/HeaderActions.tsx
+++ b/app/components/HeaderActions.tsx
@@ -56,14 +56,14 @@ export default function HeaderActions() {
 
       {!sessionUser ? (
         <Link
-          className="inline-flex items-center justify-center border border-[color:var(--foreground)] px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--foreground)] transition hover:bg-[color:var(--foreground)] hover:text-white sm:px-4 sm:text-[11px] sm:tracking-[0.15em]"
+          className="site-pill-button text-[10px] uppercase tracking-[0.14em] sm:text-[11px] sm:tracking-[0.15em]"
           href="/login"
         >
-          Sign up
+          Login
         </Link>
       ) : (
         <Link
-          className="inline-flex items-center justify-center border border-[color:var(--foreground)] px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--foreground)] transition hover:bg-[color:var(--foreground)] hover:text-white sm:px-4 sm:text-[11px] sm:tracking-[0.15em]"
+          className="site-pill-button text-[10px] uppercase tracking-[0.14em] sm:text-[11px] sm:tracking-[0.15em]"
           href={profileHref}
         >
           Dashboard

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -26,7 +26,7 @@ export default function TopNav() {
       <button
         aria-expanded={isMenuOpen}
         aria-label="Abrir menu principal"
-        className="inline-flex items-center justify-center border border-[color:var(--foreground)] px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-[color:var(--foreground)] lg:hidden"
+        className="site-pill-button text-[11px] uppercase tracking-[0.15em] lg:hidden"
         onClick={() => setIsMenuOpen((current) => !current)}
         type="button"
       >

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,28 +38,51 @@ body {
   transform: rotate(180deg);
 }
 
-/* Adiciona transição consistente para elementos interativos de formulário. */
-button,
-[role="button"],
-input[type="button"],
-input[type="submit"],
-input[type="reset"] {
-  transition: box-shadow 0.2s ease-in-out;
-}
-
-/* Remove sombra padrão no hover para preservar visual limpo e plano. */
-button:hover,
-[role="button"]:hover,
-input[type="button"]:hover,
-input[type="submit"]:hover,
-input[type="reset"]:hover {
-  box-shadow: none;
-}
-
 @layer components {
-  /* Mantém utilitário reutilizável para tamanho de botões secundários. */
+  /* Define estilo base único para todos os botões com visual pill e destaque vermelho. */
+  .site-pill-button,
   .button-size-login {
-    @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold whitespace-nowrap;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 100px;
+    padding: 12.5px 30px;
+    background-color: #dc2626 !important;
+    color: #ffffff !important;
+    font-size: 0.875rem;
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+    transition: all 0.5s;
+    -webkit-transition: all 0.5s;
+  }
+
+  /* Realça o botão no hover com aumento subtil e sombra difusa vermelha. */
+  .site-pill-button:hover,
+  .button-size-login:hover {
+    background-color: #ef4444 !important;
+    filter: none !important;
+    box-shadow: 0 0 20px rgb(239 68 68 / 32%);
+    transform: scale(1.1);
+  }
+
+  /* Aplica estado de clique com redução de escala para feedback tátil. */
+  .site-pill-button:active,
+  .button-size-login:active {
+    background-color: #b91c1c !important;
+    filter: none !important;
+    transition: all 0.25s;
+    -webkit-transition: all 0.25s;
+    box-shadow: none;
+    transform: scale(0.98);
+  }
+
+  /* Evita animações quando o botão está desativado para manter acessibilidade. */
+  .site-pill-button:disabled,
+  .button-size-login:disabled {
+    transform: none;
+    box-shadow: none;
   }
 
   /* Mantém estilo textual consistente para botões em páginas internas. */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,7 +44,7 @@ export default function HomePage() {
 
           <div className="mt-7 sm:mt-8">
             <Link
-              className="inline-flex items-center justify-center border border-[color:var(--foreground)] bg-white px-6 py-3 text-[10px] font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)] transition hover:bg-[color:var(--foreground)] hover:text-white sm:px-8 sm:text-[11px] sm:tracking-[0.18em]"
+              className="site-pill-button text-[10px] uppercase tracking-[0.16em] sm:text-[11px] sm:tracking-[0.18em]"
               href="/about"
             >
               Começa Já


### PR DESCRIPTION
### Motivation

- Unify button appearance across the site by replacing repeated utility classes with a single reusable pill-style button class and stronger visual emphasis.
- Improve affordance and micro-interactions for primary CTAs with hover and active states.
- Simplify markup in header, top navigation and hero by using the shared class.

### Description

- Adds a new `.site-pill-button` CSS class in `app/globals.css` that defines a red pill-style button with hover, active and disabled states and replaces the previous Tailwind utility group used for these buttons. 
- Removes the previous generic button transition/hover rules and consolidates styling into `.site-pill-button` and `.button-size-login` with explicit properties, shadows and transforms. 
- Updates `HeaderActions.tsx`, `TopNav.tsx` and `page.tsx` to replace inline utility class strings with `className="site-pill-button ..."` and changes the header auth label from `Sign up` to `Login`.

### Testing

- Ran a local type-check and project build with `npm run build`, which completed successfully. 
- Executed linting with `npm run lint`, which reported no blocking issues. 
- Verified the affected pages render and the updated buttons respond to hover and active states in a local browser smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2340f1a34832e8110c1e9486e1418)