### PR TITLE
Change quiz module background color to coral/salmon

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -632,7 +632,7 @@ export default function CursoPage() {
             &larr; Voltar ao conteúdo
           </button>
 
-          <div className="rounded-2xl border border-white/20 bg-slate-950/80 p-6 backdrop-blur-sm">
+          <div className="rounded-2xl border border-white/20 bg-[#feb1a5] p-6 backdrop-blur-sm">
             <h2 className="text-xl font-bold mb-1">{activeModule.title}</h2>
             <p className="text-sm text-white/60 mb-6">
               Responda a todas as questões. Necessita de 60% para concluir o módulo.


### PR DESCRIPTION
## Summary
Updated the visual styling of the quiz module container by changing its background color from a dark slate to a coral/salmon tone.

## Changes
- Changed the quiz module container background color from `bg-slate-950/80` (dark slate with 80% opacity) to `bg-[#feb1a5]` (coral/salmon color)
- This affects the visual appearance of the quiz interface on the curso page

## Details
The background color change applies to the main quiz module container that displays the quiz title, instructions, and questions. The new coral/salmon color (`#feb1a5`) replaces the previous dark theme styling while maintaining all other styling properties (rounded corners, border, padding, and backdrop blur effect).

https://claude.ai/code/session_01JnpE8RtHiULkpDgEZUccXA