### PR TITLE
Adjust homepage hero layout and transparent navigation overlay

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import HeaderActions from "./HeaderActions";
+import TopNav from "./TopNav";
+
+export default function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isHomePage = pathname === "/";
+
+  return (
+    <div className="mx-auto min-h-screen w-full bg-[color:var(--background)]">
+      {/* Mantém o cabeçalho absoluto na home para sobrepor o hero, e sticky nas páginas internas. */}
+      <header
+        className={`${
+          isHomePage
+            ? "absolute inset-x-0 top-0 z-50 border-b border-transparent bg-transparent"
+            : "sticky top-0 z-50 border-b border-[color:var(--line)] bg-[color:var(--background)]/95 backdrop-blur-sm"
+        } px-4 py-5 sm:px-6 md:px-10 md:py-6`}
+      >
+        <div className="relative mx-auto grid w-full max-w-6xl grid-cols-[1fr_auto] items-center gap-3 lg:grid-cols-[minmax(220px,1fr)_auto_minmax(180px,1fr)]">
+          <a
+            className="text-[10px] font-black uppercase tracking-[0.28em] text-[color:var(--foreground)] sm:text-xs sm:tracking-[0.35em]"
+            href="/"
+          >
+            Cliente Mistério
+          </a>
+
+          {/* Mantém o menu no centro em ecrãs grandes e no lado direito em ecrãs pequenos. */}
+          <div className="justify-self-end lg:justify-self-center">
+            <TopNav />
+          </div>
+
+          {/* Alinha o botão de ação ao limite direito do conteúdo para manter consistência visual. */}
+          <div className="hidden lg:flex lg:justify-self-end">
+            <HeaderActions />
+          </div>
+
+          {/* Mantém as ações disponíveis no mobile sem quebrar o layout do menu hamburguer. */}
+          <div className="justify-self-end lg:hidden">
+            <HeaderActions />
+          </div>
+        </div>
+      </header>
+
+      {/* Remove margens na home para permitir hero full-bleed e mantém paddings nas páginas internas. */}
+      <main className={isHomePage ? "px-0 pb-0" : "px-4 pb-10 sm:px-6 md:px-10"}>{children}</main>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Montserrat } from "next/font/google";
-import TopNav from "./components/TopNav";
-import HeaderActions from "./components/HeaderActions";
+import AppShell from "./components/AppShell";
 import "./globals.css";
 
 // Define a fonte principal com estilo geométrico para reforçar o visual editorial.
@@ -38,38 +37,7 @@ export default function RootLayout({
       <body
         className={`${montserrat.variable} ${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
       >
-        {/* Mantém o fundo em largura total enquanto o conteúdo segue os mesmos eixos do hero. */}
-        <div className="mx-auto min-h-screen w-full max-w-[1400px] bg-[color:var(--background)]">
-          {/* Usa o mesmo content width do hero para alinhar logo com texto e ação com a imagem. */}
-          <header className="sticky top-0 z-50 border-b border-[color:var(--line)] bg-[color:var(--background)]/95 px-4 py-5 backdrop-blur-sm sm:px-6 md:px-10 md:py-6">
-            <div className="relative mx-auto grid w-full max-w-6xl grid-cols-[1fr_auto] items-center gap-3 lg:grid-cols-[minmax(220px,1fr)_auto_minmax(180px,1fr)]">
-              <a
-                className="text-[10px] font-black uppercase tracking-[0.28em] text-[color:var(--foreground)] sm:text-xs sm:tracking-[0.35em]"
-                href="/"
-              >
-                Cliente Mistério
-              </a>
-
-              {/* Mantém o menu no centro em ecrãs grandes e no lado direito em ecrãs pequenos. */}
-              <div className="justify-self-end lg:justify-self-center">
-                <TopNav />
-              </div>
-
-              {/* Alinha o botão de ação ao limite direito do content width para coincidir com a imagem. */}
-              <div className="hidden lg:flex lg:justify-self-end">
-                <HeaderActions />
-              </div>
-
-              {/* Mantém as ações disponíveis no mobile sem quebrar o layout do menu hamburguer. */}
-              <div className="justify-self-end lg:hidden">
-                <HeaderActions />
-              </div>
-            </div>
-          </header>
-
-          {/* Renderiza o conteúdo principal sem deslocar o eixo de alinhamento lateral. */}
-          <main className="px-4 pb-10 sm:px-6 md:px-10">{children}</main>
-        </div>
+        <AppShell>{children}</AppShell>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,14 +5,14 @@ const mainHeroImagePath = "/images/Background.png";
 
 export default function HomePage() {
   return (
-    <section className="px-0 pb-6 pt-2">
-      {/* Define uma grelha de duas colunas para dividir o ecrã em metades no desktop. */}
-      <div className="relative mx-auto grid min-h-[calc(100vh-130px)] w-full max-w-none bg-[#efefef] lg:grid-cols-2">
-        {/* Reserva a metade esquerda como área limpa para reforçar o efeito de divisão do ecrã. */}
+    <section className="w-full">
+      {/* Divide o hero em duas colunas no desktop para manter o texto à esquerda e a imagem à direita. */}
+      <div className="relative grid min-h-screen w-full bg-[#efefef] lg:grid-cols-2">
+        {/* Reserva a metade esquerda como área limpa para reforçar o contraste da composição. */}
         <div aria-hidden="true" className="hidden lg:block" />
 
-        {/* Coloca a imagem a ocupar toda a metade direita, com enquadramento elegante em várias larguras. */}
-        <div className="relative min-h-[420px] lg:min-h-full">
+        {/* Garante que a imagem começa no topo e chega até ao extremo direito da página. */}
+        <div className="relative min-h-screen">
           <Image
             alt="Cliente mistério em destaque"
             className="object-cover object-center"
@@ -23,8 +23,8 @@ export default function HomePage() {
           />
         </div>
 
-        {/* Mantém o botão principal exatamente no centro para destacar a ação principal da página. */}
-        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+        {/* Posiciona o botão mais abaixo para evitar o centro visual da página. */}
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-end justify-center pb-16 sm:pb-20 lg:pb-24">
           <Link
             className="pointer-events-auto site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
             href="/about"


### PR DESCRIPTION
### Motivation
- Make the homepage hero image full-bleed (starts at the top and reaches the right edge), let page text sit over the image under a transparent navigation bar, and lower the primary CTA for better visual hierarchy.
- Centralize header and main wrapper logic so the header can be route-aware (absolute/transparent on the home route, sticky with backdrop on inner pages).

### Description
- Added `app/components/AppShell.tsx` which provides a route-aware header that is `absolute` and transparent on the home page and `sticky` with border/background on other pages, and conditionally removes `main` padding for the home route.
- Updated `app/layout.tsx` to use the new `AppShell` component instead of inline header/main markup.
- Updated `app/page.tsx` to make the hero full-bleed using `min-h-screen`, ensure the hero image starts at the top and extends to the page edge, and move the "Começa Já" CTA lower by switching the CTA container to `items-end` with bottom padding.
- Preserved existing `TopNav` and `HeaderActions` usage and styles while making the structural changes minimal and reversible.

### Testing
- Ran `npm run lint`, which failed with `sh: 1: next: not found` in this environment so linting could not complete.
- Ran `npm ci`, which failed due to a `403 Forbidden` when fetching packages from the npm registry so dependencies were not installed.
- Ran `npm run dev -- --hostname 0.0.0.0 --port 3000`, which failed with `next: not found` so the app could not be started for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab098f2acc832eac0fccab0100f98d)