### PR TITLE
Add request timeouts to dashboard API calls

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -172,8 +172,12 @@ export default function DashboardPage() {
     setSessionEmail(storedSession);
 
     const loadProfile = async () => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+
       try {
-        const response = await fetch("/api/user");
+        const response = await fetch("/api/user", { signal: controller.signal });
+        clearTimeout(timeoutId);
         const data = (await response.json()) as ProfileResponse;
 
         if (!response.ok || !data.user) {
@@ -199,6 +203,7 @@ export default function DashboardPage() {
         setProfile(normalizedProfile);
         localStorage.setItem(userStorageKey, JSON.stringify(normalizedProfile));
       } catch {
+        clearTimeout(timeoutId);
         router.push("/login");
       }
     };
@@ -206,13 +211,18 @@ export default function DashboardPage() {
     loadProfile();
 
     const loadCourseProgress = async () => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
+
       try {
-        const response = await fetch("/api/course/progress");
+        const response = await fetch("/api/course/progress", { signal: controller.signal });
+        clearTimeout(timeoutId);
         if (response.ok) {
           const data = (await response.json()) as CourseProgressData;
           setCourseProgress(data);
         }
       } catch {
+        clearTimeout(timeoutId);
         // Progresso do curso não disponível.
       }
     };


### PR DESCRIPTION
## Summary
Added abort signal timeouts to API requests in the dashboard page to prevent hanging requests and improve user experience when the API is unresponsive.

## Key Changes
- Added 10-second timeout to the `/api/user` profile loading request
- Added 5-second timeout to the `/api/course/progress` request
- Implemented `AbortController` to cancel requests that exceed their timeout duration
- Ensured timeouts are properly cleared on both successful responses and error cases

## Implementation Details
- Each async function (`loadProfile` and `loadCourseProgress`) now creates its own `AbortController` and sets a timeout that aborts the fetch if the response takes too long
- The `clearTimeout()` call is placed immediately after a successful response to prevent unnecessary timeout cleanup
- Error handlers also clear the timeout to avoid memory leaks
- Different timeout durations reflect the expected response times: 10 seconds for user profile (more critical) and 5 seconds for course progress (less critical)

https://claude.ai/code/session_01WM2KPRCU3nqerF3XdeZU7e