### PR TITLE
feat(dashboard): add animated red preference checkboxes

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -650,26 +650,40 @@ export default function DashboardPage() {
         <aside className="rounded-[32px] bg-white p-6 shadow-[0_20px_50px_rgba(31,41,55,0.08)]">
           <h3 className="card-title">Preferências</h3>
           <div className="mt-4 space-y-3">
-            <label className="flex items-center justify-between text-sm text-slate-700">
-              Receber newsletter
-
-              <input
-                className="h-4 w-4 accent-[color:var(--primary)]"
-                type="checkbox"
-                checked={preferences.receiveNewsletter}
-                onChange={() => handlePreferenceChange("receiveNewsletter")}
-              />
-            </label>
-            <label className="flex items-center justify-between text-sm text-slate-700">
-              Notificações da comunidade
-              <input
-                className="h-4 w-4 accent-[color:var(--primary)]"
-                type="checkbox"
-                checked={preferences.allowNotifications}
-                onChange={() => handlePreferenceChange("allowNotifications")}
-              />
-
-            </label>
+            <div className="flex items-center justify-between text-sm text-slate-700">
+              <label htmlFor="receive-newsletter">Receber newsletter</label>
+              <span className="checkbox-wrapper-12">
+                <span className="cbx">
+                  <input
+                    id="receive-newsletter"
+                    type="checkbox"
+                    checked={preferences.receiveNewsletter}
+                    onChange={() => handlePreferenceChange("receiveNewsletter")}
+                  />
+                  <label htmlFor="receive-newsletter" aria-hidden="true" />
+                  <svg viewBox="0 0 15 14" fill="none" aria-hidden="true">
+                    <path d="M2 8.36364L6.23077 12L13 2" />
+                  </svg>
+                </span>
+              </span>
+            </div>
+            <div className="flex items-center justify-between text-sm text-slate-700">
+              <label htmlFor="allow-notifications">Notificações da comunidade</label>
+              <span className="checkbox-wrapper-12">
+                <span className="cbx">
+                  <input
+                    id="allow-notifications"
+                    type="checkbox"
+                    checked={preferences.allowNotifications}
+                    onChange={() => handlePreferenceChange("allowNotifications")}
+                  />
+                  <label htmlFor="allow-notifications" aria-hidden="true" />
+                  <svg viewBox="0 0 15 14" fill="none" aria-hidden="true">
+                    <path d="M2 8.36364L6.23077 12L13 2" />
+                  </svg>
+                </span>
+              </span>
+            </div>
           </div>
         </aside>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -209,4 +209,117 @@ body {
   .section-label-uppercase {
     @apply text-sm font-semibold uppercase tracking-[0.3em] text-[color:var(--primary)];
   }
+
+
+  /* Estrutura o contêiner do checkbox animado e permite posicionamento relativo dos elementos internos. */
+  .checkbox-wrapper-12 {
+    position: relative;
+  }
+
+  /* Define cálculo de layout consistente para todos os elementos do componente. */
+  .checkbox-wrapper-12 * {
+    box-sizing: border-box;
+  }
+
+  /* Remove aparência nativa do checkbox para aplicar o visual personalizado e manter cursor de clique. */
+  .checkbox-wrapper-12 input[type="checkbox"] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    -webkit-tap-highlight-color: transparent;
+    cursor: pointer;
+    margin: 0;
+  }
+
+  /* Remove outline padrão no foco porque o estado visual já é comunicado pela animação do componente. */
+  .checkbox-wrapper-12 input[type="checkbox"]:focus {
+    outline: 0;
+  }
+
+  /* Define a área ativa do checkbox circular com dimensões fixas para alinhamento consistente. */
+  .checkbox-wrapper-12 .cbx {
+    position: relative;
+    width: 24px;
+    height: 24px;
+  }
+
+  /* Cria o contorno circular base do checkbox antes da seleção. */
+  .checkbox-wrapper-12 .cbx input {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 24px;
+    height: 24px;
+    border: 2px solid #bfbfc0;
+    border-radius: 50%;
+  }
+
+  /* Camada de fundo animada que recebe o splash vermelho quando o checkbox é marcado. */
+  .checkbox-wrapper-12 .cbx > label {
+    width: 24px;
+    height: 24px;
+    background: none;
+    border-radius: 50%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translate3d(0, 0, 0);
+    pointer-events: none;
+  }
+
+  /* Posiciona o ícone de confirmação dentro do círculo. */
+  .checkbox-wrapper-12 .cbx svg {
+    position: absolute;
+    top: 5px;
+    left: 4px;
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  /* Configura o traço do check para animação progressiva no estado marcado. */
+  .checkbox-wrapper-12 .cbx svg path {
+    stroke: #ffffff;
+    stroke-width: 3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 19;
+    stroke-dashoffset: 19;
+    transition: stroke-dashoffset 0.3s ease;
+    transition-delay: 0.2s;
+  }
+
+  /* Dispara a animação de splash vermelho ao marcar o checkbox. */
+  .checkbox-wrapper-12 .cbx input:checked + label {
+    animation: splash-12 0.6s ease forwards;
+  }
+
+  /* Revela o ícone de check ao concluir a marcação. */
+  .checkbox-wrapper-12 .cbx input:checked + label + svg path {
+    stroke-dashoffset: 0;
+  }
+
+  /* Cria a expansão radial vermelha durante a seleção do checkbox. */
+  @keyframes splash-12 {
+    40% {
+      background: #dc2626;
+      box-shadow:
+        0 -18px 0 -8px #dc2626,
+        16px -8px 0 -8px #dc2626,
+        16px 8px 0 -8px #dc2626,
+        0 18px 0 -8px #dc2626,
+        -16px 8px 0 -8px #dc2626,
+        -16px -8px 0 -8px #dc2626;
+    }
+
+    100% {
+      background: #dc2626;
+      box-shadow:
+        0 -36px 0 -10px transparent,
+        32px -16px 0 -10px transparent,
+        32px 16px 0 -10px transparent,
+        0 36px 0 -10px transparent,
+        -32px 16px 0 -10px transparent,
+        -32px -16px 0 -10px transparent;
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace plain native checkboxes in the dashboard "Preferências" panel with a Uiverse-style animated checkbox that uses a red splash visual to match the project look. 
- Provide a reusable CSS component so the animated checkbox can be reused elsewhere in the app while keeping the same preference state behaviour.

### Description
- Replaced the two native inputs in `app/dashboard/page.tsx` with structured markup using `checkbox-wrapper-12` and `cbx` wrappers, SVG check icon, explicit `id`/`htmlFor` attributes and `aria-hidden` labels to keep accessibility and state handlers intact.  
- Added the animated checkbox styles to `app/globals.css`, implementing the reset of native appearance, circular visual, animated check stroke and `@keyframes splash-12` adapted to the red tone `#dc2626`.  
- Preserved existing preference state and handlers (`preferences.receiveNewsletter`, `preferences.allowNotifications`, and `handlePreferenceChange`) without changing application logic.  

### Testing
- Ran `npm run lint` which failed because `next` is not available in the current environment so lint could not execute (failure).  
- Attempted `npm ci` which failed due to a `403 Forbidden` fetching the `pg` package from the registry, preventing dependency installation (failure).  
- Tried a Playwright screenshot of `http://127.0.0.1:3000/dashboard` which failed with `net::ERR_EMPTY_RESPONSE` because the app could not be started in this environment (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23c770060832e8d3db7e655d5d9a7)