### PR TITLE
Move logout button to bottom of dashboard page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -595,13 +595,6 @@ export default function DashboardPage() {
             >
               {isSavingProfile ? "A guardar..." : "Guardar perfil"}
             </button>
-            <button
-              className="button-size-login border border-slate-200"
-              type="button"
-              onClick={handleLogout}
-            >
-              Terminar sessão
-            </button>
           </div>
 
           <div className="mt-8 border-t border-slate-200 pt-8">
@@ -678,6 +671,16 @@ export default function DashboardPage() {
             </div>
           </div>
         </aside>
+
+        <div className="flex justify-end">
+          <button
+            className="button-size-login border border-slate-200"
+            type="button"
+            onClick={handleLogout}
+          >
+            Terminar sessão
+          </button>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- O botão "Terminar sessão" deve ficar no final da página do dashboard para separar as ações de gestão de perfil das ações de sessão e cumprir o requisito de layout.

### Description
- Removido o botão de logout da linha de ações do perfil e adicionado um bloco `div` com `className="flex justify-end"` no final do conteúdo principal para renderizar o botão no rodapé da página, preservando `handleLogout` e o mesmo estilo visual.

### Testing
- Executado `npm run lint`, que falhou porque o binário `next` não está disponível no ambiente (dependências não instaladas).
- Executado `npm install`, que falhou com `403 Forbidden` ao tentar acessar o registry npm neste ambiente.
- Tentativa de validação com Playwright para carregar `http://127.0.0.1:3000/dashboard` falhou com `ERR_EMPTY_RESPONSE` porque a aplicação não estava em execução localmente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7099a2998832eb3cd2c2840d7de13)