### PR TITLE
Remove sidebar social markers and header search/heart icons

### DIFF
--- a/app/components/HeaderActions.tsx
+++ b/app/components/HeaderActions.tsx
@@ -46,14 +46,6 @@ export default function HeaderActions() {
 
   return (
     <div className="flex items-center gap-2 sm:gap-3">
-      {/* Apresenta ícones minimalistas para simular a zona de utilitários do cabeçalho de moda. */}
-      <span aria-hidden className="hidden text-lg text-[color:var(--foreground)] md:inline">
-        ⌕
-      </span>
-      <span aria-hidden className="hidden text-lg text-[color:var(--foreground)] md:inline">
-        ♡
-      </span>
-
       {!sessionUser ? (
         <Link
           className="site-pill-button text-[10px] uppercase tracking-[0.14em] sm:text-[11px] sm:tracking-[0.15em]"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,17 +19,12 @@ export default function HomePage() {
         />
       </div>
 
-      {/* Constrói a coluna lateral com texto vertical e marcadores sociais, sem a linha vertical preta. */}
+      {/* Constrói a coluna lateral apenas com texto vertical, sem marcadores sociais. */}
       <aside className="relative z-10 hidden py-8 lg:flex lg:flex-col lg:items-center lg:justify-between">
         <p className="vertical-text text-[10px] font-semibold uppercase tracking-[0.35em] text-[color:var(--foreground)]">
           Bad Co.
         </p>
 
-        <div className="flex flex-col items-center gap-5 text-xs text-[color:var(--foreground)]">
-          <span aria-hidden>f</span>
-          <span aria-hidden>t</span>
-          <span aria-hidden>◎</span>
-        </div>
       </aside>
 
       {/* Mantém o conteúdo textual em primeiro plano para legibilidade sobre a imagem de fundo. */}


### PR DESCRIPTION
### Motivation
- Limpar a interface removendo marcadores sociais decorativos na sidebar da homepage e ícones utilitários (pesquisa/coração) no cabeçalho para um visual mais minimal.

### Description
- Removed the `f`, `t` and `◎` markers from the homepage sidebar in `app/page.tsx` and updated the aside comment to reflect the change.
- Removed the search (`⌕`) and heart (`♡`) spans from `app/components/HeaderActions.tsx` while preserving the existing `Login` / `Dashboard` behavior and session logic.

### Testing
- Ran `npm run lint`, which failed because the `next` binary is not available in the environment (dependencies not installed).
- Ran `npm install`, which failed with `403 Forbidden` while fetching `pg` from the npm registry, blocking dependency installation.
- Attempted to capture a homepage screenshot via Playwright, which failed with `ERR_EMPTY_RESPONSE` because the app was not responding on `http://127.0.0.1:3000`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a37121a4e8832e824679de5ed12ac5)