### PR TITLE
Remove border from mobile hamburger toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -86,24 +86,23 @@ body {
     box-shadow: none;
   }
 
-  /* Define botão quadrado com fundo branco para destacar apenas o símbolo vermelho. */
+  /* Mantém apenas a área clicável do botão, sem moldura visual. */
   .menu-toggle-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: var(--header-control-height);
     height: var(--header-control-height);
-    border: 1px solid #fecaca;
-    border-radius: 14px;
-    background-color: #ffffff;
+    border: 0;
+    border-radius: 0;
+    background-color: transparent;
     cursor: pointer;
     transition: all 0.3s ease;
   }
 
-  /* Aplica hover suave com sombra vermelha para reforçar interatividade. */
+  /* Mantém feedback no hover sem adicionar borda ou contorno extra. */
   .menu-toggle-button:hover {
-    box-shadow: 0 0 20px rgb(239 68 68 / 22%);
-    border-color: #f87171;
+    opacity: 0.85;
   }
 
   /* Organiza as barras do ícone hamburguer sem texto associado. */


### PR DESCRIPTION
### Motivation
- Present only the three horizontal bars for the mobile menu toggle by removing the visual frame so the control matches the intended minimalist design.

### Description
- Modified `app/globals.css` to remove the visible frame from `.menu-toggle-button` by setting `border: 0`, `border-radius: 0`, and `background-color: transparent`, and replaced the hover `box-shadow` effect with a simple `opacity: 0.85` to retain feedback while avoiding a border-like appearance.

### Testing
- Ran `npm run -s lint`, which failed in this environment due to a missing `next` binary; and attempted a Playwright screenshot of `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because the application server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30861d984832e8a6f296d7f8c9144)