### PR TITLE
Add right-side decorative image to home hero section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,27 @@
+import Image from "next/image";
 import Link from "next/link";
 
 export default function HomePage() {
   return (
     <section className="w-full">
-      {/* Mantém o hero em coluna única para remover a imagem e priorizar a mensagem principal. */}
+      {/* Mantém o hero em coluna única para priorizar a mensagem principal em ecrãs pequenos. */}
       <div className="relative flex min-h-screen w-full bg-transparent">
+        {/* Posiciona a imagem decorativa no lado direito apenas em desktop para não comprometer a leitura no mobile. */}
+        <div className="pointer-events-none absolute inset-y-0 right-0 hidden w-[42vw] max-w-[680px] lg:block">
+          {/* Usa imagem local otimizada do Next para garantir desempenho e manter o visual solicitado. */}
+          <Image
+            src="/images/background (2).png"
+            alt="Imagem decorativa do lado direito"
+            fill
+            className="object-contain object-right"
+            priority
+          />
+        </div>
+
         {/* Centraliza e limita a largura do conteúdo textual para preservar legibilidade em todos os ecrãs. */}
         <div className="relative z-10 flex w-full px-6 py-24 sm:px-10 lg:px-16">
-          {/* Organiza título, benefícios e CTA com espaçamento consistente. */}
-          <div className="mx-auto flex min-h-[70vh] w-full max-w-3xl flex-col items-center justify-center gap-8 text-center">
+          {/* Organiza título, benefícios e CTA com espaçamento consistente e com respiro à direita em desktop. */}
+          <div className="mx-auto flex min-h-[70vh] w-full max-w-3xl flex-col items-center justify-center gap-8 pr-0 text-center lg:mx-0 lg:ml-0 lg:pr-[30vw]">
             {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
             <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-white/80">
               Formação e prática
@@ -19,7 +32,7 @@ export default function HomePage() {
               Sê pago para testar produtos e serviços
             </h1>
 
-            {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual sem imagem lateral. */}
+            {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual. */}
             <ul className="space-y-2 text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl">
               <li>-Sem horários</li>
               <li>-Escolhes as marcas</li>


### PR DESCRIPTION
### Motivation
- Improve the visual design of the home hero by adding the requested decorative image from `public/images/background (2).png` on the right side. 
- Keep mobile readability by showing the image only on large screens. 

### Description
- Imported `next/image` and added a right-aligned decorative `<Image>` using `src="/images/background (2).png"` inside `app/page.tsx` and set it to render only on `lg` screens. 
- Adjusted hero layout spacing by adding `pr-0` and `lg:pr-[30vw]` to the hero content container so text does not overlap the new image. 
- Minor comment updates to clarify behavior and preserved the rest of the hero structure and CTAs unchanged.

### Testing
- Ran `npm run lint` which failed because the `next` binary is not available in this environment (`sh: 1: next: not found`).
- Attempted `npm install` which ran but did not produce a usable `next` CLI in this environment (installation appeared unstable/hanging during the session). 
- Ran a Playwright script to capture a screenshot which failed because no local dev server was responding at `http://127.0.0.1:3000` (error `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18982627c832e9d1011cb84174b1e)