### PR TITLE
Fix homepage header navigation centering

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -26,11 +26,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             Cliente Mistério
           </a>
 
-          {/* Na home desloca o menu para o centro da metade esquerda; nas páginas internas mantém ao centro global. */}
+          {/* Mantém o menu sempre no centro para evitar sobreposição com o logótipo. */}
           <div
-            className={`justify-self-end lg:absolute lg:-translate-x-1/2 ${
-              isHomePage ? "lg:left-1/4" : "lg:left-1/2"
-            }`}
+            className="justify-self-end lg:absolute lg:left-1/2 lg:-translate-x-1/2"
           >
             <TopNav />
           </div>


### PR DESCRIPTION
### Motivation
- Corrigir a sobreposição do logótipo com a barra de navegação na homepage e garantir que o menu fica sempre centrado no desktop.

### Description
- Atualizei `app/components/AppShell.tsx` para remover o offset específico da homepage e aplicar classes fixas `lg:left-1/2 lg:-translate-x-1/2` ao contêiner do menu, preservando o comportamento responsivo existente.

### Testing
- Executei `npm run lint` (falhou porque o binário `next` não estava disponível), `npm ci` (falhou por lockfile fora de sincronia) e `npx next dev -p 3000` (falhou por erro 403 no registry npm), portanto não foi possível gerar preview local; o patch foi aplicado e commitado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af007d66a0832ebc49980092ca18e3)