### PR TITLE
Center hero content more on desktop (app/page.tsx)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,9 +19,9 @@ export default function HomePage() {
         </div>
 
         {/* Centraliza e limita a largura do conteúdo textual para preservar legibilidade em todos os ecrãs. */}
-        <div className="relative z-10 flex w-full px-6 py-24 sm:px-10 lg:px-16">
-          {/* Organiza título, benefícios e CTA com espaçamento consistente e com respiro à direita em desktop. */}
-          <div className="mx-auto flex min-h-[70vh] w-full max-w-3xl flex-col items-center justify-center gap-8 pr-0 text-center lg:mx-0 lg:ml-0 lg:pr-[30vw]">
+        <div className="relative z-10 flex w-full px-6 py-24 sm:px-10 lg:px-20 xl:px-24">
+          {/* Organiza título, benefícios e CTA com espaçamento consistente, deslocando o bloco ligeiramente para o centro em desktop. */}
+          <div className="mx-auto flex min-h-[70vh] w-full max-w-3xl flex-col items-center justify-center gap-8 pr-0 text-center lg:max-w-4xl lg:pr-[26vw] xl:pr-[24vw]">
             {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
             <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-white/80">
               Formação e prática


### PR DESCRIPTION
### Motivation
- Improve the visual balance of the home hero so the text block reads less left-aligned and appears more centered on larger screens.

### Description
- Updated `app/page.tsx` to increase horizontal padding on large breakpoints (`lg:px-20 xl:px-24`) to push the content inward. 
- Adjusted the hero text container max width and right padding (`lg:max-w-4xl lg:pr-[26vw] xl:pr-[24vw]`) so the text block visually shifts toward center on desktop while preserving mobile layout. 
- Kept all existing content, hierarchy and responsive behavior intact (title, benefits list and CTA remain unchanged).

### Testing
- Ran `npm run lint`, which failed because `next` is not installed in this environment (`sh: 1: next: not found`).
- Ran `npm ci`, which failed due to registry access (`403 Forbidden` when fetching `pg`).
- Attempted a Playwright screenshot of `http://127.0.0.1:3000`, which failed because no dev server responded (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18d8f0430832eaab4dfc38206abf2)