### PR TITLE
style: padroniza tipografia com Montserrat e títulos em bold

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,6 +32,17 @@ body {
   font-family: var(--font-sans);
 }
 
+/* Força todos os elementos tipográficos principais a usar Montserrat em negrito. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-sans);
+  font-weight: 700;
+}
+
 /* Gira texto para orientação vertical usada na barra lateral do hero. */
 .vertical-text {
   writing-mode: vertical-rl;
@@ -156,23 +167,23 @@ body {
 
   /* Define tipografia padrão para títulos principais do site. */
   .page-title {
-    @apply text-3xl font-semibold text-[color:var(--foreground)];
+    @apply text-3xl font-bold text-[color:var(--foreground)];
   }
 
   .section-title {
-    @apply text-2xl font-semibold text-[color:var(--foreground)];
+    @apply text-2xl font-bold text-[color:var(--foreground)];
   }
 
   .section-title-inverse {
-    @apply text-2xl font-semibold text-white;
+    @apply text-2xl font-bold text-white;
   }
 
   .card-title {
-    @apply text-lg font-semibold text-[color:var(--foreground)];
+    @apply text-lg font-bold text-[color:var(--foreground)];
   }
 
   .subsection-title {
-    @apply text-base font-semibold text-[color:var(--foreground)];
+    @apply text-base font-bold text-[color:var(--foreground)];
   }
 
   .section-label {


### PR DESCRIPTION
### Motivation
- Garantir que a tipografia do site use Montserrat de forma consistente e que todos os títulos e subtítulos sejam sempre apresentados em negrito para obedecer ao padrão visual.

### Description
- Atualizado `app/globals.css` para forçar `h1` a `h6` a usar `var(--font-sans)` com `font-weight: 700` (bold).
- Substituídas as classes utilitárias de título (`.page-title`, `.section-title`, `.section-title-inverse`, `.card-title`, `.subsection-title`) de `font-semibold` para `font-bold` para garantir consistência em componentes reutilizáveis.
- Todas as alterações estão contidas no ficheiro `app/globals.css` e devolvem o ficheiro completo atualizado.

### Testing
- Executado `npm run lint`, que falhou porque o binário `next` não está disponível no ambiente (`sh: 1: next: not found`).
- Executado `npm ci`, que falhou devido a bloqueio de acesso ao registry (`403 Forbidden` ao buscar dependências).
- Tentativa de captura com Playwright em `http://127.0.0.1:3000` falhou porque não havia servidor local ativo (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1256a224832ea2c33bce1ad2d864)