### PR TITLE
Align header and hero layout to match reference composition

### DIFF
--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -22,7 +22,7 @@ export default function TopNav() {
 
   return (
     <>
-      {/* Exibe botão de menu apenas no mobile com ícone puro, sem texto visível. */}
+      {/* Exibe botão hamburguer apenas no mobile para manter o desktop limpo e alinhado ao centro. */}
       <button
         aria-expanded={isMenuOpen}
         aria-label="Abrir menu principal"
@@ -37,15 +37,15 @@ export default function TopNav() {
         </span>
       </button>
 
-      {/* Mantém navegação horizontal no desktop para preservar o layout editorial. */}
-      <nav className="hidden items-center gap-8 lg:flex">
+      {/* Mantém os links centrados no desktop e destaca a página ativa com sublinhado. */}
+      <nav className="hidden items-center justify-center gap-8 xl:gap-10 lg:flex">
         {navigationItems.map((item) => {
           const isActive = pathname === item.href;
 
           return (
             <Link
               key={item.href}
-              className={`text-[11px] font-semibold uppercase tracking-[0.18em] transition ${
+              className={`relative pb-2 text-[14px] font-semibold transition ${
                 isActive
                   ? "text-[color:var(--accent)]"
                   : "text-[color:var(--foreground)] hover:text-[color:var(--accent)]"
@@ -53,12 +53,16 @@ export default function TopNav() {
               href={item.href}
             >
               {item.label}
+
+              {isActive ? (
+                <span className="absolute inset-x-0 -bottom-[2px] h-[2px] bg-[color:var(--accent)]" />
+              ) : null}
             </Link>
           );
         })}
       </nav>
 
-      {/* Renderiza menu em coluna no mobile com texto vermelho e estilo do mockup. */}
+      {/* Renderiza menu vertical no mobile com área clicável confortável e ordem visual consistente. */}
       {isMenuOpen ? (
         <nav className="mobile-menu-container absolute inset-x-4 top-[84px] z-40 flex flex-col overflow-hidden rounded-[10px] border border-[color:var(--line)] bg-[color:var(--surface)] shadow-sm lg:hidden">
           {navigationItems.map((item, index) => {
@@ -68,7 +72,7 @@ export default function TopNav() {
             return (
               <Link
                 key={item.href}
-                className={`mobile-menu-item px-5 py-4 text-[11px] font-semibold uppercase tracking-[0.18em] transition ${
+                className={`mobile-menu-item px-5 py-4 text-sm font-semibold transition ${
                   isActive
                     ? "text-[#b91c1c]"
                     : "text-[color:var(--accent)] hover:bg-red-50"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,21 +38,34 @@ export default function RootLayout({
       <body
         className={`${montserrat.variable} ${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
       >
-        {/* Desenha o container principal sem moldura para remover a linha vermelha externa. */}
+        {/* Limita a largura máxima da página para manter o mesmo eixo de alinhamento da referência. */}
         <div className="mx-auto min-h-screen w-full max-w-[1400px] bg-[color:var(--background)]">
-          {/* Cria a faixa superior com navegação central e ações discretas à direita. */}
-          <header className="relative flex items-center justify-between gap-3 px-4 py-5 sm:px-6 md:px-10 md:py-6">
+          {/* Estrutura o cabeçalho em três áreas (logo, menu, ação) para manter disposição equilibrada no desktop. */}
+          <header className="relative grid grid-cols-[1fr_auto] items-center gap-3 px-4 py-5 sm:px-6 md:px-10 md:py-6 lg:grid-cols-[minmax(220px,1fr)_auto_minmax(180px,1fr)]">
             <a
               className="text-[10px] font-black uppercase tracking-[0.28em] text-[color:var(--foreground)] sm:text-xs sm:tracking-[0.35em]"
               href="/"
             >
               Cliente Mistério
             </a>
-            <TopNav />
-            <HeaderActions />
+
+            {/* Mantém o menu no centro em ecrãs grandes e no lado direito em ecrãs pequenos. */}
+            <div className="justify-self-end lg:justify-self-center">
+              <TopNav />
+            </div>
+
+            {/* Alinha o botão de ação à direita para reproduzir a hierarquia visual do exemplo. */}
+            <div className="hidden lg:flex lg:justify-self-end">
+              <HeaderActions />
+            </div>
+
+            {/* Mantém as ações disponíveis no mobile sem quebrar o layout do menu hamburguer. */}
+            <div className="justify-self-end lg:hidden">
+              <HeaderActions />
+            </div>
           </header>
 
-          {/* Renderiza o conteúdo da página respeitando a largura do layout editorial. */}
+          {/* Renderiza o conteúdo principal sem deslocar o eixo de alinhamento lateral. */}
           <main className="px-4 pb-10 sm:px-6 md:px-10">{children}</main>
         </div>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,11 @@ import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <section className="px-4 pb-10 pt-2 sm:px-6 lg:px-8">
-      {/* Centraliza o conteúdo numa largura máxima para aproximar texto e imagem em ecrãs grandes. */}
-      <div className="mx-auto grid min-h-[calc(100vh-120px)] w-full max-w-6xl items-center gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(340px,480px)] lg:gap-10">
-        {/* Mantém o bloco textual com largura controlada para preservar legibilidade e hierarquia visual. */}
-        <article className="max-w-xl bg-white p-4 shadow-[0_0_0_1px_rgba(0,0,0,0.03)] sm:p-5 lg:bg-transparent lg:p-0 lg:shadow-none">
+    <section className="px-0 pb-10 pt-2">
+      {/* Cria duas colunas no desktop para posicionar o conteúdo textual à esquerda e a imagem à direita. */}
+      <div className="mx-auto grid min-h-[calc(100vh-130px)] w-full max-w-6xl items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(420px,520px)] lg:gap-12">
+        {/* Mantém o bloco textual encostado ao lado esquerdo para reproduzir o alinhamento da referência. */}
+        <article className="max-w-[640px] pt-6 lg:pt-0">
           <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)] sm:text-[11px] sm:tracking-[0.28em]">
             Novo Curso
           </p>
@@ -16,11 +16,11 @@ export default function HomePage() {
             O único curso de <span className="text-[color:var(--accent)]">cliente mistério</span> em Portugal
           </h1>
 
-          <p className="mt-5 text-sm font-medium text-[#4a4a4a] sm:mt-6 sm:text-base">
+          <p className="mt-8 max-w-[560px] text-base font-medium leading-relaxed text-[#4a4a4a]">
             Sê dos primeiros Clientes Mistério certificados!
           </p>
 
-          <div className="mt-7 sm:mt-8">
+          <div className="mt-10">
             <Link
               className="site-pill-button text-[10px] uppercase tracking-[0.16em] sm:text-[11px] sm:tracking-[0.18em]"
               href="/about"
@@ -30,14 +30,14 @@ export default function HomePage() {
           </div>
         </article>
 
-        {/* Reserva uma coluna fixa para a imagem no desktop para reduzir o espaço vazio entre blocos. */}
-        <div className="relative mx-auto h-[340px] w-full max-w-[360px] sm:h-[420px] sm:max-w-[420px] lg:h-[680px] lg:max-w-[480px]">
+        {/* Reserva uma área alta para a imagem e ancora o conteúdo no fundo para equilibrar a composição. */}
+        <div className="relative mx-auto h-[360px] w-full max-w-[390px] sm:h-[460px] sm:max-w-[440px] lg:h-[720px] lg:max-w-[520px]">
           <Image
             alt="Cliente mistério em destaque"
             className="object-contain object-bottom lg:object-right-bottom"
             fill
             priority
-            sizes="(max-width: 640px) 90vw, (max-width: 1024px) 70vw, 480px"
+            sizes="(max-width: 640px) 92vw, (max-width: 1024px) 68vw, 520px"
             src="/images/IMG_2622.png"
           />
         </div>


### PR DESCRIPTION
### Motivation
- Adjust the page header and hero so the brand, navigation and call-to-action align and the hero text sits left with the image anchored to the right matching the provided reference image.

### Description
- Reorganized the header into a three-zone grid so brand, centered nav and right-side actions align consistently by editing `app/layout.tsx`.
- Centered desktop navigation and added an active-link underline and spacing tweaks in `app/components/TopNav.tsx` for a cleaner horizontal distribution.
- Resized and re-spaced the hero columns, tightened text width and increased image container sizing and `sizes` hints in `app/page.tsx` to reproduce the visual balance of the reference.
- Kept all changes responsive and preserved existing button and mobile menu behavior while improving desktop alignment.

### Testing
- Ran `npm run lint` which failed because the `next` binary is not available in this environment so lint could not complete.
- Attempted `npm install` which failed with a `403 Forbidden` from the npm registry preventing dependency installation and further local validation.
- Tried an automated Playwright screenshot of `http://127.0.0.1:3000` which failed with an empty response because no dev server was running in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ed1651d0832e97e77f594641aae3)