### PR TITLE
Add credentials: include to all fetch requests for cookie-based auth

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -59,6 +59,7 @@ export default function AccountPage() {
     try {
       const response = await fetch("/api/auth/register", {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),
       });

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -48,6 +48,7 @@ export default function ContactPage() {
     try {
       const response = await fetch("/api/contact", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -293,7 +293,7 @@ export default function CursoPage() {
 
   const loadProgress = useCallback(async () => {
     try {
-      const response = await fetch("/api/course/progress");
+      const response = await fetch("/api/course/progress", { credentials: "include" });
       if (response.ok) {
         const data = (await response.json()) as ProgressData;
         setProgress(data);
@@ -364,6 +364,7 @@ export default function CursoPage() {
       try {
         const response = await fetch("/api/course/progress", {
           method: "PUT",
+          credentials: "include",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             moduleId: activeModuleId,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -176,7 +176,7 @@ export default function DashboardPage() {
       const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
       try {
-        const response = await fetch("/api/user", { signal: controller.signal });
+        const response = await fetch("/api/user", { credentials: "include", signal: controller.signal });
         clearTimeout(timeoutId);
         const data = (await response.json()) as ProfileResponse;
 
@@ -215,7 +215,7 @@ export default function DashboardPage() {
       const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
 
       try {
-        const response = await fetch("/api/course/progress", { signal: controller.signal });
+        const response = await fetch("/api/course/progress", { credentials: "include", signal: controller.signal });
         clearTimeout(timeoutId);
         if (response.ok) {
           const data = (await response.json()) as CourseProgressData;
@@ -273,6 +273,7 @@ export default function DashboardPage() {
     try {
       const response = await fetch("/api/user", {
         method: "PUT",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: profile.email,
@@ -384,6 +385,7 @@ export default function DashboardPage() {
     try {
       const response = await fetch("/api/user/password", {
         method: "PUT",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           currentPassword: passwordForm.currentPassword,
@@ -410,7 +412,7 @@ export default function DashboardPage() {
 
   const handleLogout = async () => {
     // Termina a sessão no servidor e remove os dados locais antes do redirecionamento.
-    await fetch("/api/auth/logout", { method: "POST" });
+    await fetch("/api/auth/logout", { method: "POST", credentials: "include" });
     localStorage.removeItem(sessionStorageKey);
     localStorage.removeItem(userStorageKey);
     router.push("/login");

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -30,6 +30,7 @@ export default function ForgotPasswordPage() {
     try {
       const response = await fetch("/api/auth/forgot-password", {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
       });

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -78,6 +78,7 @@ export default function LoginPage() {
     try {
       const response = await fetch("/api/auth/login", {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
       });

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -59,6 +59,7 @@ function ResetPasswordContent() {
     try {
       const response = await fetch("/api/auth/reset-password", {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token, newPassword, confirmPassword }),
       });


### PR DESCRIPTION
## Summary
This PR adds `credentials: "include"` to all fetch requests across the application to ensure cookies are properly sent with cross-origin requests. This is necessary for cookie-based authentication to work correctly.

## Key Changes
- **Dashboard page**: Added `credentials: "include"` to 5 fetch calls:
  - GET `/api/user` (user profile fetch)
  - GET `/api/course/progress` (progress fetch)
  - PUT `/api/user` (profile update)
  - PUT `/api/user/password` (password change)
  - POST `/api/auth/logout` (logout)

- **Course page**: Added `credentials: "include"` to 2 fetch calls:
  - GET `/api/course/progress` (progress load)
  - PUT `/api/course/progress` (progress update)

- **Account page**: Added `credentials: "include"` to POST `/api/auth/register`

- **Contact page**: Added `credentials: "include"` to POST `/api/contact`

- **Forgot password page**: Added `credentials: "include"` to POST `/api/auth/forgot-password`

- **Login page**: Added `credentials: "include"` to POST `/api/auth/login`

- **Reset password page**: Added `credentials: "include"` to POST `/api/auth/reset-password`

## Implementation Details
The `credentials: "include"` option tells the browser to include cookies in fetch requests, which is essential for maintaining authenticated sessions. Without this flag, authentication cookies are not sent by default in fetch requests, causing authentication failures.

https://claude.ai/code/session_011bXVXF5G6JQJBVBfQza7VT