### PR TITLE
Remove email confirmation requirement on signup

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -22,7 +22,6 @@ type UserRow = {
   profile_completed: boolean;
   is_admin: boolean;
   password_hash: string;
-  email_confirmed: boolean;
 };
 
 export const POST = async (request: Request) => {
@@ -38,7 +37,7 @@ export const POST = async (request: Request) => {
 
   const normalizedEmail = payload.email.trim().toLowerCase();
   const result = await query<UserRow>(
-    `select id, first_name, last_name, full_name, email, birth_date, city, gender, education_level, profile_completed, is_admin, password_hash, email_confirmed
+    `select id, first_name, last_name, full_name, email, birth_date, city, gender, education_level, profile_completed, is_admin, password_hash
      from users
      where email = $1`,
     [normalizedEmail]
@@ -53,12 +52,6 @@ export const POST = async (request: Request) => {
     );
   }
 
-  if (!user.email_confirmed) {
-    return NextResponse.json(
-      { message: "Confirme o seu e-mail antes de iniciar sessão." },
-      { status: 403 }
-    );
-  }
 
   try {
     // Cria a sessão autenticada e evita quebra total caso haja erro de configuração.

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
 
-import { createEmailConfirmationTemplate } from "@/lib/authEmail";
 import { query } from "@/lib/database";
-import { sendEmail } from "@/lib/email";
 import { hashPassword } from "@/lib/password";
-import { createToken, hashToken } from "@/lib/token";
 
 type RegisterPayload = {
   firstName: string;
@@ -57,8 +54,6 @@ export const POST = async (request: Request) => {
   const lastName = payload.lastName.trim();
   const fullName = `${firstName} ${lastName}`.trim();
   const passwordHash = hashPassword(payload.password);
-  const confirmationToken = createToken();
-  const confirmationTokenHash = hashToken(confirmationToken);
   const firstAdminEmail = process.env.ADMIN_EMAIL?.trim().toLowerCase();
   const shouldBeAdmin = Boolean(firstAdminEmail) && normalizedEmail === firstAdminEmail;
 
@@ -71,32 +66,15 @@ export const POST = async (request: Request) => {
       password_hash,
       profile_completed,
       email_confirmed,
-      email_confirmation_token_hash,
-      email_confirmation_sent_at,
       is_admin
     )
-     values ($1, $2, $3, $4, $5, false, false, $6, now(), $7)
+     values ($1, $2, $3, $4, $5, false, true, $6)
      returning id, first_name, last_name, full_name, email, is_admin, created_at`,
-    [firstName, lastName, fullName, normalizedEmail, passwordHash, confirmationTokenHash, shouldBeAdmin]
+    [firstName, lastName, fullName, normalizedEmail, passwordHash, shouldBeAdmin]
   );
 
-  try {
-    // Envia e-mail de confirmação para bloquear login até validação da conta.
-    const template = createEmailConfirmationTemplate(confirmationToken);
-    await sendEmail({
-      to: normalizedEmail,
-      subject: template.subject,
-      html: template.html,
-    });
-  } catch {
-    return NextResponse.json(
-      { message: "Conta criada, mas não foi possível enviar o e-mail de confirmação." },
-      { status: 500 }
-    );
-  }
-
   return NextResponse.json({
-    message: "Conta criada com sucesso. Confirme o e-mail para ativar o acesso.",
+    message: "Conta criada com sucesso. Já pode iniciar sessão.",
     user: {
       id: result.rows[0]?.id,
       firstName: result.rows[0]?.first_name,

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -47,18 +47,8 @@ export default function LoginPage() {
     const urlParameters = new URLSearchParams(window.location.search);
 
     if (urlParameters.get("registered") === "1") {
-      // Exibe orientação após registo para o utilizador confirmar o e-mail.
-      setFeedback("Conta criada com sucesso. Verifique o e-mail para confirmar a conta.");
-    }
-
-    if (urlParameters.get("confirmed") === "1") {
-      // Mostra confirmação quando o utilizador valida a conta pelo link enviado.
-      setFeedback("Conta confirmada com sucesso. Já pode iniciar sessão.");
-    }
-
-    if (urlParameters.get("confirmed") === "0") {
-      // Informa token inválido ou expirado no fluxo de confirmação de conta.
-      setFeedback("Link de confirmação inválido ou expirado.");
+      // Exibe confirmação de registo concluído e acesso imediato ao login.
+      setFeedback("Conta criada com sucesso. Já pode iniciar sessão.");
     }
 
     // Mantém o utilizador autenticado ao regressar ao ecrã de login.


### PR DESCRIPTION
### Motivation
- Simplificar o fluxo de registo para permitir que novos utilizadores iniciem sessão imediatamente sem depender da confirmação por e-mail.
- Remover a geração e armazenamento de tokens de confirmação e o envio do e-mail de ativação, mantendo intactas as restantes funcionalidades de autenticação.

### Description
- Atualiza o endpoint `POST /api/auth/register` para gravar novos utilizadores com `email_confirmed = true` e elimina a geração de `confirmationToken` e o envio de e-mail de confirmação, ajustando os parâmetros SQL de inserção em `app/api/auth/register/route.ts`.
- Remove a validação que bloqueava o login quando `email_confirmed` era `false` do endpoint `POST /api/auth/login` em `app/api/auth/login/route.ts`.
- Atualiza a mensagem e o comportamento na página de login para refletir o acesso imediato após registo e remove o tratamento de query strings relacionadas com confirmação em `app/login/page.tsx`.
- Mantém inalteradas as funcionalidades de reposição de password e envio de e-mails de recuperação.

### Testing
- Executei `npm run lint` e a verificação falhou devido a `next` não estar instalado no ambiente local (`sh: 1: next: not found`).
- Tentei `npm ci` e a instalação das dependências falhou por restrição de acesso ao registry (`403 Forbidden - GET https://registry.npmjs.org/pg`).
- Não foram executados testes automatizados adicionais neste ambiente por falta de dependências e restrições de rede.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7009f742c832eabd0ad8534d15cbb)