### PR TITLE
Switch accent color from red to blue across header, CTA and hero

### DIFF
--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -53,15 +53,15 @@ export default function TopNav() {
               key={item.href}
               className={`relative pb-2 text-[16px] font-semibold transition ${
                 isActive
-                  ? "text-[color:var(--accent)]"
-                  : "text-[color:var(--foreground)] hover:text-[color:var(--accent)]"
+                  ? "text-[#2596be]"
+                  : "text-[#2596be] hover:text-[#2596be]"
               }`}
               href={item.href}
             >
               {item.label}
 
               {isActive ? (
-                <span className="absolute inset-x-0 -bottom-[2px] h-[2px] bg-[color:var(--accent)]" />
+                <span className="absolute inset-x-0 -bottom-[2px] h-[2px] bg-[#2596be]" />
               ) : null}
             </Link>
           );
@@ -80,8 +80,8 @@ export default function TopNav() {
                 key={item.href}
                 className={`mobile-menu-item px-5 py-4 text-base font-semibold transition ${
                   isActive
-                    ? "text-[color:var(--accent)]"
-                    : "text-[color:var(--accent)] hover:bg-red-50"
+                    ? "text-[#2596be]"
+                    : "text-[#2596be] hover:bg-[#eaf6fb]"
                 } ${isLast ? "border-b-0" : "border-b border-[color:var(--line)]"}`}
                 href={item.href}
                 onClick={closeMenu}

--- a/app/globals.css
+++ b/app/globals.css
@@ -46,7 +46,7 @@ h6 {
 }
 
 @layer components {
-  /* Define estilo base único para todos os botões com visual pill e destaque vermelho. */
+  /* Define estilo base único para todos os botões com visual pill e destaque azul. */
   .site-pill-button,
   .button-size-login {
     display: inline-flex;
@@ -56,7 +56,7 @@ h6 {
     border: 0;
     border-radius: 100px;
     padding: 0 30px;
-    background-color: #F56151 !important;
+    background-color: #2596be !important;
     color: #ffffff !important;
     font-size: 0.875rem;
     font-weight: 700;
@@ -67,19 +67,19 @@ h6 {
     touch-action: manipulation;
   }
 
-  /* Realça o botão no hover com aumento subtil e sombra difusa vermelha. */
+  /* Realça o botão no hover com aumento subtil e sombra difusa azul. */
   .site-pill-button:hover,
   .button-size-login:hover {
-    background-color: #F56151 !important;
+    background-color: #2596be !important;
     filter: none !important;
-    box-shadow: 0 0 20px rgb(245 97 81 / 32%);
+    box-shadow: 0 0 20px rgb(37 150 190 / 32%);
     transform: translateZ(0) scale(1.03);
   }
 
   /* Aplica estado de clique com redução de escala para feedback tátil. */
   .site-pill-button:active,
   .button-size-login:active {
-    background-color: #F56151 !important;
+    background-color: #2596be !important;
     filter: none !important;
     box-shadow: none;
     transform: translateZ(0) scale(0.98);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function HomePage() {
   return (
     <section className="w-full">
       {/* Divide o hero em duas colunas no desktop para manter o texto à esquerda e a imagem à direita. */}
-      <div className="relative grid min-h-screen w-full bg-[#efefef] lg:grid-cols-2">
+      <div className="relative grid min-h-screen w-full bg-gradient-to-b from-[#0067a9] to-[#0067a9] lg:grid-cols-2">
         {/* Mantém um painel dedicado ao conteúdo textual para evitar que o texto desapareça atrás da imagem. */}
         <div className="relative z-10 flex px-6 py-24 sm:px-10 lg:px-16">
           {/* Estrutura o conteúdo textual para preservar hierarquia e legibilidade. */}
@@ -17,8 +17,8 @@ export default function HomePage() {
               Formação e prática
             </p>
 
-            {/* Destaca a proposta principal com cor vermelha e peso tipográfico forte para aumentar o impacto. */}
-            <h1 className="text-4xl font-bold leading-tight text-[color:var(--accent)] sm:text-5xl lg:text-6xl">
+            {/* Destaca a proposta principal com cor azul e peso tipográfico forte para aumentar o impacto. */}
+            <h1 className="text-4xl font-bold leading-tight text-[#2596be] sm:text-5xl lg:text-6xl">
               Sê pago para testar produtos e serviços
             </h1>
 


### PR DESCRIPTION
### Motivation
- Unify the UI accent color from the previous red tone to a blue palette to reflect an updated brand/theme. 
- Ensure visual consistency between the navigation, CTA buttons and hero content across breakpoints. 
- Harmonize hover/active states and mobile menu visuals with the new accent color.

### Description
- Replaced the previous red accent with blue `#2596be` for buttons and navigation in `app/globals.css` and `app/components/TopNav.tsx`.
- Updated desktop nav link color and active underline, and mobile menu link colors and hover background to use `#2596be` and `#eaf6fb` in `app/components/TopNav.tsx`.
- Switched the hero background from `bg-[#efefef]` to `bg-gradient-to-b from-[#0067a9] to-[#0067a9]` and changed the hero headline color to `#2596be` in `app/page.tsx`.
- Adjusted button hover shadow color to `rgb(37 150 190 / 32%)` and updated related hover/active states in `app/globals.css`.

### Testing
- No automated tests were added or modified for this visual/theme update.
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04cc2dc78832eb0ffa2992a744bf3)