### PR TITLE
Update hero and CTA colors to #0067a9

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,7 +46,7 @@ h6 {
 }
 
 @layer components {
-  /* Define estilo base único para todos os botões com visual pill e destaque vermelho. */
+  /* Define estilo base único para todos os botões com visual pill e destaque azul. */
   .site-pill-button,
   .button-size-login {
     display: inline-flex;
@@ -56,7 +56,7 @@ h6 {
     border: 0;
     border-radius: 100px;
     padding: 0 30px;
-    background-color: #F56151 !important;
+    background-color: #0067a9 !important;
     color: #ffffff !important;
     font-size: 0.875rem;
     font-weight: 700;
@@ -67,19 +67,19 @@ h6 {
     touch-action: manipulation;
   }
 
-  /* Realça o botão no hover com aumento subtil e sombra difusa vermelha. */
+  /* Realça o botão no hover com aumento subtil e sombra difusa azul. */
   .site-pill-button:hover,
   .button-size-login:hover {
-    background-color: #F56151 !important;
+    background-color: #0067a9 !important;
     filter: none !important;
-    box-shadow: 0 0 20px rgb(245 97 81 / 32%);
+    box-shadow: 0 0 20px rgb(0 103 169 / 32%);
     transform: translateZ(0) scale(1.03);
   }
 
   /* Aplica estado de clique com redução de escala para feedback tátil. */
   .site-pill-button:active,
   .button-size-login:active {
-    background-color: #F56151 !important;
+    background-color: #0067a9 !important;
     filter: none !important;
     box-shadow: none;
     transform: translateZ(0) scale(0.98);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function HomePage() {
   return (
     <section className="w-full">
       {/* Divide o hero em duas colunas no desktop para manter o texto à esquerda e a imagem à direita. */}
-      <div className="relative grid min-h-screen w-full bg-[#efefef] lg:grid-cols-2">
+      <div className="relative grid min-h-screen w-full bg-gradient-to-b from-[#0067a9] to-[#0067a9] lg:grid-cols-2">
         {/* Mantém um painel dedicado ao conteúdo textual para evitar que o texto desapareça atrás da imagem. */}
         <div className="relative z-10 flex px-6 py-24 sm:px-10 lg:px-16">
           {/* Estrutura o conteúdo textual para preservar hierarquia e legibilidade. */}
@@ -17,8 +17,8 @@ export default function HomePage() {
               Formação e prática
             </p>
 
-            {/* Destaca a proposta principal com cor vermelha e peso tipográfico forte para aumentar o impacto. */}
-            <h1 className="text-4xl font-bold leading-tight text-[color:var(--accent)] sm:text-5xl lg:text-6xl">
+            {/* Destaca a proposta principal com cor azul e peso tipográfico forte para aumentar o impacto. */}
+            <h1 className="text-4xl font-bold leading-tight text-[#0067a9] sm:text-5xl lg:text-6xl">
               Sê pago para testar produtos e serviços
             </h1>
 


### PR DESCRIPTION
### Motivation
- Harmonize the landing hero, primary CTA buttons and main headline color to the requested brand blue `#0067a9` without changing page structure.

### Description
- Updated `app/page.tsx` to use a solid gradient background `bg-gradient-to-b from-[#0067a9] to-[#0067a9]` for the hero and changed the headline color for “Sê pago para testar produtos e serviços” to `#0067a9`.
- Updated `app/globals.css` to set `.site-pill-button` and `.button-size-login` base, hover and active `background-color` to `#0067a9` and adjusted the hover `box-shadow` color accordingly.
- Minor comment text in CSS/TSX was updated to reflect the color change from “vermelho” to “azul”.

### Testing
- Ran `npm run lint`, which failed because `next` is not available in the environment (lint step could not complete).
- Attempted `npm install`, which failed due to `403 Forbidden` from the npm registry so dependencies could not be installed.
- Attempted a Playwright script to capture a screenshot from `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because the dev server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04cc2dc78832eb0ffa2992a744bf3)