### PR TITLE
Adjust homepage highlight colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -47,12 +47,16 @@ body * {
 
 /* Permite destacar textos específicos da home sem ser afetado pela regra global de contraste. */
 .home-title-highlight-text {
-  color: #e49b27 !important;
+  color: #F6C25B !important;
 }
 
 /* Aplica cor de destaque secundária aos benefícios da home com prioridade sobre a regra global. */
 .home-benefits-highlight-text {
   color: #F6C25B !important;
+}
+/* Destaca especificamente o benefício de rendimento com tom dourado mais intenso. */
+.home-benefit-extra-highlight-text {
+  color: #e49b27 !important;
 }
 
 /* Mantém campos de formulário com fundo preto e texto branco em todas as páginas. */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,10 +20,10 @@ export default function HomePage() {
             </h1>
 
             {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual sem imagem lateral. */}
-            <ul className="space-y-2 text-3xl font-bold leading-tight home-benefits-highlight-text sm:text-4xl lg:text-5xl">
+            <ul className="space-y-2 text-3xl font-bold leading-tight sm:text-4xl lg:text-5xl">
               <li>-Sem horários</li>
               <li>-Escolhes as marcas</li>
-              <li>-Rendimento extra</li>
+              <li className="home-benefit-extra-highlight-text">-Rendimento extra</li>
             </ul>
 
             {/* Mantém o CTA principal em posição central para facilitar leitura e toque em todos os dispositivos. */}


### PR DESCRIPTION
### Motivation
- Harmonize homepage copy with the requested color palette by making the main headline and a specific benefit use the specified tones. 
- Ensure only the intended benefit item uses the stronger gold tone rather than the whole list inheriting the same color. 

### Description
- Updated `app/globals.css` to change the `.home-title-highlight-text` color from `#e49b27` to `#F6C25B` and added a new utility class `.home-benefit-extra-highlight-text` with color `#e49b27`.
- Modified `app/page.tsx` to remove the global benefits highlight class from the `<ul>` and apply `home-benefit-extra-highlight-text` to the third `<li>` only.
- This keeps the first two benefit items with the default foreground color and highlights the headline and the single benefit with the requested tones.

### Testing
- Ran `npm run lint` which failed due to the environment missing `next` (`sh: 1: next: not found`).
- Attempted `npm install` which failed due to registry access policy (`403 Forbidden` when fetching dependencies).
- Tried a Playwright screenshot of `http://127.0.0.1:3000` which failed with `net::ERR_EMPTY_RESPONSE` because the dev server was not running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16548c618832e87bfb55cd16e7081)