### PR TITLE
Update preference checkboxes to red Uiverse-style custom checkboxes

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -652,37 +652,29 @@ export default function DashboardPage() {
           <div className="mt-4 space-y-3">
             <div className="flex items-center justify-between text-sm text-slate-700">
               <label htmlFor="receive-newsletter">Receber newsletter</label>
-              <span className="checkbox-wrapper-12">
-                <span className="cbx">
-                  <input
-                    id="receive-newsletter"
-                    type="checkbox"
-                    checked={preferences.receiveNewsletter}
-                    onChange={() => handlePreferenceChange("receiveNewsletter")}
-                  />
-                  <label htmlFor="receive-newsletter" aria-hidden="true" />
-                  <svg viewBox="0 0 15 14" fill="none" aria-hidden="true">
-                    <path d="M2 8.36364L6.23077 12L13 2" />
-                  </svg>
-                </span>
-              </span>
+              <label className="checkbox-container" htmlFor="receive-newsletter">
+                <input
+                  id="receive-newsletter"
+                  className="custom-checkbox"
+                  type="checkbox"
+                  checked={preferences.receiveNewsletter}
+                  onChange={() => handlePreferenceChange("receiveNewsletter")}
+                />
+                <span className="checkmark" aria-hidden="true" />
+              </label>
             </div>
             <div className="flex items-center justify-between text-sm text-slate-700">
               <label htmlFor="allow-notifications">Notificações da comunidade</label>
-              <span className="checkbox-wrapper-12">
-                <span className="cbx">
-                  <input
-                    id="allow-notifications"
-                    type="checkbox"
-                    checked={preferences.allowNotifications}
-                    onChange={() => handlePreferenceChange("allowNotifications")}
-                  />
-                  <label htmlFor="allow-notifications" aria-hidden="true" />
-                  <svg viewBox="0 0 15 14" fill="none" aria-hidden="true">
-                    <path d="M2 8.36364L6.23077 12L13 2" />
-                  </svg>
-                </span>
-              </span>
+              <label className="checkbox-container" htmlFor="allow-notifications">
+                <input
+                  id="allow-notifications"
+                  className="custom-checkbox"
+                  type="checkbox"
+                  checked={preferences.allowNotifications}
+                  onChange={() => handlePreferenceChange("allowNotifications")}
+                />
+                <span className="checkmark" aria-hidden="true" />
+              </label>
             </div>
           </div>
         </aside>

--- a/app/globals.css
+++ b/app/globals.css
@@ -184,115 +184,78 @@ body {
   }
 
 
-  /* Estrutura o contêiner do checkbox animado e permite posicionamento relativo dos elementos internos. */
-  .checkbox-wrapper-12 {
+  /* Mantém o contêiner do checkbox alinhado com o texto e reserva espaço para o marcador customizado. */
+  .checkbox-container {
+    display: inline-block;
     position: relative;
-  }
-
-  /* Define cálculo de layout consistente para todos os elementos do componente. */
-  .checkbox-wrapper-12 * {
-    box-sizing: border-box;
-  }
-
-  /* Remove aparência nativa do checkbox para aplicar o visual personalizado e manter cursor de clique. */
-  .checkbox-wrapper-12 input[type="checkbox"] {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    -webkit-tap-highlight-color: transparent;
+    width: 25px;
+    height: 25px;
     cursor: pointer;
-    margin: 0;
+    user-select: none;
   }
 
-  /* Remove outline padrão no foco porque o estado visual já é comunicado pela animação do componente. */
-  .checkbox-wrapper-12 input[type="checkbox"]:focus {
-    outline: 0;
+  /* Esconde o input nativo mas preserva acessibilidade e interação por teclado. */
+  .custom-checkbox {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
   }
 
-  /* Define a área ativa do checkbox circular com dimensões fixas para alinhamento consistente. */
-  .checkbox-wrapper-12 .cbx {
-    position: relative;
-    width: 24px;
-    height: 24px;
-  }
-
-  /* Cria o contorno circular base do checkbox antes da seleção. */
-  .checkbox-wrapper-12 .cbx input {
+  /* Cria a caixa visual padrão do checkbox com cantos arredondados e sombra suave. */
+  .checkbox-container .checkmark {
     position: absolute;
     top: 0;
     left: 0;
-    width: 24px;
-    height: 24px;
-    border: 2px solid #bfbfc0;
-    border-radius: 50%;
+    height: 25px;
+    width: 25px;
+    background-color: #eee;
+    border-radius: 4px;
+    transition: background-color 0.3s;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   }
 
-  /* Camada de fundo animada que recebe o splash vermelho quando o checkbox é marcado. */
-  .checkbox-wrapper-12 .cbx > label {
-    width: 24px;
-    height: 24px;
-    background: none;
-    border-radius: 50%;
+  /* Desenha o ícone de confirmação e mantém oculto até o estado marcado. */
+  .checkbox-container .checkmark::after {
+    content: "";
     position: absolute;
-    top: 0;
-    left: 0;
-    transform: translate3d(0, 0, 0);
-    pointer-events: none;
-  }
-
-  /* Posiciona o ícone de confirmação dentro do círculo. */
-  .checkbox-wrapper-12 .cbx svg {
-    position: absolute;
+    display: none;
+    left: 9px;
     top: 5px;
-    left: 4px;
-    z-index: 1;
-    pointer-events: none;
+    width: 5px;
+    height: 10px;
+    border: solid #fff;
+    border-width: 0 3px 3px 0;
+    transform: rotate(45deg);
   }
 
-  /* Configura o traço do check para animação progressiva no estado marcado. */
-  .checkbox-wrapper-12 .cbx svg path {
-    stroke: #ffffff;
-    stroke-width: 3;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-dasharray: 19;
-    stroke-dashoffset: 19;
-    transition: stroke-dashoffset 0.3s ease;
-    transition-delay: 0.2s;
+  /* Aplica o tom vermelho solicitado e reforça destaque visual quando selecionado. */
+  .custom-checkbox:checked ~ .checkmark {
+    background-color: #dc2626;
+    box-shadow: 0 3px 7px rgba(220, 38, 38, 0.3);
   }
 
-  /* Dispara a animação de splash vermelho ao marcar o checkbox. */
-  .checkbox-wrapper-12 .cbx input:checked + label {
-    animation: splash-12 0.6s ease forwards;
+  /* Exibe o check e dispara animação curta para feedback da seleção. */
+  .custom-checkbox:checked ~ .checkmark::after {
+    display: block;
+    animation: check-anim 0.2s forwards;
   }
 
-  /* Revela o ícone de check ao concluir a marcação. */
-  .checkbox-wrapper-12 .cbx input:checked + label + svg path {
-    stroke-dashoffset: 0;
+  /* Remove contorno padrão e usa anel customizado para foco acessível. */
+  .custom-checkbox:focus-visible ~ .checkmark {
+    outline: 2px solid #dc2626;
+    outline-offset: 2px;
   }
 
-  /* Cria a expansão radial vermelha durante a seleção do checkbox. */
-  @keyframes splash-12 {
-    40% {
-      background: #dc2626;
-      box-shadow:
-        0 -18px 0 -8px #dc2626,
-        16px -8px 0 -8px #dc2626,
-        16px 8px 0 -8px #dc2626,
-        0 18px 0 -8px #dc2626,
-        -16px 8px 0 -8px #dc2626,
-        -16px -8px 0 -8px #dc2626;
+  /* Faz o traço do check crescer verticalmente para simular desenho do ícone. */
+  @keyframes check-anim {
+    0% {
+      height: 0;
     }
 
     100% {
-      background: #dc2626;
-      box-shadow:
-        0 -36px 0 -10px transparent,
-        32px -16px 0 -10px transparent,
-        32px 16px 0 -10px transparent,
-        0 36px 0 -10px transparent,
-        -32px 16px 0 -10px transparent,
-        -32px -16px 0 -10px transparent;
+      height: 10px;
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Replace the old circular splash checkbox implementation with a simpler Uiverse-derived checkbox that uses a square red checked state as requested.
- Simplify markup and CSS to improve maintainability and match the visual spec (red checkboxes) while keeping keyboard accessibility.

### Description
- Updated `app/dashboard/page.tsx` to replace the previous `.checkbox-wrapper-12`/SVG structure for the two preference controls with a semantic `label` + `input` structure using `checkbox-container`, `custom-checkbox` and `checkmark` classes.
- Replaced the previous animated splash CSS in `app/globals.css` with a compact Uiverse-style implementation that defines `.checkbox-container`, `.custom-checkbox`, `.checkmark`, a `check-anim` keyframe and a red checked/focus appearance (`#dc2626`).
- Kept original input `id`s and React handlers (`handlePreferenceChange`) to preserve behavior while changing only markup and styles.
- Committed the changes on the current branch (`481f2d4`).

### Testing
- Ran `npm run lint`, which failed because the `next` binary is not available in the environment (`next: not found`).
- Ran `npm install`, which failed due to registry/network restrictions with a `403 Forbidden` error when fetching dependencies.
- Ran `npm run dev`, which also failed for the same reason as lint (`next: not found`), so no runtime verification could be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7029d0c14832e87f179d2746a4dee)