### PR TITLE
Atualiza a cor de destaque global para #F6C25B

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -56,7 +56,7 @@ body * {
 }
 /* Destaca especificamente o benefício de rendimento com tom dourado mais intenso. */
 .home-benefit-extra-highlight-text {
-  color: #e49b27 !important;
+  color: #F6C25B !important;
 }
 
 /* Mantém campos de formulário com fundo preto e texto branco em todas as páginas. */
@@ -354,7 +354,7 @@ h6 {
   position: absolute;
   top: -14px;
   left: 10px;
-  color: #e49b27 !important;
+  color: #F6C25B !important;
   font-size: 11px;
   font-weight: 600;
   opacity: 0.7;
@@ -394,20 +394,20 @@ h6 {
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  background-color: #e49b27;
+  background-color: #F6C25B;
   border: none;
   border-radius: 24px;
   transition: all 0.3s ease;
 }
 
 .submit:hover {
-  background-color: #e49b27;
+  background-color: #F6C25B;
   box-shadow: 0 5px 20px rgb(88 188 130 / 30%);
   transform: translateY(-2px);
 }
 
 .form-link {
-  color: #e49b27 !important;
+  color: #F6C25B !important;
   font-size: 14px;
   font-weight: 600;
   text-decoration: none;


### PR DESCRIPTION
### Motivation
- Replace all usages of the outdated highlight color `#e49b27` with `#F6C25B` in the global stylesheet to standardize the site's accent color.

### Description
- Updated `app/globals.css` replacing every occurrence of `#e49b27`/`#E49B27` with `#F6C25B`, affecting home highlight texts, form labels, submit buttons and form links.

### Testing
- Ran a search with `rg -n "#e49b27|#E49B27|#F6C25B" app/globals.css` and inspected the file with `nl`/`cat` and `git diff -- app/globals.css`, confirming the replacements and a successful `git commit`; `npm run lint` could not be executed successfully because `next` was not available and `npm install` failed with a `403 Forbidden` when accessing the registry, preventing full lint/CI validation in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b6ba1ad8832ea98ee0cfa4df97c3)