### PR TITLE
Improve navigation fluidity and remove redundant UI code

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import HeaderActions from "./HeaderActions";
 import TopNav from "./TopNav";
@@ -19,12 +20,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         } px-4 py-5 sm:px-6 md:px-10 md:py-6`}
       >
         <div className="relative flex w-full items-center justify-between gap-3">
-          <a
+          <Link
             className="text-[11px] font-black uppercase tracking-[0.3em] text-[color:var(--foreground)] sm:text-sm sm:tracking-[0.35em]"
             href="/"
           >
             CM
-          </a>
+          </Link>
 
           {/* Na home centra o menu na metade cinzenta; nas restantes páginas mantém o centro global. */}
           <div
@@ -35,13 +36,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             <TopNav />
           </div>
 
-          {/* Alinha o botão de ação ao limite direito do conteúdo para manter consistência visual. */}
-          <div className="hidden lg:flex">
-            <HeaderActions />
-          </div>
-
-          {/* Mantém as ações disponíveis no mobile sem quebrar o layout do menu hamburguer. */}
-          <div className="lg:hidden">
+          {/* Mantém uma única instância das ações para evitar renderização duplicada e navegação menos fluída. */}
+          <div>
             <HeaderActions />
           </div>
         </div>

--- a/app/components/HeaderActions.tsx
+++ b/app/components/HeaderActions.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 
 type SessionUser = {
   fullName: string;
@@ -13,12 +14,8 @@ const userStorageKey = "vp_user";
 const sessionStorageKey = "vp_session";
 
 export default function HeaderActions() {
+  const pathname = usePathname();
   const [sessionUser, setSessionUser] = useState<SessionUser | null>(null);
-
-  const profileHref = useMemo(() => {
-    // Mantém destino único para utilizadores autenticados.
-    return "/dashboard";
-  }, []);
 
   useEffect(() => {
     // Lê a sessão guardada no browser para alternar ação entre login e dashboard.
@@ -42,7 +39,7 @@ export default function HeaderActions() {
     } catch {
       setSessionUser(null);
     }
-  }, []);
+  }, [pathname]);
 
   return (
     <div className="flex items-center gap-2 sm:gap-3">
@@ -56,7 +53,7 @@ export default function HeaderActions() {
       ) : (
         <Link
           className="site-pill-button text-[11px] uppercase tracking-[0.14em] sm:text-[12px] sm:tracking-[0.15em]"
-          href={profileHref}
+          href="/dashboard"
         >
           Dashboard
         </Link>

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const navigationItems = [
   { href: "/", label: "Home" },
@@ -15,6 +15,11 @@ const navigationItems = [
 export default function TopNav() {
   const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  useEffect(() => {
+    // Fecha automaticamente o menu quando a rota muda para manter a navegação ágil no mobile.
+    setIsMenuOpen(false);
+  }, [pathname]);
 
   const closeMenu = () => {
     // Fecha o menu após navegação para melhorar a experiência em ecrãs pequenos.

--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,8 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
 /* Força todos os elementos tipográficos principais a usar Montserrat em negrito. */
@@ -41,12 +43,6 @@ h5,
 h6 {
   font-family: var(--font-sans);
   font-weight: 700;
-}
-
-/* Gira texto para orientação vertical usada na barra lateral do hero. */
-.vertical-text {
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
 }
 
 @layer components {
@@ -66,8 +62,9 @@ h6 {
     font-weight: 700;
     line-height: 1;
     white-space: nowrap;
-    transition: all 0.5s;
-    -webkit-transition: all 0.5s;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    will-change: transform;
+    touch-action: manipulation;
   }
 
   /* Realça o botão no hover com aumento subtil e sombra difusa vermelha. */
@@ -76,7 +73,7 @@ h6 {
     background-color: #F56151 !important;
     filter: none !important;
     box-shadow: 0 0 20px rgb(245 97 81 / 32%);
-    transform: scale(1.1);
+    transform: translateZ(0) scale(1.03);
   }
 
   /* Aplica estado de clique com redução de escala para feedback tátil. */
@@ -84,10 +81,8 @@ h6 {
   .button-size-login:active {
     background-color: #F56151 !important;
     filter: none !important;
-    transition: all 0.25s;
-    -webkit-transition: all 0.25s;
     box-shadow: none;
-    transform: scale(0.98);
+    transform: translateZ(0) scale(0.98);
   }
 
   /* Evita animações quando o botão está desativado para manter acessibilidade. */


### PR DESCRIPTION
### Motivation
- Reduce page reloads and duplicated header renders to make navigation feel faster and smoother.
- Ensure mobile menu state doesn't persist across route changes to avoid a stuck drawer and improve perceived responsiveness.
- Simplify session UI logic so header actions update reliably on client-side navigation.
- Lower rendering cost of interactive elements by narrowing CSS animations and enabling touch optimizations.

### Description
- Replaced the brand anchor with a client-side `next/link` in `app/components/AppShell.tsx` to avoid full page reloads when clicking the logo.
- Removed duplicated `HeaderActions` instances in the header so only one instance is mounted, reducing unnecessary renders and DOM duplication.
- Simplified `app/components/HeaderActions.tsx` by removing an unused `useMemo`, using `usePathname` and refreshing session state on route changes, and hardcoding the dashboard href to `"/dashboard"` for clarity.
- Improved mobile menu behavior in `app/components/TopNav.tsx` by adding an effect that auto-closes the menu when `pathname` changes.
- Optimized `app/globals.css` by adding `text-rendering`/`-webkit-font-smoothing`, replacing broad `transition: all` rules with targeted transitions (`transform`, `box-shadow`, `opacity`), reducing hover scale intensity, adding `will-change` and `touch-action: manipulation`, and removing the unused `.vertical-text` rule.

### Testing
- Attempted `npm ci` to install dependencies, but it failed with a registry access `403` so full local install could not be performed (automated check failed).
- Attempted `npm run lint`, but `next` was not available without dependencies so linting could not run (automated check failed).
- Ran code searches (`rg`) and file inspections to validate changes and confirmed removal of `.vertical-text` usages and the updated component code (automated checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04418d5cc832e817aa0ec2c086f64)