### PR TITLE
Remover caixas brancas nas páginas Sobre e O Curso

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -15,30 +15,30 @@ export default function AboutPage() {
 
   return (
     <section className="space-y-12 pb-4">
-      {/* Cria o bloco principal com duas colunas para aproximar o layout ao design de referência. */}
-      <article className="mx-auto grid w-full max-w-6xl gap-8 rounded-[34px] bg-white p-8 shadow-[0_22px_55px_rgba(15,23,42,0.08)] lg:grid-cols-[1.1fr_0.9fr] lg:items-center lg:p-12">
-        {/* Mantém toda a informação atual do site, com hierarquia visual e pormenores vermelhos. */}
+      {/* Mantém a estrutura de duas colunas sem cartão branco para seguir o estilo da landing page. */}
+      <article className="mx-auto grid w-full max-w-6xl gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        {/* Preserva o conteúdo da página e ajusta a hierarquia para texto branco com destaques amarelos. */}
         <div className="space-y-6">
-          <p className="inline-flex rounded-full bg-red-50 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] home-title-highlight-text">
             Sobre a Cliente Mistério
           </p>
 
-          <h1 className="text-4xl font-semibold leading-tight text-zinc-900 lg:text-5xl">
+          <h1 className="text-4xl font-semibold leading-tight home-title-highlight-text lg:text-5xl">
             Aprende a atuar como cliente real com método e consistência.
           </h1>
 
-          <p className="max-w-2xl text-base leading-7 text-zinc-600">
+          <p className="max-w-2xl text-base leading-7">
             Um Cliente Mistério é um cliente “normal” contratado para avaliar serviços
             (atendimento, rapidez, qualidade e cumprimento de regras) e, ao mesmo tempo, gerar
             rendimento extra por cada avaliação realizada.
           </p>
 
-          <p className="max-w-2xl text-base leading-7 text-zinc-600">
+          <p className="max-w-2xl text-base leading-7">
             Quanto melhor e mais consistente fores, mais convites costumas receber para novas
             visitas e análises.
           </p>
 
-          <p className="max-w-2xl text-base leading-7 text-zinc-600">
+          <p className="max-w-2xl text-base leading-7">
             Neste curso, vais aprender do básico ao avançado como fazer visitas sem falhas,
             entregar relatórios profissionais e aumentar a tua taxa de aprovação para
             transformares isto num extra mensal realista.
@@ -49,10 +49,10 @@ export default function AboutPage() {
             {highlightMetrics.map((metric) => (
               <div
                 key={metric.label}
-                className="rounded-2xl border border-red-100 bg-red-50/70 px-4 py-3"
+                className="rounded-2xl border border-white/30 px-4 py-3"
               >
-                <p className="text-2xl font-bold text-[color:var(--accent)]">{metric.value}</p>
-                <p className="text-sm font-medium text-zinc-700">{metric.label}</p>
+                <p className="text-2xl font-bold home-title-highlight-text">{metric.value}</p>
+                <p className="text-sm font-medium">{metric.label}</p>
               </div>
             ))}
           </div>
@@ -60,8 +60,8 @@ export default function AboutPage() {
 
         {/* Usa imagem existente do projeto para manter coerência com os recursos atuais. */}
         <div className="relative mx-auto w-full max-w-md">
-          <div className="absolute -left-4 -top-4 h-full w-full rounded-[28px] border-2 border-red-200" />
-          <div className="relative overflow-hidden rounded-[28px] border border-red-100 bg-white p-3 shadow-[0_20px_40px_rgba(220,38,38,0.16)]">
+          <div className="absolute -left-4 -top-4 h-full w-full rounded-[28px] border-2 border-white/40" />
+          <div className="relative overflow-hidden rounded-[28px] border border-white/20 p-3">
             <Image
               src="/images/IMG_2622.png"
               alt="Formação de cliente mistério"
@@ -70,11 +70,11 @@ export default function AboutPage() {
               className="h-[430px] w-full rounded-2xl object-cover"
               priority
             />
-            <div className="absolute bottom-8 left-8 rounded-xl bg-white/95 px-4 py-3 shadow-lg">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--accent)]">
+            <div className="absolute bottom-8 left-8 rounded-xl bg-black/65 px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] home-title-highlight-text">
                 Curso estruturado
               </p>
-              <p className="text-sm font-medium text-zinc-700">
+              <p className="text-sm font-medium">
                 Do básico ao avançado com foco em resultados reais.
               </p>
             </div>
@@ -82,11 +82,11 @@ export default function AboutPage() {
         </div>
       </article>
 
-      {/* Recria a secção de cartões com destaque vermelho para as vantagens atuais do curso. */}
-      <article className="mx-auto w-full max-w-6xl rounded-[34px] bg-zinc-50 p-8 lg:p-12">
+      {/* Mantém a secção de vantagens sem caixa branca, reforçando o contraste de texto. */}
+      <article className="mx-auto w-full max-w-6xl">
         <div className="mx-auto max-w-3xl text-center">
-          <h2 className="text-3xl font-semibold text-zinc-900 lg:text-4xl">Vantagens do curso</h2>
-          <p className="mt-3 text-base leading-7 text-zinc-600">
+          <h2 className="text-3xl font-semibold home-title-highlight-text lg:text-4xl">Vantagens do curso</h2>
+          <p className="mt-3 text-base leading-7">
             Estrutura prática para melhorares a qualidade das avaliações e aumentares o teu
             rendimento com consistência.
           </p>
@@ -96,13 +96,13 @@ export default function AboutPage() {
           {courseAdvantages.map((advantage, index) => (
             <li
               key={advantage}
-              className="group rounded-2xl border border-zinc-200 bg-white p-5 transition duration-300 hover:-translate-y-1 hover:border-red-300 hover:shadow-[0_16px_28px_rgba(220,38,38,0.14)]"
+              className="group rounded-2xl border border-white/30 p-5 transition duration-300 hover:-translate-y-1 hover:border-[#F6C25B]"
             >
               <div className="flex items-start gap-3">
-                <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-red-100 text-xs font-bold text-[color:var(--accent)]">
+                <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#F6C25B] text-xs font-bold text-black">
                   {index + 1}
                 </span>
-                <p className="text-base leading-7 text-zinc-700">{advantage}</p>
+                <p className="text-base leading-7">{advantage}</p>
               </div>
             </li>
           ))}

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -83,16 +83,16 @@ const courseModules = [
 
 export default function CoursePage() {
   return (
-    <section className="mx-auto w-full max-w-5xl space-y-8 rounded-[32px] bg-white p-6 shadow-[0_18px_45px_rgba(15,23,42,0.08)] lg:p-10">
+    <section className="mx-auto w-full max-w-5xl space-y-8">
       {/* Define o cabeçalho principal para contextualizar o conteúdo da página de módulos. */}
       <header className="space-y-3">
-        <p className="inline-flex rounded-full bg-red-50 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] home-title-highlight-text">
           Estrutura do curso
         </p>
 
-        <h1 className="text-3xl font-semibold text-zinc-900 lg:text-4xl">O Curso</h1>
+        <h1 className="text-3xl font-semibold home-title-highlight-text lg:text-4xl">O Curso</h1>
 
-        <p className="max-w-3xl text-base leading-7 text-zinc-600">
+        <p className="max-w-3xl text-base leading-7">
           Clica em cada módulo para veres os submódulos e os tópicos abordados em cada etapa da
           formação.
         </p>
@@ -103,18 +103,18 @@ export default function CoursePage() {
         {courseModules.map((moduleItem) => (
           <details
             key={moduleItem.title}
-            className="group rounded-2xl border border-zinc-200 bg-zinc-50 p-5 open:border-red-200 open:bg-white"
+            className="group rounded-2xl border border-white/30 p-5 open:border-[#F6C25B]"
           >
             {/* Mostra apenas o título do módulo fechado e revela os tópicos ao clicar. */}
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-left text-base font-semibold text-zinc-800 marker:content-none">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-left text-base font-semibold marker:content-none">
               <span>{moduleItem.title}</span>
-              <span className="text-[color:var(--accent)] transition-transform duration-200 group-open:rotate-45">+</span>
+              <span className="home-title-highlight-text transition-transform duration-200 group-open:rotate-45">+</span>
             </summary>
 
-            <ul className="mt-4 space-y-3 border-t border-zinc-200 pt-4 text-sm leading-6 text-zinc-700">
+            <ul className="mt-4 space-y-3 border-t border-white/20 pt-4 text-sm leading-6">
               {moduleItem.topics.map((topic) => (
                 <li key={topic} className="flex items-start gap-3">
-                  <span className="mt-2 h-1.5 w-1.5 rounded-full bg-red-500" />
+                  <span className="mt-2 h-1.5 w-1.5 rounded-full bg-[#F6C25B]" />
                   <span>{topic}</span>
                 </li>
               ))}


### PR DESCRIPTION
### Motivation
- Alinhar as páginas internas `Sobre` e `O Curso` com o estilo da landing page removendo os cartões/caixas brancas e adotando texto branco com títulos amarelos.
- Melhorar contraste e consistência visual sem alterar o conteúdo textual ou a estrutura funcional das páginas.

### Description
- Atualizei `app/about/page.tsx` para remover o `bg-white`/card wrapper e ajustar classes para usar `home-title-highlight-text` (títulos amarelos) e texto branco, além de substituir fundos brancos de métricas e cartões por bordas translúcidas e tons compatíveis.
- Ajustei a área da imagem em `app/about/page.tsx` para usar bordas e um rótulo sobreposto com fundo semi-transparente preto em vez de um bloco branco.
- Atualizei `app/o-curso/page.tsx` para eliminar o fundo branco principal, converter cabeçalhos e marcadores para o estilo de destaque (`home-title-highlight-text`) e adaptar os `details`/acordeões para bordas translúcidas e marcadores amarelos.
- Mantive todo o conteúdo e a semântica original dos componentes; as mudanças são apenas de classes CSS/estilo utilitário para atender ao novo esquema visual.

### Testing
- Executei `npm run lint` e a verificação falhou localmente com `sh: 1: next: not found` devido ao ambiente não ter o binário `next` disponível. (falha)
- Tentei instalar dependências com `npm ci`, mas a execução foi bloqueada por `403 Forbidden` no registro npm ao buscar a dependência `pg`. (falha)
- Tentei capturar uma screenshot com Playwright acessando `http://127.0.0.1:3000/about`, mas falhou com `net::ERR_EMPTY_RESPONSE` porque não havia servidor local ativo na porta `3000`. (falha)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19761a84c832e8249da620b5fb210)