### PR TITLE
Reduce form dimensions across site and dashboard

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -318,16 +318,17 @@ h6 {
 
 .login-form {
   width: 100%;
-  max-width: 520px;
-  padding: 40px;
+  max-width: 460px;
+  padding: 30px;
   background: rgb(255 255 255 / 90%);
-  border-radius: 12px;
+  border-radius: 10px;
   box-shadow: 0 10px 30px rgb(0 0 0 / 10%);
   animation: fadeIn 1.5s ease-out;
 }
 
 .dashboard-form {
-  max-width: 100%;
+  max-width: min(100%, 900px) !important;
+  margin-inline: auto;
 }
 
 .login-form * {
@@ -335,9 +336,9 @@ h6 {
 }
 
 .form-heading {
-  margin-bottom: 25px;
+  margin-bottom: 18px;
   color: #333 !important;
-  font-size: 2rem;
+  font-size: 1.65rem;
   font-weight: 600;
   text-align: center;
   text-transform: uppercase;
@@ -346,15 +347,15 @@ h6 {
 
 .input-group {
   position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 14px;
 }
 
 .input-group .label {
   position: absolute;
-  top: -16px;
-  left: 12px;
+  top: -14px;
+  left: 10px;
   color: #e49b27 !important;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   opacity: 0.7;
   transition: all 0.3s ease;
@@ -364,18 +365,18 @@ h6 {
 .input-group textarea,
 .input-group select {
   width: 100%;
-  padding: 15px 20px;
+  padding: 11px 14px;
   color: #333 !important;
-  font-size: 1rem;
+  font-size: 0.92rem;
   background-color: #f5f5f5 !important;
   border: 2px solid #ddd !important;
-  border-radius: 10px;
+  border-radius: 8px;
   outline: none;
   transition: all 0.3s ease;
 }
 
 .input-group textarea {
-  min-height: 140px;
+  min-height: 110px;
   resize: vertical;
 }
 
@@ -388,14 +389,14 @@ h6 {
 
 .submit {
   width: 100%;
-  padding: 15px;
+  padding: 11px;
   color: #fff !important;
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
   background-color: #e49b27;
   border: none;
-  border-radius: 30px;
+  border-radius: 24px;
   transition: all 0.3s ease;
 }
 
@@ -418,8 +419,8 @@ h6 {
 }
 
 .form-feedback {
-  padding: 12px 14px;
-  font-size: 0.875rem;
+  padding: 10px 12px;
+  font-size: 0.8rem;
   border: 1px solid #fed7aa;
   border-radius: 12px;
   background-color: #fffbeb;
@@ -441,6 +442,6 @@ h6 {
 @media (max-width: 480px) {
   .login-form {
     width: 90%;
-    padding: 30px;
+    padding: 22px;
   }
 }


### PR DESCRIPTION
### Motivation
- Forms across the site (including the dashboard) were visually oversized and needed a more compact, consistent scale for better UX.
- Centralize sizing adjustments in the shared global stylesheet so all pages using the same classes inherit the smaller dimensions.

### Description
- Updated `app/globals.css` to reduce the base form card size by adjusting `.login-form` `max-width`, `padding`, and `border-radius` to make form containers more compact.
- Constrained dashboard forms by adding a tighter cap to `.dashboard-form` via `max-width: min(100%, 900px)` and centered it with `margin-inline: auto` to avoid overly wide inputs on large screens.
- Reduced spacing and typography on form elements by tweaking `.form-heading` (smaller `font-size` and `margin-bottom`), `.input-group` spacing, label positioning and size, input/textarea/select `padding`, `font-size`, and `border-radius`, and textarea `min-height` for a denser layout.
- Made buttons and feedback messages smaller by adjusting `.submit` padding, font size and `border-radius`, and `.form-feedback` padding and font-size, and tightened mobile padding under the `480px` media query.

### Testing
- Ran `npm run lint`, which failed because the environment did not have `next` installed (`sh: 1: next: not found`).
- Attempted `npm install` to restore dependencies, which failed due to registry access returning `403 Forbidden`, preventing local dependency installation and further runtime checks.
- Attempted an automated Playwright screenshot of `http://127.0.0.1:3000/login`, which failed because the app server was not responding (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19ac76b44832e86fcb21480b1c99a)