### PR TITLE
Update hero copy and simplify landing-page hero layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,18 +17,17 @@ export default function HomePage() {
               Formação e prática
             </p>
 
-            {/* Recupera a mensagem principal com ênfase cromática na proposta de valor. */}
-            <h1 className="text-4xl font-semibold leading-tight text-black sm:text-5xl lg:text-6xl">
-              Aprende a observar,
-              <span className="block text-[#dc2626]">avaliar e melhorar serviços.</span>
+            {/* Destaca a proposta principal com cor vermelha e peso tipográfico forte para aumentar o impacto. */}
+            <h1 className="text-4xl font-bold leading-tight text-[#dc2626] sm:text-5xl lg:text-6xl">
+              Sê pago para testar produtos e serviços
             </h1>
 
-            {/* Explica a proposta de valor com linguagem curta para não competir visualmente com a imagem. */}
-            <p className="max-w-lg text-sm leading-7 text-black/70 sm:text-base">
-              O programa Cliente Mistério ajuda-te a desenvolver pensamento crítico,
-              método de avaliação e capacidade de transformar observações em melhorias
-              concretas para equipas e negócios.
-            </p>
+            {/* Lista os benefícios principais em frases curtas para facilitar leitura rápida. */}
+            <ul className="space-y-2 text-sm leading-7 text-black/75 sm:text-base">
+              <li>Sem horários</li>
+              <li>Escolhes as marcas</li>
+              <li>Rendimento extra ao teu ritmo</li>
+            </ul>
 
             {/* Em mobile mantém o CTA no fluxo natural para facilitar leitura e toque. */}
             <div className="flex justify-center pb-4 pt-8 lg:hidden">


### PR DESCRIPTION
### Motivation
- Change the hero messaging to make the value proposition explicit (paid product/service testing) and increase impact by using a stronger, single-line headline.
- Simplify the supporting copy into a short benefits list to improve scannability on the landing page.

### Description
- Updated `app/page.tsx` hero `h1` text to "Sê pago para testar produtos e serviços" and adjusted typography classes to use a bolder, red-accented heading.
- Replaced the paragraph describing the program with a short unordered list of benefits (`Sem horários`, `Escolhes as marcas`, `Rendimento extra ao teu ritmo`) and updated adjacent comments for clarity.
- Kept existing CTA markup and layout behavior for mobile and desktop while preserving the hero image container.

### Testing
- Ran `npm run build` to verify the Next.js build and `npm run lint` to check code style; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af166a2d24832eb3902f08771b05d4)