### PR TITLE
Dashboard: white header, wider form layout and yellow checkboxes

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -475,14 +475,15 @@ export default function DashboardPage() {
       )}
 
       <div className="mx-auto w-full max-w-6xl space-y-8">
-        <header className="rounded-[32px] bg-[color:var(--surface)] p-8 shadow-[0_20px_50px_rgba(31,41,55,0.08)]">
-          <h1 className="page-title">Olá, {profile.firstName}</h1>
-          <p className="mt-3 text-sm">Faça a gestão da sua conta e segurança.</p>
+        <header className="rounded-[32px] bg-white p-8 text-black shadow-[0_20px_50px_rgba(31,41,55,0.08)]">
+          <h1 className="page-title !text-black">Olá, {profile.firstName}</h1>
+          <p className="mt-3 text-sm text-black">Faça a gestão da sua conta e segurança.</p>
         </header>
 
-        <article className="login-form max-w-none">
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="input-group">
+        <div className="grid items-start gap-8 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+          <article className="login-form dashboard-form max-w-none">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="input-group">
               <input
                 value={profile.firstName}
                 onChange={(event) => handleProfileChange("firstName", event.target.value)}
@@ -566,101 +567,102 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          {profileFeedback && (
-            <p className="form-feedback mt-2">
-              {profileFeedback}
-            </p>
-          )}
+            {profileFeedback && (
+              <p className="form-feedback mt-2">
+                {profileFeedback}
+              </p>
+            )}
 
-          <div className="mt-4 flex gap-3">
-            <button
-              className="submit"
-              type="button"
-              onClick={handleSaveProfile}
-            >
-              {isSavingProfile ? "A guardar..." : "Guardar perfil"}
-            </button>
-          </div>
+            <div className="mt-4 flex gap-3">
+              <button
+                className="submit"
+                type="button"
+                onClick={handleSaveProfile}
+              >
+                {isSavingProfile ? "A guardar..." : "Guardar perfil"}
+              </button>
+            </div>
 
-          <div className="mt-8 border-t border-slate-200 pt-8">
-            <h2 className="section-title">Alterar palavra-passe</h2>
-            <div className="mt-4 grid gap-4 md:grid-cols-2">
-              <div className="input-group md:col-span-2">
-                <input
-                  placeholder="Senha atual"
-                  type="password"
-                  value={passwordForm.currentPassword}
-                  onChange={(event) =>
-                    handlePasswordFieldChange("currentPassword", event.target.value)
-                  }
-                />
-                <span className="label">Senha atual</span>
+            <div className="mt-8 border-t border-slate-200 pt-8">
+              <h2 className="section-title">Alterar palavra-passe</h2>
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <div className="input-group md:col-span-2">
+                  <input
+                    placeholder="Senha atual"
+                    type="password"
+                    value={passwordForm.currentPassword}
+                    onChange={(event) =>
+                      handlePasswordFieldChange("currentPassword", event.target.value)
+                    }
+                  />
+                  <span className="label">Senha atual</span>
+                </div>
+                <div className="input-group">
+                  <input
+                    placeholder="Nova senha"
+                    type="password"
+                    value={passwordForm.newPassword}
+                    onChange={(event) =>
+                      handlePasswordFieldChange("newPassword", event.target.value)
+                    }
+                  />
+                  <span className="label">Nova senha</span>
+                </div>
+                <div className="input-group">
+                  <input
+                    placeholder="Confirmar nova senha"
+                    type="password"
+                    value={passwordForm.confirmNewPassword}
+                    onChange={(event) =>
+                      handlePasswordFieldChange("confirmNewPassword", event.target.value)
+                    }
+                  />
+                  <span className="label">Confirmar nova senha</span>
+                </div>
               </div>
-              <div className="input-group">
-                <input
-                  placeholder="Nova senha"
-                  type="password"
-                  value={passwordForm.newPassword}
-                  onChange={(event) =>
-                    handlePasswordFieldChange("newPassword", event.target.value)
-                  }
-                />
-                <span className="label">Nova senha</span>
+              {passwordFeedback && <p className="form-feedback mt-2">{passwordFeedback}</p>}
+              <button
+                className="submit mt-4"
+                type="button"
+                onClick={handleChangePassword}
+              >
+                {isSavingPassword ? "A atualizar..." : "Atualizar senha"}
+              </button>
+            </div>
+          </article>
+
+          <aside className="login-form max-w-none xl:sticky xl:top-6">
+            <h3 className="card-title">Preferências</h3>
+            <div className="mt-4 space-y-3">
+              <div className="flex items-center justify-between text-sm">
+                <label htmlFor="receive-newsletter">Receber newsletter</label>
+                <label className="checkbox-container" htmlFor="receive-newsletter">
+                  <input
+                    id="receive-newsletter"
+                    className="custom-checkbox"
+                    type="checkbox"
+                    checked={preferences.receiveNewsletter}
+                    onChange={() => handlePreferenceChange("receiveNewsletter")}
+                  />
+                  <span className="checkmark" aria-hidden="true" />
+                </label>
               </div>
-              <div className="input-group">
-                <input
-                  placeholder="Confirmar nova senha"
-                  type="password"
-                  value={passwordForm.confirmNewPassword}
-                  onChange={(event) =>
-                    handlePasswordFieldChange("confirmNewPassword", event.target.value)
-                  }
-                />
-                <span className="label">Confirmar nova senha</span>
+              <div className="flex items-center justify-between text-sm">
+                <label htmlFor="allow-notifications">Notificações da comunidade</label>
+                <label className="checkbox-container" htmlFor="allow-notifications">
+                  <input
+                    id="allow-notifications"
+                    className="custom-checkbox"
+                    type="checkbox"
+                    checked={preferences.allowNotifications}
+                    onChange={() => handlePreferenceChange("allowNotifications")}
+                  />
+                  <span className="checkmark" aria-hidden="true" />
+                </label>
               </div>
             </div>
