### PR TITLE
Update quiz module background color to darker slate

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -292,7 +292,7 @@ export default function CursoPage() {
             &larr; Voltar ao conteúdo
           </button>
 
-          <div className="rounded-2xl border border-white/20 bg-white/5 p-6 backdrop-blur-sm">
+          <div className="rounded-2xl border border-white/20 bg-slate-950/80 p-6 backdrop-blur-sm">
             <h2 className="text-xl font-bold mb-1">{activeModule.title}</h2>
             <p className="text-sm text-white/60 mb-6">
               Responda a todas as questões. Necessita de 60% para concluir o módulo.


### PR DESCRIPTION
## Summary
Updated the background color styling of the quiz module container to use a darker, more opaque slate color for improved visual contrast and readability.

## Changes
- Changed the quiz module container background from `bg-white/5` (semi-transparent white) to `bg-slate-950/80` (dark slate with 80% opacity)
- This provides a darker, more defined background that better contrasts with the text content while maintaining the backdrop blur effect

## Details
The modification affects the visual presentation of the quiz module interface on the curso page, making the quiz questions section more visually distinct and easier to read against the page background.

https://claude.ai/code/session_01RT6p6wgbKpDs3kQqsw2MtB