### PR TITLE
Refactor hero layout to responsive two-column content wrapper with decorative image

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,49 +4,52 @@ import Link from "next/link";
 export default function HomePage() {
   return (
     <section className="w-full">
-      {/* Mantém o hero em coluna única para priorizar a mensagem principal em ecrãs pequenos. */}
-      <div className="relative flex min-h-screen w-full bg-transparent">
-        {/* Posiciona a imagem decorativa no lado direito apenas em desktop para não comprometer a leitura no mobile. */}
-        <div className="pointer-events-none absolute inset-y-0 right-0 hidden w-[42vw] max-w-[680px] lg:block">
-          {/* Usa imagem local otimizada do Next para garantir desempenho e manter o visual solicitado. */}
-          <Image
-            src="/images/background (2).png"
-            alt="Imagem decorativa do lado direito"
-            fill
-            className="object-contain object-right"
-            priority
-          />
-        </div>
+      {/* Mantém o hero a ocupar o ecrã para preservar o impacto visual da primeira dobra. */}
+      <div className="relative min-h-screen w-full bg-transparent">
+        {/* Usa um content wrapper com limites de largura para criar margens laterais consistentes em desktop. */}
+        <div className="mx-auto flex min-h-screen w-full max-w-[1440px] px-6 py-16 sm:px-10 lg:px-20 xl:px-24">
+          {/* Em desktop, distribui texto e imagem em duas colunas com espaçamento semelhante à referência. */}
+          <div className="grid w-full items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)] lg:gap-16 xl:gap-20">
+            {/* Agrupa o conteúdo textual e mantém alinhamento central no mobile e à esquerda no desktop. */}
+            <div className="flex w-full max-w-2xl flex-col items-center justify-center gap-8 text-center lg:items-start lg:text-left">
+              {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
+              <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-white/80">
+                Formação e prática
+              </p>
 
-        {/* Centraliza e limita a largura do conteúdo textual para preservar legibilidade em todos os ecrãs. */}
-        <div className="relative z-10 flex w-full px-6 py-24 sm:px-10 lg:px-16">
-          {/* Organiza título, benefícios e CTA com espaçamento consistente e com respiro à direita em desktop. */}
-          <div className="mx-auto flex min-h-[70vh] w-full max-w-3xl flex-col items-center justify-center gap-8 pr-0 text-center lg:mx-0 lg:ml-0 lg:pr-[30vw]">
-            {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
-            <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-white/80">
-              Formação e prática
-            </p>
+              {/* Destaca a proposta principal com cor de marca e peso tipográfico forte para aumentar o impacto. */}
+              <h1 className="text-4xl font-bold leading-tight home-title-highlight-text sm:text-5xl lg:text-6xl">
+                Sê pago para testar produtos e serviços
+              </h1>
 
-            {/* Destaca a proposta principal com cor de marca e peso tipográfico forte para aumentar o impacto. */}
-            <h1 className="text-4xl font-bold leading-tight home-title-highlight-text sm:text-5xl lg:text-6xl">
-              Sê pago para testar produtos e serviços
-            </h1>
+              {/* Mostra os benefícios em destaque com leitura vertical clara e espaçamento equilibrado. */}
+              <ul className="space-y-2 text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl">
+                <li>-Sem horários</li>
+                <li>-Escolhes as marcas</li>
+                <li>-Rendimento extra</li>
+              </ul>
 
-            {/* Mostra os benefícios em destaque com alinhamento central para manter equilíbrio visual. */}
-            <ul className="space-y-2 text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl">
-              <li>-Sem horários</li>
-              <li>-Escolhes as marcas</li>
-              <li>-Rendimento extra</li>
-            </ul>
+              {/* Posiciona o CTA junto ao bloco textual para manter hierarquia e facilitar interação. */}
+              <div className="flex justify-center pb-4 pt-8 lg:justify-start">
+                <Link
+                  className="site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
+                  href="/about"
+                >
+                  Começa Já
+                </Link>
+              </div>
+            </div>
 
-            {/* Mantém o CTA principal em posição central para facilitar leitura e toque em todos os dispositivos. */}
-            <div className="flex justify-center pb-4 pt-8">
-              <Link
-                className="site-pill-button px-10 py-4 text-[11px] uppercase tracking-[0.2em] shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
-                href="/about"
-              >
-                Começa Já
-              </Link>
+            {/* Exibe a imagem na segunda coluna para criar separação real entre os blocos em desktop. */}
+            <div className="relative mx-auto hidden h-[70vh] min-h-[520px] w-full max-w-[620px] lg:block">
+              {/* Usa imagem local otimizada do Next para garantir desempenho e fidelidade visual. */}
+              <Image
+                src="/images/background (2).png"
+                alt="Imagem decorativa do lado direito"
+                fill
+                className="object-contain object-center"
+                priority
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Improve hero responsiveness and preserve the visual impact of the first fold by introducing a constrained content wrapper and a two-column layout on desktop.
- Ensure the decorative image does not interfere with mobile readability by hiding it on small screens and placing it in a dedicated column on larger viewports.

### Description
- Replace the previous absolute right-side image container with a centered content wrapper (`max-w-[1440px]`, `px-6`/`lg:px-20`) and a responsive grid using `lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)]` to separate text and image.
- Reorganize textual content into a mobile-centered stack that becomes left-aligned on desktop, update typography for the `h1` and benefits list, and move the CTA to sit adjacent to the text block.
- Move the `Image` component into the second column (hidden on small screens), adjust its classes to `object-contain object-center`, keep `priority`, and remove the previous absolute/pointer-events container for consistent spacing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18d8f0430832eaab4dfc38206abf2)