### PR TITLE
Set homepage benefit list text to white

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,10 +20,10 @@ export default function HomePage() {
             </h1>
 
             {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual sem imagem lateral. */}
-            <ul className="space-y-2 text-3xl font-bold leading-tight sm:text-4xl lg:text-5xl">
+            <ul className="space-y-2 text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl">
               <li>-Sem horários</li>
               <li>-Escolhes as marcas</li>
-              <li className="home-benefit-extra-highlight-text">-Rendimento extra</li>
+              <li>-Rendimento extra</li>
             </ul>
 
             {/* Mantém o CTA principal em posição central para facilitar leitura e toque em todos os dispositivos. */}


### PR DESCRIPTION
### Motivation
- Garantir que os três tópicos da secção de benefícios (`-Sem horários`, `-Escolhes as marcas`, `-Rendimento extra`) apareçam em branco conforme solicitado para uniformidade visual.

### Description
- Atualizei `app/page.tsx` para adicionar a classe `text-white` ao `<ul>` que contém os benefícios e removi a classe `home-benefit-extra-highlight-text` do terceiro `<li>` para que todos os itens partilhem a mesma cor; o ficheiro foi salvo com a versão completa atualizada.

### Testing
- Tentei executar `npm run lint` e `npm install`, mas `npm run lint` falhou porque `next` não está instalado e `npm install` falhou com `403 Forbidden` ao aceder ao registry npm, e a tentativa de capturar a página com Playwright falhou com `ERR_EMPTY_RESPONSE` porque a aplicação não pôde ser iniciada sem dependências.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b172d4dbf0832eb3226c720854354b)