### PR TITLE
refactor: centralize home page hero image source

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 
+const mainHeroImagePath = "/images/IMG_2622.png";
+
 export default function HomePage() {
   return (
     <section className="px-0 pb-10 pt-2">
@@ -38,7 +40,7 @@ export default function HomePage() {
             fill
             priority
             sizes="(max-width: 640px) 92vw, (max-width: 1024px) 68vw, 520px"
-            src="/images/IMG_2622.png"
+            src={mainHeroImagePath}
           />
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Centralize the homepage hero image path so the source can be updated in one place instead of using an inline string literal.

### Description
- Introduced `mainHeroImagePath = "/images/IMG_2622.png"` in `app/page.tsx` and changed the homepage `Image` component to use `src={mainHeroImagePath}` instead of the inline path.

### Testing
- Ran `npm run lint` which failed in this environment because `next` is not available (`sh: 1: next: not found`).
- Attempted a Playwright screenshot of `http://127.0.0.1:3000` which failed because no local server responded (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaff6cd168832e81c2e9e4406f9506)