### PR TITLE
Align header logo and login button with hero section edges

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,30 +38,32 @@ export default function RootLayout({
       <body
         className={`${montserrat.variable} ${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
       >
-        {/* Limita a largura máxima da página para manter o mesmo eixo de alinhamento da referência. */}
+        {/* Mantém o fundo em largura total enquanto o conteúdo segue os mesmos eixos do hero. */}
         <div className="mx-auto min-h-screen w-full max-w-[1400px] bg-[color:var(--background)]">
-          {/* Estrutura o cabeçalho em três áreas (logo, menu, ação) para manter disposição equilibrada no desktop. */}
-          <header className="relative grid grid-cols-[1fr_auto] items-center gap-3 px-4 py-5 sm:px-6 md:px-10 md:py-6 lg:grid-cols-[minmax(220px,1fr)_auto_minmax(180px,1fr)]">
-            <a
-              className="text-[10px] font-black uppercase tracking-[0.28em] text-[color:var(--foreground)] sm:text-xs sm:tracking-[0.35em]"
-              href="/"
-            >
-              Cliente Mistério
-            </a>
+          {/* Usa o mesmo content width do hero para alinhar logo com texto e ação com a imagem. */}
+          <header className="px-4 py-5 sm:px-6 md:px-10 md:py-6">
+            <div className="relative mx-auto grid w-full max-w-6xl grid-cols-[1fr_auto] items-center gap-3 lg:grid-cols-[minmax(220px,1fr)_auto_minmax(180px,1fr)]">
+              <a
+                className="text-[10px] font-black uppercase tracking-[0.28em] text-[color:var(--foreground)] sm:text-xs sm:tracking-[0.35em]"
+                href="/"
+              >
+                Cliente Mistério
+              </a>
 
-            {/* Mantém o menu no centro em ecrãs grandes e no lado direito em ecrãs pequenos. */}
-            <div className="justify-self-end lg:justify-self-center">
-              <TopNav />
-            </div>
+              {/* Mantém o menu no centro em ecrãs grandes e no lado direito em ecrãs pequenos. */}
+              <div className="justify-self-end lg:justify-self-center">
+                <TopNav />
+              </div>
 
-            {/* Alinha o botão de ação à direita para reproduzir a hierarquia visual do exemplo. */}
-            <div className="hidden lg:flex lg:justify-self-end">
-              <HeaderActions />
-            </div>
+              {/* Alinha o botão de ação ao limite direito do content width para coincidir com a imagem. */}
+              <div className="hidden lg:flex lg:justify-self-end">
+                <HeaderActions />
+              </div>
 
-            {/* Mantém as ações disponíveis no mobile sem quebrar o layout do menu hamburguer. */}
-            <div className="justify-self-end lg:hidden">
-              <HeaderActions />
+              {/* Mantém as ações disponíveis no mobile sem quebrar o layout do menu hamburguer. */}
+              <div className="justify-self-end lg:hidden">
+                <HeaderActions />
+              </div>
             </div>
           </header>
 


### PR DESCRIPTION
### Motivation
- Garantir que o logo fique alinhado com a extrema esquerda da secção de texto do hero e que o botão de ação (Login/Dashboard) fique alinhado com a borda da imagem no desktop.
- Manter a estrutura responsiva existente sem alterar a lógica de navegação ou autenticação, apenas ajustando o enquadramento horizontal do cabeçalho.

### Description
- Envolvi o conteúdo do `header` num container centralizado `max-w-6xl` para usar o mesmo content width do hero e assim alinhar os eixos (`app/layout.tsx`).
- Substituí o `header` em grid direto por um `header` com padding que contém uma `div` interna `mx-auto grid w-full max-w-6xl grid-cols-[1fr_auto]` para preservar o layout de três áreas em desktop e alinhar logo/menu/ações.
- Preservei o comportamento responsivo atual (menu centrado em `lg`, ações separadas para desktop/mobile) e não alterei componentes `TopNav` ou `HeaderActions`.

### Testing
- Executado `npm run lint`, que falhou porque o binário `next` não está disponível sem instalar dependências (falha esperada no ambiente atual).
- Tentado `npm ci`, que falhou com `403 Forbidden` ao aceder ao registry npm impedindo a instalação das dependências (falha por restrição de rede).
- Tentado captura com Playwright (`page.goto('http://127.0.0.1:3000')`), que falhou com `ERR_EMPTY_RESPONSE` porque a aplicação não estava a correr nesta porta (falha por app não estar em execução).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6f2965370832e9d71a7c05d16cd9f)