### PR TITLE
Remove imagem da home, aplica gradiente radial e centraliza navbar no desktop

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -27,12 +27,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             CM
           </Link>
 
-          {/* Na home centra o menu na metade cinzenta; nas restantes páginas mantém o centro global. */}
-          <div
-            className={`justify-self-end lg:absolute lg:-translate-x-1/2 ${
-              isHomePage ? "lg:left-1/4" : "lg:left-1/2"
-            }`}
-          >
+          {/* Mantém o menu centrado no cabeçalho em desktop, inclusive na home. */}
+          <div className="justify-self-end lg:absolute lg:left-1/2 lg:-translate-x-1/2">
             <TopNav />
           </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,16 @@
-import Image from "next/image";
 import Link from "next/link";
-
-const mainHeroImagePath = "/images/Background.png";
 
 export default function HomePage() {
   return (
     <section className="w-full">
-      {/* Divide o hero em duas colunas no desktop para manter o texto à esquerda e a imagem à direita. */}
-      <div className="relative grid min-h-screen w-full bg-gradient-to-b from-[#0067a9] to-[#0067a9] lg:grid-cols-2">
-        {/* Mantém um painel dedicado ao conteúdo textual para evitar que o texto desapareça atrás da imagem. */}
-        <div className="relative z-10 flex px-6 py-24 sm:px-10 lg:px-16">
-          {/* Estrutura o conteúdo textual para preservar hierarquia e legibilidade. */}
-          <div className="flex min-h-[70vh] w-full max-w-xl flex-col gap-8">
+      {/* Mantém o hero em coluna única para remover a imagem e priorizar a mensagem principal. */}
+      <div className="relative flex min-h-screen w-full bg-[#9581C8] bg-[radial-gradient(circle,rgba(149,129,200,1)_0%,rgba(81,66,136,1)_100%)]">
+        {/* Centraliza e limita a largura do conteúdo textual para preservar legibilidade em todos os ecrãs. */}
+        <div className="relative z-10 flex w-full px-6 py-24 sm:px-10 lg:px-16">
+          {/* Organiza título, benefícios e CTA com espaçamento consistente. */}
+          <div className="mx-auto flex min-h-[70vh] w-full max-w-3xl flex-col items-center justify-center gap-8 text-center">
             {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
-            <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-black/70">
+            <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-white/80">
               Formação e prática
             </p>
 
@@ -22,15 +19,15 @@ export default function HomePage() {
               Sê pago para testar produtos e serviços
             </h1>
 
-            {/* Mostra os benefícios em bold e com tamanho ligeiramente inferior ao título principal. */}
-            <ul className="space-y-2 text-3xl font-bold leading-tight text-black sm:text-4xl lg:text-5xl">
+            {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual sem imagem lateral. */}
+            <ul className="space-y-2 text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl">
               <li>-Sem horários</li>
               <li>-Escolhes as marcas</li>
               <li>-Rendimento extra</li>
             </ul>
 
-            {/* Em mobile mantém o CTA no fluxo natural para facilitar leitura e toque. */}
-            <div className="flex justify-center pb-4 pt-8 lg:hidden">
+            {/* Mantém o CTA principal em posição central para facilitar leitura e toque em todos os dispositivos. */}
+            <div className="flex justify-center pb-4 pt-8">
               <Link
                 className="site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
                 href="/about"
@@ -39,28 +36,6 @@ export default function HomePage() {
               </Link>
             </div>
           </div>
-        </div>
-
-        {/* No desktop posiciona o CTA no centro horizontal da página, mantendo a altura atual no hero. */}
-        <div className="pointer-events-none absolute inset-x-0 bottom-[18%] z-20 hidden justify-center lg:flex">
-          <Link
-            className="pointer-events-auto site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
-            href="/about"
-          >
-            Começa Já
-          </Link>
-        </div>
-
-        {/* Garante que a imagem começa no topo e chega até ao extremo direito da página. */}
-        <div className="relative min-h-screen">
-          <Image
-            alt="Cliente mistério em destaque"
-            className="object-cover object-center"
-            fill
-            priority
-            sizes="(max-width: 1024px) 100vw, 50vw"
-            src={mainHeroImagePath}
-          />
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Simplificar o hero da página principal removendo a imagem lateral para priorizar o conteúdo textual e o CTA. 
- Aplicar o fundo fornecido (fallback sólido e gradiente radial) para corresponder ao design solicitado. 
- Garantir que a navigation bar fique centralizada no desktop mesmo na home para melhor alinhamento visual.

### Description
- Remove a referência e o componente `Image` da home em `app/page.tsx` e converte o hero para uma única coluna com conteúdo centrado. 
- Aplica o fundo solicitado na home usando classes utilitárias Tailwind: fallback `#9581C8` e gradiente radial `rgba(149,129,200,1) 0% -> rgba(81,66,136,1) 100%` em `app/page.tsx`. 
- Ajusta a posição do menu no cabeçalho em `app/components/AppShell.tsx` para usar `lg:left-1/2` e `lg:-translate-x-1/2`, centralizando a `TopNav` no desktop. 
- Atualiza cores de texto e layout do hero (por exemplo `text-white/80` para o rótulo editorial e `text-white` para a lista de benefícios) e remove o painel de imagem e CTA flutuante redundante em `app/page.tsx`.
- Ficheiros alterados: `app/page.tsx` e `app/components/AppShell.tsx`.

### Testing
- Executado `npm run lint`, que falhou com `sh: 1: next: not found`, logo lint não pôde ser validado no ambiente atual. 
- Tentativa de `npm ci` falhou com erro `403 Forbidden` ao aceder ao registry, portanto não foi possível instalar dependências para testes locais. 
- Tentativa de capturar screenshot via Playwright falhou com `ERR_EMPTY_RESPONSE` porque a aplicação não respondeu em `http://127.0.0.1:3000`, portanto a verificação visual não pôde ser concluída.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06594f7d0832e81e9cbd3bfbb28ee)