### PR TITLE
Padroniza largura/altura de conteúdo e centraliza botão de terminar sessão

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -16,7 +16,7 @@ export default function AboutPage() {
   return (
     <section className="space-y-12 pb-4">
       {/* Mantém a estrutura de duas colunas sem cartão branco para seguir o estilo da landing page. */}
-      <article className="mx-auto grid w-full max-w-6xl gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+      <article className="grid w-full gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
         {/* Preserva o conteúdo da página e ajusta a hierarquia para texto branco com destaques amarelos. */}
         <div className="space-y-6">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] home-title-highlight-text">

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -80,7 +80,7 @@ export default function AccountPage() {
 
   return (
     <section className="space-y-8">
-      <div className="mx-auto flex w-full max-w-5xl justify-center">
+      <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form max-w-[620px]">
           <h1 className="form-heading">Criar conta</h1>
 

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -36,7 +36,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       </header>
 
       {/* Remove margens na home para permitir hero full-bleed e mantém paddings nas páginas internas. */}
-      <main className={isHomePage ? "px-0 pb-0" : "px-4 pb-10 sm:px-6 md:px-10"}>{children}</main>
+      <main className={isHomePage ? "px-0 pb-0" : "px-4 pb-10 pt-8 sm:px-6 sm:pt-10 md:px-10"}>
+        {isHomePage ? children : <div className="mx-auto w-full max-w-6xl">{children}</div>}
+      </main>
     </div>
   );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -66,7 +66,7 @@ export default function ContactPage() {
 
   return (
     <section className="space-y-8">
-      <div className="mx-auto flex w-full max-w-5xl justify-center">
+      <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form max-w-[620px]">
           <h1 className="form-heading">Contacto</h1>
           <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -495,7 +495,7 @@ export default function DashboardPage() {
       <div className="mx-auto w-full max-w-6xl space-y-8">
         <header className="rounded-[32px] bg-white p-8 text-black shadow-[0_20px_50px_rgba(31,41,55,0.08)]">
           <h1 className="page-title !text-black">Olá, {profile.firstName}</h1>
-          <p className="mt-3 text-sm text-black">Faça a gestão da sua conta e segurança.</p>
+          <p className="mt-3 text-sm !text-black">Faça a gestão da sua conta e segurança.</p>
         </header>
 
         <div className="grid items-start gap-8 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
@@ -694,7 +694,7 @@ export default function DashboardPage() {
           </aside>
         </div>
 
-        <div className="flex justify-end">
+        <div className="flex justify-center">
           <button
             className="submit max-w-[280px]"
             type="button"

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -41,7 +41,7 @@ export default function ForgotPasswordPage() {
 
   return (
     <section className="space-y-8">
-      <div className="mx-auto flex w-full max-w-5xl justify-center">
+      <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <h1 className="form-heading">Recuperar password</h1>
           <form onSubmit={handleSubmit}>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -113,7 +113,7 @@ export default function LoginPage() {
 
   return (
     <section className="space-y-8">
-      <div className="mx-auto flex w-full max-w-5xl justify-center">
+      <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <h1 className="form-heading">Login</h1>
           <form onSubmit={handleSubmit}>

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -83,7 +83,7 @@ const courseModules = [
 
 export default function CoursePage() {
   return (
-    <section className="mx-auto w-full max-w-5xl space-y-8">
+    <section className="w-full space-y-8">
       {/* Define o cabeçalho principal para contextualizar o conteúdo da página de módulos. */}
       <header className="space-y-3">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] home-title-highlight-text">

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -23,7 +23,7 @@ export default function ResetPasswordPage() {
 function ResetPasswordLoadingState() {
   return (
     <section className="space-y-8">
-      <div className="mx-auto flex w-full max-w-5xl justify-center">
+      <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <p className="text-center text-sm">A carregar formulário de recuperação...</p>
         </article>
@@ -70,7 +70,7 @@ function ResetPasswordContent() {
 
   return (
     <section className="space-y-8">
-      <div className="mx-auto flex w-full max-w-5xl justify-center">
+      <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <h1 className="form-heading">Definir password</h1>
           <form onSubmit={handleSubmit}>


### PR DESCRIPTION
### Motivation
- Garantir que todas as páginas internas partilham a mesma largura e começam à mesma distância da navigation bar para consistência visual.  
- Tornar o botão de "Terminar sessão" centralizado na página do dashboard para alinhar com o layout e melhorar a hierarquia visual.  
- Assegurar que o texto informativo do dashboard "Faça a gestão da sua conta e segurança." aparece em preto com prioridade para legibilidade.  

### Description
- Atualizei o wrapper global em `app/components/AppShell.tsx` para envolver conteúdos internos num contêiner `max-w-6xl` e adicionei padding superior consistente (`pt-8 sm:pt-10`) para uniformizar a distância entre a navbar e o primeiro conteúdo.  
- Padronizei os wrappers das páginas de formulários (`app/account/page.tsx`, `app/contact/page.tsx`, `app/login/page.tsx`, `app/forgot-password/page.tsx`, `app/reset-password/page.tsx`) para usar `max-w-6xl` em vez de `max-w-5xl`.  
- Removi restrições locais redundantes de largura em `app/about/page.tsx` e `app/o-curso/page.tsx` para que herdem o novo limite global.  
- No `app/dashboard/page.tsx` alterei a classe do parágrafo para `!text-black` para forçar a cor preta e mudei o botão de logout de `justify-end` para `justify-center` para centralização.  

### Testing
- Executei `npm run lint` e a tarefa falhou com `sh: 1: next: not found` devido à ausência do binário `next` no ambiente (lint não pôde correr).  
- Executei `npm ci` e a instalação falhou com erro `403 Forbidden` ao aceder ao registry npm, impedindo instalação de dependências e validação de build.  
- Tentei `npm run dev` e falhou com `sh: 1: next: not found`, impedindo validação visual local; as alterações foram validadas via diff e inspeção de ficheiros em repositório.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a16969b4832eb763f9a6c2a729da)