### PR TITLE
Switch header and navigation to dark theme and update pill button styling

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -13,11 +13,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     <div className="mx-auto min-h-screen w-full bg-[color:var(--background)]">
       {/* Mantém o cabeçalho absoluto na home para sobrepor o hero, e sticky nas páginas internas. */}
       <header
-        className={`${
-          isHomePage
-            ? "absolute inset-x-0 top-0 z-50 border-b border-transparent bg-transparent"
-            : "sticky top-0 z-50 border-b border-[color:var(--line)] bg-[color:var(--background)]/95 backdrop-blur-sm"
-        } px-4 py-5 sm:px-6 md:px-10 md:py-6`}
+        className="sticky top-0 z-50 border-b border-[color:var(--line)] bg-black px-4 py-5 sm:px-6 md:px-10 md:py-6"
       >
         <div className="relative flex w-full items-center justify-between gap-3">
           <Link

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -53,15 +53,15 @@ export default function TopNav() {
               key={item.href}
               className={`relative pb-2 text-[16px] font-semibold transition ${
                 isActive
-                  ? "text-[#e3a319]"
-                  : "text-[#e3a319] hover:text-[#e3a319]"
+                  ? "text-white"
+                  : "text-white hover:text-white"
               }`}
               href={item.href}
             >
               {item.label}
 
               {isActive ? (
-                <span className="absolute inset-x-0 -bottom-[2px] h-[2px] bg-[#e3a319]" />
+                <span className="absolute inset-x-0 -bottom-[2px] h-[2px] bg-white" />
               ) : null}
             </Link>
           );
@@ -70,7 +70,7 @@ export default function TopNav() {
 
       {/* Renderiza menu vertical no mobile com área clicável confortável e ordem visual consistente. */}
       {isMenuOpen ? (
-        <nav className="mobile-menu-container absolute inset-x-4 top-[84px] z-40 flex flex-col overflow-hidden rounded-[10px] border border-[color:var(--line)] bg-[color:var(--surface)] shadow-sm lg:hidden">
+        <nav className="mobile-menu-container absolute inset-x-4 top-[84px] z-40 flex flex-col overflow-hidden rounded-[10px] border border-[color:var(--line)] bg-black shadow-sm lg:hidden">
           {navigationItems.map((item, index) => {
             const isActive = pathname === item.href;
             const isLast = index === navigationItems.length - 1;
@@ -80,8 +80,8 @@ export default function TopNav() {
                 key={item.href}
                 className={`mobile-menu-item px-5 py-4 text-base font-semibold transition ${
                   isActive
-                    ? "text-[#e3a319]"
-                    : "text-[#e3a319] hover:bg-[#fdf3dc]"
+                    ? "text-white"
+                    : "text-white hover:bg-[#111111]"
                 } ${isLast ? "border-b-0" : "border-b border-[color:var(--line)]"}`}
                 href={item.href}
                 onClick={closeMenu}

--- a/app/globals.css
+++ b/app/globals.css
@@ -56,7 +56,8 @@ h6 {
     border: 0;
     border-radius: 100px;
     padding: 0 30px;
-    background-color: #e3a319 !important;
+    background-color: #000000 !important;
+    border: 1px solid #ffffff;
     color: #ffffff !important;
     font-size: 0.875rem;
     font-weight: 700;
@@ -70,16 +71,16 @@ h6 {
   /* Realça o botão no hover com aumento subtil e sombra difusa dourada. */
   .site-pill-button:hover,
   .button-size-login:hover {
-    background-color: #e3a319 !important;
+    background-color: #000000 !important;
     filter: none !important;
-    box-shadow: 0 0 20px rgb(227 163 25 / 32%);
+    box-shadow: 0 0 20px rgb(255 255 255 / 28%);
     transform: translateZ(0) scale(1.03);
   }
 
   /* Aplica estado de clique com redução de escala para feedback tátil. */
   .site-pill-button:active,
   .button-size-login:active {
-    background-color: #e3a319 !important;
+    background-color: #000000 !important;
     filter: none !important;
     box-shadow: none;
     transform: translateZ(0) scale(0.98);


### PR DESCRIPTION
### Motivation
- Unify the app chrome to a dark/black theme and simplify header behavior by removing the special-case absolute header on the home page.
- Replace the previous gold accent (`#e3a319`) with a neutral black/white palette for navigation and controls to achieve a more minimal visual language.

### Description
- Simplified the header in `AppShell.tsx` to always use a sticky black header by replacing the conditional absolute/sticky class with a single sticky black class.
- Updated `TopNav.tsx` to use white text and underline for active links and changed the mobile menu background and hover state to dark variants instead of the previous gold/light styles.
- Reworked button styles in `app/globals.css` by changing `.site-pill-button` and `.button-size-login` to a black background with a white border, white text, and adjusted hover/box-shadow and active states to match the dark theme.

### Testing
- Ran a project type-check with `tsc --noEmit` which completed successfully.
- Executed the build with `npm run build` which completed without errors.
- Ran linting with `npm run lint` which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06845c3c4832e9ec2d188d8266f2f)