### PR TITLE
Restore missing left-side hero text on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,37 @@ export default function HomePage() {
     <section className="w-full">
       {/* Divide o hero em duas colunas no desktop para manter o texto à esquerda e a imagem à direita. */}
       <div className="relative grid min-h-screen w-full bg-[#efefef] lg:grid-cols-2">
-        {/* Reserva a metade esquerda como área limpa para reforçar o contraste da composição. */}
-        <div aria-hidden="true" className="hidden lg:block" />
+        {/* Mantém um painel dedicado ao conteúdo textual para evitar que o texto desapareça atrás da imagem. */}
+        <div className="relative z-10 flex items-center px-6 py-24 sm:px-10 lg:px-16">
+          {/* Centraliza e limita a largura do bloco para preservar leitura confortável em ecrãs largos. */}
+          <div className="max-w-xl space-y-6">
+            {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
+            <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-black/70">
+              Formação e prática
+            </p>
+
+            {/* Recupera a mensagem principal que estava em falta no lado esquerdo do hero. */}
+            <h1 className="text-4xl font-semibold leading-tight text-black sm:text-5xl lg:text-6xl">
+              Aprende a observar,
+              <span className="block text-[#dc2626]">avaliar e melhorar serviços.</span>
+            </h1>
+
+            {/* Explica a proposta de valor com linguagem curta para não competir visualmente com a imagem. */}
+            <p className="max-w-lg text-sm leading-7 text-black/70 sm:text-base">
+              O programa Cliente Mistério ajuda-te a desenvolver pensamento crítico,
+              método de avaliação e capacidade de transformar observações em melhorias
+              concretas para equipas e negócios.
+            </p>
+
+            {/* Mantém a ação principal junto do texto para reforçar o fluxo natural de leitura. */}
+            <Link
+              className="site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
+              href="/about"
+            >
+              Começa Já
+            </Link>
+          </div>
+        </div>
 
         {/* Garante que a imagem começa no topo e chega até ao extremo direito da página. */}
         <div className="relative min-h-screen">
@@ -21,16 +50,6 @@ export default function HomePage() {
             sizes="(max-width: 1024px) 100vw, 50vw"
             src={mainHeroImagePath}
           />
-        </div>
-
-        {/* Posiciona o botão mais abaixo para evitar o centro visual da página. */}
-        <div className="pointer-events-none absolute inset-0 z-10 flex items-end justify-center pb-16 sm:pb-20 lg:pb-24">
-          <Link
-            className="pointer-events-auto site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
-            href="/about"
-          >
-            Começa Já
-          </Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Fix the layout bug where the left-side hero copy had disappeared, restoring visible editorial content and a clear CTA in the hero area.

### Description
- Replaced the previously hidden left column with a visible text panel in `app/page.tsx` that includes a label, headline, supporting paragraph and CTA button. 
- Added layout classes (`z-10`, padding and `max-w-xl`) to keep the text readable above the hero image and keep the two-column structure with the image on the right. 
- Removed the old absolute bottom-centered CTA overlay so the page uses the left-aligned CTA alongside the restored copy. 
- Kept Portuguese inline comments explaining each block and preserved original image usage (`/images/Background.png`).

### Testing
- Ran `npm run lint` which failed because the `next` binary is not available in the current environment (no dependencies installed). 
- Ran `npm ci` which failed with `403 Forbidden` from the npm registry, preventing dependency installation. 
- Attempted a Playwright script to capture a screenshot of `http://127.0.0.1:3000`, which failed with `net::ERR_EMPTY_RESPONSE` because the app was not running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab141d89c4832e944b92d8b320e333)