### PR TITLE
Add homepage text highlight classes and switch pill buttons to white

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -44,6 +44,17 @@ body * {
   color: var(--foreground) !important;
 }
 
+
+/* Permite destacar textos específicos da home sem ser afetado pela regra global de contraste. */
+.home-title-highlight-text {
+  color: #e49b27 !important;
+}
+
+/* Aplica cor de destaque secundária aos benefícios da home com prioridade sobre a regra global. */
+.home-benefits-highlight-text {
+  color: #F6C25B !important;
+}
+
 /* Mantém campos de formulário com fundo preto e texto branco em todas as páginas. */
 input,
 textarea,
@@ -65,7 +76,7 @@ h6 {
 }
 
 @layer components {
-  /* Define estilo base único para todos os botões com visual pill e destaque dourado. */
+  /* Define estilo base único para todos os botões com fundo branco e texto preto. */
   .site-pill-button,
   .button-size-login {
     display: inline-flex;
@@ -75,9 +86,9 @@ h6 {
     border: 0;
     border-radius: 100px;
     padding: 0 30px;
-    background-color: #000000 !important;
+    background-color: #ffffff !important;
     border: 1px solid #ffffff;
-    color: #ffffff !important;
+    color: #000000 !important;
     font-size: 0.875rem;
     font-weight: 700;
     line-height: 1;
@@ -87,10 +98,10 @@ h6 {
     touch-action: manipulation;
   }
 
-  /* Realça o botão no hover com aumento subtil e sombra difusa dourada. */
+  /* Realça o botão no hover mantendo o contraste de fundo branco com texto preto. */
   .site-pill-button:hover,
   .button-size-login:hover {
-    background-color: #000000 !important;
+    background-color: #ffffff !important;
     filter: none !important;
     box-shadow: 0 0 20px rgb(255 255 255 / 28%);
     transform: translateZ(0) scale(1.03);
@@ -99,7 +110,7 @@ h6 {
   /* Aplica estado de clique com redução de escala para feedback tátil. */
   .site-pill-button:active,
   .button-size-login:active {
-    background-color: #000000 !important;
+    background-color: #ffffff !important;
     filter: none !important;
     box-shadow: none;
     transform: translateZ(0) scale(0.98);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,13 +14,13 @@ export default function HomePage() {
               Formação e prática
             </p>
 
-            {/* Destaca a proposta principal com cor dourada e peso tipográfico forte para aumentar o impacto. */}
-            <h1 className="text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl">
+            {/* Destaca a proposta principal com cor de marca e peso tipográfico forte para aumentar o impacto. */}
+            <h1 className="text-4xl font-bold leading-tight home-title-highlight-text sm:text-5xl lg:text-6xl">
               Sê pago para testar produtos e serviços
             </h1>
 
             {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual sem imagem lateral. */}
-            <ul className="space-y-2 text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl">
+            <ul className="space-y-2 text-3xl font-bold leading-tight home-benefits-highlight-text sm:text-4xl lg:text-5xl">
               <li>-Sem horários</li>
               <li>-Escolhes as marcas</li>
               <li>-Rendimento extra</li>


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy on the landing hero by allowing specific headline and benefits text to use brand highlight colors despite a global contrast rule. 
- Standardize button appearance to a white background with black text for clearer contrast and consistent CTA styling. 
- Ensure form controls keep a dark background with readable white text across the site.

### Description
- Added two new CSS classes in `app/globals.css`: ` .home-title-highlight-text` and `.home-benefits-highlight-text` to override the global `color` rule for targeted highlighted text. 
- Updated the global rule that forced white text for all elements and maintained it while providing explicit overrides for the new highlight classes. 
- Changed pill button styles in `app/globals.css` (`.site-pill-button`, `.button-size-login`) to use a white background and black text, and adjusted hover/active states to preserve the white background. 
- Applied the new highlight classes in `app/page.tsx` to the hero `h1` (`home-title-highlight-text`) and benefits `ul` (`home-benefits-highlight-text`) to expose the new colors on the homepage.

### Testing
- No automated tests were run for these style and markup changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b160f6d010832e94b02db37639a22c)