### PR TITLE
Toggle password form visibility on dashboard (show only after clicking "Alterar Password")

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -132,6 +132,7 @@ export default function DashboardPage() {
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [isCompletingFirstAccess, setIsCompletingFirstAccess] = useState(false);
   const [isSavingPassword, setIsSavingPassword] = useState(false);
+  const [isPasswordFormVisible, setIsPasswordFormVisible] = useState(false);
 
   const mustCompleteProfile = useMemo(() => {
     if (!profile) {
@@ -206,6 +207,23 @@ export default function DashboardPage() {
 
   const handlePasswordFieldChange = (field: keyof PasswordForm, value: string) => {
     setPasswordForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const handlePasswordFormVisibility = () => {
+    setIsPasswordFormVisible((previous) => {
+      const nextVisibility = !previous;
+
+      if (!nextVisibility) {
+        setPasswordFeedback(null);
+        setPasswordForm({
+          currentPassword: "",
+          newPassword: "",
+          confirmNewPassword: "",
+        });
+      }
+
+      return nextVisibility;
+    });
   };
 
   const hasNationalIdValue = (nationalId: string, hasNationalId: boolean) => {
@@ -583,52 +601,64 @@ export default function DashboardPage() {
               </button>
             </div>
 
-            <div className="mt-8 border-t border-slate-200 pt-8">
-              <h2 className="section-title">Alterar palavra-passe</h2>
-              <div className="mt-4 grid gap-4 md:grid-cols-2">
-                <div className="input-group md:col-span-2">
-                  <input
-                    placeholder="Senha atual"
-                    type="password"
-                    value={passwordForm.currentPassword}
-                    onChange={(event) =>
-                      handlePasswordFieldChange("currentPassword", event.target.value)
-                    }
-                  />
-                  <span className="label">Senha atual</span>
-                </div>
-                <div className="input-group">
-                  <input
-                    placeholder="Nova senha"
-                    type="password"
-                    value={passwordForm.newPassword}
-                    onChange={(event) =>
-                      handlePasswordFieldChange("newPassword", event.target.value)
-                    }
-                  />
-                  <span className="label">Nova senha</span>
-                </div>
-                <div className="input-group">
-                  <input
-                    placeholder="Confirmar nova senha"
-                    type="password"
-                    value={passwordForm.confirmNewPassword}
-                    onChange={(event) =>
-                      handlePasswordFieldChange("confirmNewPassword", event.target.value)
-                    }
-                  />
-                  <span className="label">Confirmar nova senha</span>
-                </div>
-              </div>
-              {passwordFeedback && <p className="form-feedback mt-2">{passwordFeedback}</p>}
+            <div className="mt-4 text-center">
               <button
-                className="submit mt-4"
+                className="form-link bg-transparent p-0"
                 type="button"
-                onClick={handleChangePassword}
+                onClick={handlePasswordFormVisibility}
               >
-                {isSavingPassword ? "A atualizar..." : "Atualizar senha"}
+                {isPasswordFormVisible ? "Fechar alteração de password" : "Alterar Password"}
               </button>
             </div>
+
+            {isPasswordFormVisible && (
+              <div className="mt-8 border-t border-slate-200 pt-8">
+                <h2 className="section-title">Alterar palavra-passe</h2>
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                  <div className="input-group md:col-span-2">
+                    <input
+                      placeholder="Senha atual"
+                      type="password"
+                      value={passwordForm.currentPassword}
+                      onChange={(event) =>
+                        handlePasswordFieldChange("currentPassword", event.target.value)
+                      }
+                    />
+                    <span className="label">Senha atual</span>
+                  </div>
+                  <div className="input-group">
+                    <input
+                      placeholder="Nova senha"
+                      type="password"
+                      value={passwordForm.newPassword}
+                      onChange={(event) =>
+                        handlePasswordFieldChange("newPassword", event.target.value)
+                      }
+                    />
+                    <span className="label">Nova senha</span>
+                  </div>
+                  <div className="input-group">
+                    <input
+                      placeholder="Confirmar nova senha"
+                      type="password"
+                      value={passwordForm.confirmNewPassword}
+                      onChange={(event) =>
+                        handlePasswordFieldChange("confirmNewPassword", event.target.value)
+                      }
+                    />
+                    <span className="label">Confirmar nova senha</span>
+                  </div>
+                </div>
+                {passwordFeedback && <p className="form-feedback mt-2">{passwordFeedback}</p>}
+                <button
+                  className="submit mt-4"
+                  type="button"
+                  onClick={handleChangePassword}
+                >
+                  {isSavingPassword ? "A atualizar..." : "Atualizar senha"}
+                </button>
+              </div>
+            )}
           </article>
 
           <aside className="login-form max-w-none xl:sticky xl:top-6">


### PR DESCRIPTION
### Motivation
- Reduce UI clutter by hiding the password-change form by default and only showing it when the user explicitly clicks the "Alterar Password" link. 
- No external skills were required to implement this change.

### Description
- Added a new state `isPasswordFormVisible` to control the visibility of the password form in `app/dashboard/page.tsx`.
- Implemented `handlePasswordFormVisibility` which toggles the visibility and clears password fields and feedback when the form is hidden.
- Moved the password section inside a conditional render `{isPasswordFormVisible && (...)}` so the form is not rendered until toggled.
- Added a link-style button labeled `Alterar Password` (placed above the `Guardar perfil` button) to toggle the password form visibility.

### Testing
- Ran `npm run lint` which failed because `next` is not available in this environment (`sh: 1: next: not found`).
- Attempted `npm install` but dependency install failed due to registry access returning `403 Forbidden` for `pg`, preventing full lint/build validation.
- Attempted a Playwright screenshot of `http://127.0.0.1:3000/dashboard` which failed with `ERR_EMPTY_RESPONSE` because the app was not running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19d3f417c832eae48763b59e5c321)