-            {passwordFeedback && <p className="form-feedback mt-2">{passwordFeedback}</p>}
-            <button
-              className="submit mt-4"
-              type="button"
-              onClick={handleChangePassword}
-            >
-              {isSavingPassword ? "A atualizar..." : "Atualizar senha"}
-            </button>
-          </div>
-        </article>
-
-        <aside className="login-form max-w-none">
-          <h3 className="card-title">Preferências</h3>
-          <div className="mt-4 space-y-3">
-            <div className="flex items-center justify-between text-sm">
-              <label htmlFor="receive-newsletter">Receber newsletter</label>
-              <label className="checkbox-container" htmlFor="receive-newsletter">
-                <input
-                  id="receive-newsletter"
-                  className="custom-checkbox"
-                  type="checkbox"
-                  checked={preferences.receiveNewsletter}
-                  onChange={() => handlePreferenceChange("receiveNewsletter")}
-                />
-                <span className="checkmark" aria-hidden="true" />
-              </label>
-            </div>
-            <div className="flex items-center justify-between text-sm">
-              <label htmlFor="allow-notifications">Notificações da comunidade</label>
-              <label className="checkbox-container" htmlFor="allow-notifications">
-                <input
-                  id="allow-notifications"
-                  className="custom-checkbox"
-                  type="checkbox"
-                  checked={preferences.allowNotifications}
-                  onChange={() => handlePreferenceChange("allowNotifications")}
-                />
-                <span className="checkmark" aria-hidden="true" />
-              </label>
-            </div>
-          </div>
-        </aside>
+          </aside>
+        </div>
 
         <div className="flex justify-end">
           <button

--- a/app/globals.css
+++ b/app/globals.css
@@ -251,7 +251,7 @@ h6 {
     left: 0;
     height: 25px;
     width: 25px;
-    background-color: #eee;
+    background-color: #fef3c7;
     border-radius: 4px;
     transition: background-color 0.3s;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
@@ -271,10 +271,10 @@ h6 {
     transform: rotate(45deg);
   }
 
-  /* Aplica o tom vermelho solicitado e reforça destaque visual quando selecionado. */
+  /* Aplica o tom amarelo solicitado e reforça destaque visual quando selecionado. */
   .custom-checkbox:checked ~ .checkmark {
-    background-color: #F56151;
-    box-shadow: 0 3px 7px rgba(245, 97, 81, 0.3);
+    background-color: #facc15;
+    box-shadow: 0 3px 7px rgba(250, 204, 21, 0.35);
   }
 
   /* Exibe o check e dispara animação curta para feedback da seleção. */
@@ -285,7 +285,7 @@ h6 {
 
   /* Remove contorno padrão e usa anel customizado para foco acessível. */
   .custom-checkbox:focus-visible ~ .checkmark {
-    outline: 2px solid #F56151;
+    outline: 2px solid #facc15;
     outline-offset: 2px;
   }
 
@@ -318,12 +318,16 @@ h6 {
 
 .login-form {
   width: 100%;
-  max-width: 420px;
+  max-width: 520px;
   padding: 40px;
   background: rgb(255 255 255 / 90%);
   border-radius: 12px;
   box-shadow: 0 10px 30px rgb(0 0 0 / 10%);
   animation: fadeIn 1.5s ease-out;
+}
+
+.dashboard-form {
+  max-width: 100%;
 }
 
 .login-form * {


### PR DESCRIPTION
### Motivation
- Fazer a secção de boas-vindas do dashboard ("Olá, ... / Faça a gestão da sua conta e segurança.") com fundo branco e texto preto para melhor legibilidade sobre o cartão.
- Reduzir a verticalidade do formulário principal tornando-o mais largo e aproveitando um layout em duas colunas para UX de edição de perfil.
- Alterar o estilo das checkboxes para amarelo com check branco e foco consistente com o tom amarelo solicitado.

### Description
- Atualizado `app/dashboard/page.tsx` para definir o `header` com `bg-white` e classes explícitas `text-black` no título e subtítulo, e para reestruturar a área principal para uma grelha com duas colunas (`xl:grid-cols[...]`) contendo o formulário principal e a coluna de preferências laterais.
- Modificado `app/dashboard/page.tsx` para mover o formulário principal para um `article` com classes `login-form dashboard-form max-w-none` e tornar o card de preferências um `aside` fixo em ecrãs maiores (`xl:sticky xl:top-6`).
- Alterado `app/globals.css` para aumentar `max-width` de `.login-form` de `420px` para `520px`, adicionar `.dashboard-form { max-width: 100%; }` e ajustar as regras do checkbox para usar `background-color: #fef3c7` (base), estado marcado `#facc15` e `box-shadow`/`outline` amarelos com o `check` em branco.

### Testing
- Executado `npm run lint`, que falhou com `sh: 1: next: not found` porque o binário `next` não está instalado no ambiente de execução (teste automatizado falhou).
- Tentativa de instalar dependências com `npm install` falhou com `403 Forbidden` ao buscar o pacote `pg` no registry, impedindo validação adicional (falha por ambiente externo).
- Tentativa de captura de ecrã com Playwright (`page.goto('http://127.0.0.1:3000/dashboard')`) falhou com `ERR_EMPTY_RESPONSE` porque a aplicação não estava a correr no porto 3000 (falha de ambiente de runtime).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17b02d9c8832e9cc6e86cb5c3bffd)