### PR TITLE
Adjust home hero navigation and CTA positioning

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -26,8 +26,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             Cliente Mistério
           </a>
 
-          {/* Mantém o menu no centro em ecrãs grandes e no lado direito em ecrãs pequenos. */}
-          <div className="justify-self-end lg:absolute lg:left-1/2 lg:-translate-x-1/2">
+          {/* Na home desloca o menu para o centro da metade esquerda; nas páginas internas mantém ao centro global. */}
+          <div
+            className={`justify-self-end lg:absolute lg:-translate-x-1/2 ${
+              isHomePage ? "lg:left-1/4" : "lg:left-1/2"
+            }`}
+          >
             <TopNav />
           </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,9 +9,9 @@ export default function HomePage() {
       {/* Divide o hero em duas colunas no desktop para manter o texto à esquerda e a imagem à direita. */}
       <div className="relative grid min-h-screen w-full bg-[#efefef] lg:grid-cols-2">
         {/* Mantém um painel dedicado ao conteúdo textual para evitar que o texto desapareça atrás da imagem. */}
-        <div className="relative z-10 flex items-center px-6 py-24 sm:px-10 lg:px-16">
-          {/* Centraliza e limita a largura do bloco para preservar leitura confortável em ecrãs largos. */}
-          <div className="max-w-xl space-y-6">
+        <div className="relative z-10 flex px-6 py-24 sm:px-10 lg:px-16">
+          {/* Estrutura o conteúdo para manter texto acima e CTA centrado na parte inferior da metade esquerda. */}
+          <div className="flex min-h-[70vh] w-full max-w-xl flex-col justify-between">
             {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
             <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-black/70">
               Formação e prática
@@ -30,13 +30,15 @@ export default function HomePage() {
               concretas para equipas e negócios.
             </p>
 
-            {/* Mantém a ação principal junto do texto para reforçar o fluxo natural de leitura. */}
-            <Link
-              className="site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
-              href="/about"
-            >
-              Começa Já
-            </Link>
+            {/* Posiciona a CTA centrada horizontalmente e mais abaixo para não competir com o menu superior. */}
+            <div className="flex justify-center pb-4 pt-8 lg:pb-8">
+              <Link
+                className="site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
+                href="/about"
+              >
+                Começa Já
+              </Link>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Evitar que a navegação desktop sobreponha a imagem do hero movendo os menus para o centro da metade esquerda na página inicial; o botão principal deve ficar centrado horizontalmente na parte inferior do painel esquerdo para não competir com o menu superior.

### Description
- Atualizado `app/components/AppShell.tsx` para que o wrapper da navegação use `lg:left-1/4` quando `isHomePage` é `true`, e mantenha `lg:left-1/2` nas restantes páginas, deslocando assim a navegação para o centro da metade esquerda na home.
- Refatorado o layout do hero em `app/page.tsx` para usar uma coluna flexível (`flex`, `flex-col`, `justify-between`, `min-h-[70vh]`) que separa o conteúdo textual da CTA e garante espaçamento vertical consistente.
- Reposicionado o botão `Começa Já` dentro de um container centrado (`flex justify-center pb-4 pt-8 lg:pb-8`) para que fique mais abaixo e alinhado ao centro da metade esquerda, mantendo o comportamento mobile existente.

### Testing
- Executado `npm run lint`, que falhou porque o binário `next` não está disponível neste ambiente, pelo que a linting não foi concluída.
- Tentado `npm ci`, que falhou ao instalar dependências devido a um `403 Forbidden` ao buscar o pacote `pg` na registry, impedindo instalação completa das dependências.
- Tentado capturar um screenshot com Playwright apontando para `http://127.0.0.1:3000`, que falhou com `ERR_EMPTY_RESPONSE` porque a aplicação não estava a correr no porto alvo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab22fc1e4c832ea1650f178b17d9cd)