### PR TITLE
Fix quiz option text color for selected answers

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -134,7 +134,7 @@ export default function CursoPage() {
     const base = "w-full text-left p-3 rounded-lg border-2 transition-all text-sm text-slate-900";
     if (!quizSubmitted) {
       if (quizAnswers[question.id] === optionIndex) {
-        return `${base} border-[#F6C25B] bg-[#F6C25B]/10 text-slate-800`;
+        return `${base} border-[#F6C25B] bg-[#F6C25B]/10 text-white`;
       }
       return `${base} border-slate-200 hover:border-slate-300 bg-white`;
     }


### PR DESCRIPTION
## Summary
Updated the text color of selected quiz answer options to improve visibility and contrast against the yellow background.

## Changes
- Changed selected quiz option text color from `text-slate-800` to `text-white` in the quiz answer styling
- This improves readability when an answer option is selected (highlighted with the `#F6C25B` yellow background)

## Details
The selected answer option now uses white text instead of dark slate text, providing better contrast against the yellow background color (`#F6C25B`) used to indicate the user's selected answer in the quiz interface.

https://claude.ai/code/session_012mXqL8N95zpD15SoxnR4Jf