### PR TITLE
Remove 'Bad Co.' side label and shift hero image left

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,11 @@ import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <section className="relative grid min-h-[calc(100vh-110px)] gap-8 overflow-hidden px-1 pb-8 pt-1 sm:px-3 lg:min-h-[calc(100vh-120px)] lg:grid-cols-[88px_1fr]">
+    <section className="relative grid min-h-[calc(100vh-110px)] gap-8 overflow-hidden px-1 pb-8 pt-1 sm:px-3 lg:min-h-[calc(100vh-120px)]">
       {/* Mostra a imagem no desktop sem gradiente para evitar qualquer transparência lateral. */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 right-0 hidden w-[min(46vw,620px)] lg:block"
+        className="pointer-events-none absolute inset-y-0 hidden w-[min(46vw,620px)] lg:right-8 lg:block xl:right-12"
       >
         <Image
           alt="Cliente mistério em destaque"
@@ -18,14 +18,6 @@ export default function HomePage() {
           src="/images/IMG_2622.png"
         />
       </div>
-
-      {/* Constrói a coluna lateral apenas com texto vertical, sem marcadores sociais. */}
-      <aside className="relative z-10 hidden py-8 lg:flex lg:flex-col lg:items-center lg:justify-between">
-        <p className="vertical-text text-[10px] font-semibold uppercase tracking-[0.35em] text-[color:var(--foreground)]">
-          Bad Co.
-        </p>
-
-      </aside>
 
       {/* Mantém o conteúdo textual em primeiro plano para legibilidade sobre a imagem de fundo. */}
       <div className="relative z-10 grid items-start gap-8 pb-8 lg:items-center lg:gap-10">


### PR DESCRIPTION
### Motivation
- The hero layout should not show the vertical side label `Bad Co.` and the desktop image should sit closer to the main text for better visual balance.
- Simplify the hero grid so the main content and image are aligned without an unused sidebar column.

### Description
- Removed the `<aside>` block that rendered the vertical `Bad Co.` label from `app/page.tsx`.
- Eliminated the extra sidebar grid column by removing `lg:grid-cols-[88px_1fr]` from the section class in `app/page.tsx`.
- Shifted the desktop hero image left by replacing the previous `right-0` positioning with responsive offsets `lg:right-8` and `xl:right-12` on the image container in `app/page.tsx`.
- The single modified file is `app/page.tsx` and the updated file retains the mobile image block and text content intact.

### Testing
- Ran `npm run lint`, which failed because `next` is not available in the current environment (error: `sh: 1: next: not found`).
- Attempted `npm ci`, which failed due to `package.json` and `package-lock.json` being out of sync (lockfile mismatch errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a56cc8fed4832e8ed6fa8b1102bdff)