### PR TITLE
feat: update site background to match purple reference gradient

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #9581C8;
+  --background: #6f5eb2;
   --foreground: #ffffff;
   --surface: #000000;
   --surface-muted: #0f0f0f;
@@ -27,8 +27,12 @@
 }
 
 body {
-  background: #9581C8;
-  background: radial-gradient(circle, rgba(149, 129, 200, 1) 0%, rgba(81, 66, 136, 1) 100%);
+  /* Combina gradiente radial e linear para reproduzir o fundo roxo com centro mais iluminado da referência. */
+  background-color: #31285e;
+  background-image:
+    radial-gradient(circle at 50% 68%, #8f7bda 0%, #6c59b2 40%, #4e3e8f 68%, #30265d 100%),
+    linear-gradient(160deg, #231a49 0%, #4a3a86 55%, #6655ae 100%);
+  background-attachment: fixed;
   color: var(--foreground);
   font-family: var(--font-sans);
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
### Motivation
- Reproduzir o fundo roxo da imagem de referência no site mantendo os tokens de cor existentes e ignorando os elementos de primeiro plano da referência.

### Description
- Atualizei o token base `--background` para `#6f5eb2` no arquivo `app/globals.css`.
- Substituí a regra `body` por uma combinação de `radial-gradient` e `linear-gradient` com `background-attachment: fixed` e adicionei um comentário em português explicando a composição do gradiente.
- Mantive os demais tokens e estilos globais intactos para não alterar a tipografia nem a paleta funcional do projeto.
- Arquivo modificado: `app/globals.css`.

### Testing
- Executei `npm run lint` e o processo falhou porque o binário `next` não está disponível no ambiente (`sh: 1: next: not found`).
- Tentei `npm ci` e a instalação falhou com `403 Forbidden` ao resolver dependências (erro ao baixar `pg`).
- Tentei gerar um screenshot com Playwright apontando para `http://127.0.0.1:3000` e a captura falhou porque não havia servidor respondendo (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15499cc5c832e814a114050d68250)