### PR TITLE
Make site buttons white with black text and add homepage blue highlight

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -44,6 +44,12 @@ body * {
   color: var(--foreground) !important;
 }
 
+
+/* Permite destacar textos específicos da home sem ser afetado pela regra global de contraste. */
+.home-highlight-text {
+  color: #2596be !important;
+}
+
 /* Mantém campos de formulário com fundo preto e texto branco em todas as páginas. */
 input,
 textarea,
@@ -65,7 +71,7 @@ h6 {
 }
 
 @layer components {
-  /* Define estilo base único para todos os botões com visual pill e destaque dourado. */
+  /* Define estilo base único para todos os botões com fundo branco e texto preto. */
   .site-pill-button,
   .button-size-login {
     display: inline-flex;
@@ -75,9 +81,9 @@ h6 {
     border: 0;
     border-radius: 100px;
     padding: 0 30px;
-    background-color: #000000 !important;
+    background-color: #ffffff !important;
     border: 1px solid #ffffff;
-    color: #ffffff !important;
+    color: #000000 !important;
     font-size: 0.875rem;
     font-weight: 700;
     line-height: 1;
@@ -87,10 +93,10 @@ h6 {
     touch-action: manipulation;
   }
 
-  /* Realça o botão no hover com aumento subtil e sombra difusa dourada. */
+  /* Realça o botão no hover mantendo o contraste de fundo branco com texto preto. */
   .site-pill-button:hover,
   .button-size-login:hover {
-    background-color: #000000 !important;
+    background-color: #ffffff !important;
     filter: none !important;
     box-shadow: 0 0 20px rgb(255 255 255 / 28%);
     transform: translateZ(0) scale(1.03);
@@ -99,7 +105,7 @@ h6 {
   /* Aplica estado de clique com redução de escala para feedback tátil. */
   .site-pill-button:active,
   .button-size-login:active {
-    background-color: #000000 !important;
+    background-color: #ffffff !important;
     filter: none !important;
     box-shadow: none;
     transform: translateZ(0) scale(0.98);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,13 +14,13 @@ export default function HomePage() {
               Formação e prática
             </p>
 
-            {/* Destaca a proposta principal com cor dourada e peso tipográfico forte para aumentar o impacto. */}
-            <h1 className="text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl">
+            {/* Destaca a proposta principal com azul de marca e peso tipográfico forte para aumentar o impacto. */}
+            <h1 className="text-4xl font-bold leading-tight home-highlight-text sm:text-5xl lg:text-6xl">
               Sê pago para testar produtos e serviços
             </h1>
 
             {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual sem imagem lateral. */}
-            <ul className="space-y-2 text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl">
+            <ul className="space-y-2 text-3xl font-bold leading-tight home-highlight-text sm:text-4xl lg:text-5xl">
               <li>-Sem horários</li>
               <li>-Escolhes as marcas</li>
               <li>-Rendimento extra</li>


### PR DESCRIPTION
### Motivation
- Implement the requested visual update to make all site buttons use a white background with black text for consistent contrast.
- Highlight the homepage hero copy and the three benefit lines in the brand blue `#2596be` while preserving the global forced-contrast rule.

### Description
- Updated `app/globals.css` to change `.site-pill-button` and `.button-size-login` to `background-color: #ffffff` and `color: #000000`, and adjusted `:hover` and `:active` states to keep the white treatment.
- Added a `.home-highlight-text` utility in `app/globals.css` to allow specific elements to override the global `body * { color: ... !important; }` rule and use `#2596be`.
- Applied the `.home-highlight-text` class in `app/page.tsx` to the hero `h1` and the three list items (`-Sem horários`, `-Escolhes as marcas`, `-Rendimento extra`).
- Changes were committed with a descriptive message and affect all places that use the shared button classes.

### Testing
- Ran `npm run lint`, which failed because `next` is not installed in the environment (`next: not found`).
- Ran `npm ci`, which failed due to registry access (`403 Forbidden - GET https://registry.npmjs.org/pg`).
- Attempted a Playwright screenshot against `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because the dev server was not running.
- No unit/integration tests executed successfully in this environment due to dependency and runtime constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b160f6d010832e94b02db37639a22c)