### PR TITLE
Update homepage hero copy and typography

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,18 +17,17 @@ export default function HomePage() {
               Formação e prática
             </p>
 
-            {/* Recupera a mensagem principal com ênfase cromática na proposta de valor. */}
-            <h1 className="text-4xl font-semibold leading-tight text-black sm:text-5xl lg:text-6xl">
-              Aprende a observar,
-              <span className="block text-[#dc2626]">avaliar e melhorar serviços.</span>
+            {/* Destaca a proposta principal com cor vermelha e peso tipográfico forte para aumentar o impacto. */}
+            <h1 className="text-4xl font-bold leading-tight text-[#dc2626] sm:text-5xl lg:text-6xl">
+              Sê pago para testar produtos e serviços
             </h1>
 
-            {/* Explica a proposta de valor com linguagem curta para não competir visualmente com a imagem. */}
-            <p className="max-w-lg text-sm leading-7 text-black/70 sm:text-base">
-              O programa Cliente Mistério ajuda-te a desenvolver pensamento crítico,
-              método de avaliação e capacidade de transformar observações em melhorias
-              concretas para equipas e negócios.
-            </p>
+            {/* Mostra os benefícios em bold e com tamanho ligeiramente inferior ao título principal. */}
+            <ul className="space-y-2 text-3xl font-bold leading-tight text-black sm:text-4xl lg:text-5xl">
+              <li>-Sem horários</li>
+              <li>-Escolhes as marcas</li>
+              <li>-Rendimento extra</li>
+            </ul>
 
             {/* Em mobile mantém o CTA no fluxo natural para facilitar leitura e toque. */}
             <div className="flex justify-center pb-4 pt-8 lg:hidden">


### PR DESCRIPTION
### Motivation
- Make the hero message more direct and attention grabbing by replacing the descriptive paragraph with a concise, bold headline and benefit list.
- Increase visual emphasis on the proposition by switching to stronger typography and using the brand red color for the main headline.
- Preserve existing layout and CTA placement while simplifying the content hierarchy for better mobile and desktop readability.

### Description
- Replaced the previous multi-line heading and explanatory paragraph with a single bold red headline `Sê pago para testar produtos e serviços` and a bold benefits `ul` list (`-Sem horários`, `-Escolhes as marcas`, `-Rendimento extra`).
- Updated `h1` classes from `text-4xl font-semibold leading-tight text-black` to `text-4xl font-bold leading-tight text-[#dc2626]` and adjusted responsive sizes to maintain layout.
- Removed the colored `span` and long paragraph node, and introduced an oversized `ul` with `space-y-2 text-3xl font-bold leading-tight` to emphasize benefits.
- Left CTA structure and positioning intact (mobile inline CTA and desktop absolute CTA) and kept existing layout comments and container structure.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af166a2d24832eb3902f08771b05d4)