### PR TITLE
Remove button hover animation styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -119,34 +119,6 @@ h6 {
   button span {
     position: relative;
     z-index: 10;
-    transition: color 0.4s;
-  }
-
-  button:hover span {
-    color: black;
-  }
-
-  button::before,
-  button::after {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 0;
-  }
-
-  button::before {
-    content: "";
-    background: #000;
-    width: 120%;
-    left: -10%;
-    transform: skew(30deg);
-    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
-  }
-
-  button:hover::before {
-    transform: translate3d(100%, 0, 0);
   }
 
   /* Define estilo base moderno para todos os botões */


### PR DESCRIPTION
## Summary
Removed the skew and slide animation effects from button hover states in the global stylesheet.

## Changes
- Removed `transition: color 0.4s` from `button span` selector
- Removed `button:hover span` color change rule
- Removed `button::before` and `button::after` pseudo-element styles that created the skew animation effect
- Removed `button:hover::before` transform animation that translated the pseudo-element on hover

## Details
This change simplifies the button styling by removing the complex hover animation that used skewed pseudo-elements with cubic-bezier timing. The button elements will now use their base styles without the animated visual effects previously triggered on hover.

https://claude.ai/code/session_017UeuqMRCXHSL2xAx7ZnhES