### PR TITLE
Align Home hero container and paddings with internal pages to avoid content jump

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,14 +4,14 @@ import Link from "next/link";
 export default function HomePage() {
   return (
     <section className="w-full">
-      {/* Mantém o hero a ocupar o ecrã para preservar o impacto visual da primeira dobra. */}
-      <div className="relative min-h-screen w-full bg-transparent">
-        {/* Usa um content wrapper com limites de largura para criar margens laterais consistentes em desktop. */}
-        <div className="mx-auto flex min-h-screen w-full max-w-[1440px] px-6 py-16 sm:px-10 lg:px-20 xl:px-24">
-          {/* Em desktop, distribui texto e imagem em duas colunas com espaçamento semelhante à referência. */}
-          <div className="grid w-full items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)] lg:gap-16 xl:gap-20">
+      {/* Mantém o hero com o mesmo content width e paddings das páginas internas para evitar "salto" visual na navegação. */}
+      <div className="relative w-full bg-transparent">
+        {/* Reaproveita o mesmo envelope horizontal (max-w-6xl + px responsivo) usado no AppShell das páginas internas. */}
+        <div className="mx-auto w-full max-w-6xl px-4 pb-10 pt-8 sm:px-6 sm:pt-10 md:px-10">
+          {/* Em desktop, mantém duas colunas, mas com alinhamento inicial para sincronizar o ponto de arranque com a página Sobre. */}
+          <div className="grid w-full items-start gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)] lg:gap-16 xl:gap-20">
             {/* Agrupa o conteúdo textual e mantém alinhamento central no mobile e à esquerda no desktop. */}
-            <div className="flex w-full max-w-2xl flex-col items-center justify-center gap-8 text-center lg:items-start lg:text-left">
+            <div className="flex w-full max-w-2xl flex-col items-center gap-8 pt-8 text-center lg:items-start lg:pt-10 lg:text-left">
               {/* Reforça o contexto da landing com uma etiqueta editorial discreta. */}
               <p className="section-label-uppercase text-[11px] tracking-[0.35em] text-white/80">
                 Formação e prática


### PR DESCRIPTION
### Motivation
- Evitar o “salto” visual quando se navega da Home para páginas internas tornando o alinhamento vertical e horizontal consistente com a página `About`.
- Homogeneizar os `content width` e `paddings` do hero da Home com o envelope usado nas páginas internas para garantir um ponto de partida idêntico no layout.

### Description
- Ajusta `app/page.tsx` para reaproveitar o mesmo envelope horizontal (`max-w-6xl` com `px-4 sm:px-6 md:px-10`) usado no layout interno em vez de `max-w-[1440px]` e paddings próprios da landing.
- Remove o `min-h-screen` que centralizava verticalmente o conteúdo e passa o grid para `items-start` para alinhar o texto ao mesmo ponto de partida das páginas internas.
- Adiciona `pt-8`/`lg:pt-10` ao bloco textual para manter espaçamento vertical consistente com páginas internas sem alterar conteúdo visual nem a imagem do hero.
- Mudança aplicada apenas em `app/page.tsx` e preserva o restante da estrutura e classes existentes.

### Testing
- A patch foi aplicada com sucesso no arquivo `app/page.tsx` usando o processo de atualização automatizada (`apply_patch`).
- Foi executado `npm run dev` para iniciar o servidor de desenvolvimento, mas falhou com `sh: 1: next: not found` porque as dependências não estavam instaladas no ambiente; portanto o servidor não pôde ser validado localmente.
- Recomenda-se executar `npm ci` seguido de `npm run dev` em ambiente com dependências instaladas e verificar visualmente a navegação entre `/` e `/about` para confirmar que o texto não se move ao alternar páginas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1af492b70832e8b827ecad8a36f82)