### PR TITLE
Mark ThreePointsCards as client component

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -2,6 +2,8 @@
  * DESCRIÇÃO DO FICHEIRO: Componente que exibe os 3 pontos principais em cards animados.
  */
 
+"use client";
+
 export default function ThreePointsCards() {
   const points = [
     "Sem horários",


### PR DESCRIPTION
## Summary
Added the `"use client"` directive to the ThreePointsCards component to explicitly mark it as a Client Component in the Next.js App Router.

## Key Changes
- Added `"use client"` directive at the top of `app/components/ThreePointsCards.tsx`

## Implementation Details
This change ensures that the ThreePointsCards component is properly identified as a Client Component, which is necessary for any interactive features or client-side hooks that may be used within this component or its children. This is a best practice in Next.js 13+ App Router architecture to explicitly declare component boundaries.

https://claude.ai/code/session_01PqxF8pTF5VKNSEhqSXR1SN