### PR TITLE
Center left-panel nav, update logo to "CM", and center hero CTA on desktop

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -23,12 +23,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             className="text-[11px] font-black uppercase tracking-[0.3em] text-[color:var(--foreground)] sm:text-sm sm:tracking-[0.35em]"
             href="/"
           >
-            Cliente Mistério
+            CM
           </a>
 
-          {/* Mantém o menu sempre no centro para evitar sobreposição com o logótipo. */}
+          {/* Na home centra o menu na metade cinzenta; nas restantes páginas mantém o centro global. */}
           <div
-            className="justify-self-end lg:absolute lg:left-1/2 lg:-translate-x-1/2"
+            className={`justify-self-end lg:absolute lg:-translate-x-1/2 ${
+              isHomePage ? "lg:left-1/4" : "lg:left-1/2"
+            }`}
           >
             <TopNav />
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,14 +10,14 @@ export default function HomePage() {
       <div className="relative grid min-h-screen w-full bg-[#efefef] lg:grid-cols-2">
         {/* Mantém um painel dedicado ao conteúdo textual para evitar que o texto desapareça atrás da imagem. */}
         <div className="relative z-10 flex px-6 py-24 sm:px-10 lg:px-16">
-          {/* Estrutura o conteúdo para manter texto acima e CTA centrado na parte inferior da metade esquerda. */}
-          <div className="flex min-h-[70vh] w-full max-w-xl flex-col justify-between">
+          {/* Estrutura o conteúdo textual para preservar hierarquia e legibilidade. */}
+          <div className="flex min-h-[70vh] w-full max-w-xl flex-col gap-8">
             {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
             <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-black/70">
               Formação e prática
             </p>
 
-            {/* Recupera a mensagem principal que estava em falta no lado esquerdo do hero. */}
+            {/* Recupera a mensagem principal com ênfase cromática na proposta de valor. */}
             <h1 className="text-4xl font-semibold leading-tight text-black sm:text-5xl lg:text-6xl">
               Aprende a observar,
               <span className="block text-[#dc2626]">avaliar e melhorar serviços.</span>
@@ -30,8 +30,8 @@ export default function HomePage() {
               concretas para equipas e negócios.
             </p>
 
-            {/* Posiciona a CTA centrada horizontalmente e mais abaixo para não competir com o menu superior. */}
-            <div className="flex justify-center pb-4 pt-8 lg:pb-8">
+            {/* Em mobile mantém o CTA no fluxo natural para facilitar leitura e toque. */}
+            <div className="flex justify-center pb-4 pt-8 lg:hidden">
               <Link
                 className="site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
                 href="/about"
@@ -40,6 +40,16 @@ export default function HomePage() {
               </Link>
             </div>
           </div>
+        </div>
+
+        {/* No desktop posiciona o CTA no centro horizontal da página, mantendo a altura atual no hero. */}
+        <div className="pointer-events-none absolute inset-x-0 bottom-[18%] z-20 hidden justify-center lg:flex">
+          <Link
+            className="pointer-events-auto site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
+            href="/about"
+          >
+            Começa Já
+          </Link>
         </div>
 
         {/* Garante que a imagem começa no topo e chega até ao extremo direito da página. */}


### PR DESCRIPTION
### Motivation
- Align the desktop navigation so it appears centered relative to the left (gray) panel on the home hero while preserving global center alignment on inner pages.
- Replace the textual header brand with the shorter `CM` identifier for a compact header treatment.
- Ensure the primary CTA (`Começa Já`) remains in the mobile flow but appears horizontally centered on the page at the same vertical position on desktop.

### Description
- Updated `app/components/AppShell.tsx` to change the header text to `CM` and made the navigation container compute `lg:left-1/4` when on the home page and `lg:left-1/2` for other pages to center the nav relative to the left panel.
- Updated `app/page.tsx` to restructure the hero content (`flex-col gap-8`) and keep the mobile CTA in-flow while adding a desktop-only absolutely positioned centered CTA (`absolute inset-x-0 bottom-[18%] hidden lg:flex`) to center the button horizontally across the page.
- Preserved Portuguese inline comments and kept code and identifiers in English to match the project conventions and documentation requirements.

### Testing
- Ran `npm run lint`, which failed because `next` was not available in the environment (`sh: 1: next: not found`).
- Attempted `npm ci` to install dependencies, which failed due to registry access returning `403 Forbidden` when fetching packages.
- Attempted a Playwright screenshot of a local dev server on port `3000`, which failed because no server responded (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af04003074832e99b0ef2776f31edf)