### PR TITLE
Adjust header controls to share same height

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,7 @@
   --primary-soft: #f0f0f0;
   --accent: #f44336;
   --line: #d5d5d5;
+  --header-control-height: 36px;
   color-scheme: light;
 }
 
@@ -44,9 +45,10 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    height: var(--header-control-height);
     border: 0;
     border-radius: 100px;
-    padding: 12.5px 30px;
+    padding: 0 30px;
     background-color: #dc2626 !important;
     color: #ffffff !important;
     font-size: 0.875rem;
@@ -89,8 +91,8 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 56px;
-    height: 56px;
+    width: var(--header-control-height);
+    height: var(--header-control-height);
     border: 1px solid #fecaca;
     border-radius: 14px;
     background-color: #ffffff;


### PR DESCRIPTION
### Motivation
- Garantir que o botão de menu (mobile) e os controles do cabeçalho (ex.: botão de login) tenham exatamente a mesma altura para alinhamento visual consistente.

### Description
- Adicionei a variável CSS `--header-control-height: 36px` em `:root` e atualizei `app/globals.css` para aplicar `height: var(--header-control-height)` em `.site-pill-button`/`.button-size-login` e para usar `width`/`height: var(--header-control-height)` em `.menu-toggle-button`, além de ajustar `padding` para manter alinhamento do texto.

### Testing
- Rodei `git show`/commit localmente e confirmei a alteração em `app/globals.css`; não foi possível executar `npm run -s lint` porque o ambiente não tem `next`/dependências instaladas; o comando `npm ci` falhou com `403 Forbidden` ao tentar acessar o registry npm; a verificação visual por Playwright falhou porque não havia servidor em `http://127.0.0.1:3000`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2407ed0e0832e934d4d04f4e87017)