### PR TITLE
Refactor homepage hero to split-screen layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,43 +5,32 @@ const mainHeroImagePath = "/images/Background.png";
 
 export default function HomePage() {
   return (
-    <section className="px-0 pb-10 pt-2">
-      {/* Cria duas colunas no desktop para posicionar o conteúdo textual à esquerda e a imagem à direita. */}
-      <div className="mx-auto grid min-h-[calc(100vh-130px)] w-full max-w-6xl items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(420px,520px)] lg:gap-12">
-        {/* Mantém o bloco textual encostado ao lado esquerdo para reproduzir o alinhamento da referência. */}
-        <article className="max-w-[640px] pt-6 lg:pt-0">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)] sm:text-[11px] sm:tracking-[0.28em]">
-            Novo Curso
-          </p>
+    <section className="px-0 pb-6 pt-2">
+      {/* Define uma grelha de duas colunas para dividir o ecrã em metades no desktop. */}
+      <div className="relative mx-auto grid min-h-[calc(100vh-130px)] w-full max-w-none bg-[#efefef] lg:grid-cols-2">
+        {/* Reserva a metade esquerda como área limpa para reforçar o efeito de divisão do ecrã. */}
+        <div aria-hidden="true" className="hidden lg:block" />
 
-          <h1 className="mt-4 text-4xl font-black uppercase leading-[0.95] tracking-tight text-[color:var(--foreground)] sm:mt-5 sm:text-5xl lg:text-6xl">
-            O único curso de <span className="text-[color:var(--accent)]">cliente mistério</span> em Portugal
-          </h1>
-
-          <p className="mt-8 max-w-[560px] text-base font-medium leading-relaxed text-[#4a4a4a]">
-            Sê dos primeiros Clientes Mistério certificados!
-          </p>
-
-          <div className="mt-10">
-            <Link
-              className="site-pill-button text-[10px] uppercase tracking-[0.16em] sm:text-[11px] sm:tracking-[0.18em]"
-              href="/about"
-            >
-              Começa Já
-            </Link>
-          </div>
-        </article>
-
-        {/* Reserva uma área alta para a imagem e ancora o conteúdo no fundo para equilibrar a composição. */}
-        <div className="relative mx-auto h-[360px] w-full max-w-[390px] sm:h-[460px] sm:max-w-[440px] lg:h-[720px] lg:max-w-[520px]">
+        {/* Coloca a imagem a ocupar toda a metade direita, com enquadramento elegante em várias larguras. */}
+        <div className="relative min-h-[420px] lg:min-h-full">
           <Image
             alt="Cliente mistério em destaque"
-            className="object-contain object-bottom lg:object-right-bottom"
+            className="object-cover object-center"
             fill
             priority
-            sizes="(max-width: 640px) 92vw, (max-width: 1024px) 68vw, 520px"
+            sizes="(max-width: 1024px) 100vw, 50vw"
             src={mainHeroImagePath}
           />
+        </div>
+
+        {/* Mantém o botão principal exatamente no centro para destacar a ação principal da página. */}
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+          <Link
+            className="pointer-events-auto site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
+            href="/about"
+          >
+            Começa Já
+          </Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Tornar o hero da homepage visualmente dividido em duas metades no desktop para replicar a imagem que “divide o ecrã” e colocar o botão principal centralizado.

### Description
- Atualizei o ficheiro `app/page.tsx` para usar uma grelha de duas colunas em `lg` com `lg:grid-cols-2` e uma área esquerda vazia para criar a divisão visual.
- Configurei a imagem principal para preencher a metade direita com `object-cover` e `fill` para garantir que ocupa totalmente essa coluna.
- Reposicionei o botão “Começa Já” para o centro absoluto da secção principal usando um contêiner `absolute inset-0 z-10 flex items-center justify-center` e classes `pointer-events` para preservar a interacção.
- Removi o bloco textual detalhado da versão anterior para simplificar a composição e destacar a imagem e a call-to-action.

### Testing
- Executei `npm run lint`, que falhou porque o binário `next` não está disponível no ambiente (`sh: 1: next: not found`).
- Tentei `npm install`, que falhou devido a um `403 Forbidden` ao aceder ao registry para a dependência `pg` impedindo a instalação das dependências locais.
- Tentei gerar um screenshot com Playwright apontando para `http://127.0.0.1:3000`, que falhou com `ERR_EMPTY_RESPONSE` porque a aplicação não estava em execução no ambiente de teste.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab06a439ac832e91f9c3340b1444eb)