### PR TITLE
Atualiza fundo global com gradiente radial roxo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #000000;
+  --background: #9581C8;
   --foreground: #ffffff;
   --surface: #000000;
   --surface-muted: #0f0f0f;
@@ -27,7 +27,8 @@
 }
 
 body {
-  background: var(--background);
+  background: #9581C8;
+  background: radial-gradient(circle, rgba(149, 129, 200, 1) 0%, rgba(81, 66, 136, 1) 100%);
   color: var(--foreground);
   font-family: var(--font-sans);
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
### Motivation
- Ajustar o fundo global para o gradiente solicitado atualizando a variável `--background` e aplicando o gradiente no `body` para uniformizar o visual do site.

### Description
- Atualizei o arquivo `app/globals.css` definindo `--background: #9581C8;` e aplicando `background: #9581C8;` seguido de `background: radial-gradient(circle, rgba(149, 129, 200, 1) 0%, rgba(81, 66, 136, 1) 100%);` na regra do `body`.

### Testing
- Executei `npm run lint` que falhou porque o binário `next` não está disponível no ambiente; `npm ci` falhou devido a diferenças entre `package.json` e `package-lock.json`; e uma tentativa de captura com Playwright falhou com `ERR_EMPTY_RESPONSE` porque não havia servidor ativo na porta esperada (3000).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1522ae5d8832eaab38ac412e0e435)