### PR TITLE
Add Stripe Payment Link integration for course purchases

### DIFF
--- a/STRIPE_SETUP.md
+++ b/STRIPE_SETUP.md
@@ -1,0 +1,83 @@
+# Configuração do Stripe Payment Link
+
+Este documento descreve como configurar o Stripe Payment Link no seu site.
+
+## Passo 1: Configurar as Chaves do Stripe
+
+1. Acesse [Stripe Dashboard](https://dashboard.stripe.com/apikeys)
+2. Copie sua **Publishable key** (começa com `pk_`)
+3. Copie sua **Secret key** (começa com `sk_`)
+4. No arquivo `.env.local`, substitua:
+   ```
+   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_your_publishable_key_here
+   STRIPE_SECRET_KEY=sk_live_your_secret_key_here
+   ```
+
+## Passo 2: Criar o Payment Link no Stripe
+
+1. Acesse [Stripe Products](https://dashboard.stripe.com/products)
+2. Clique em "Add product"
+3. Preencha os detalhes:
+   - **Name**: "Cliente Mistério - Curso Completo"
+   - **Description**: Descrição do curso
+   - **Pricing**: Defina o preço
+   - **Billing period**: Selecione "One-time" ou "Recurring"
+4. Clique em "Create product"
+5. Na página do produto, clique em "Create payment link"
+6. Configure as opções de pagamento
+7. Copie o URL do payment link (exemplo: `https://buy.stripe.com/aeu1234567890`)
+
+## Passo 3: Configurar o Payment Link no Site
+
+1. No arquivo `.env.local`, substitua:
+   ```
+   NEXT_PUBLIC_STRIPE_PAYMENT_LINK=https://buy.stripe.com/YOUR_PAYMENT_LINK_HERE
+   ```
+
+## Onde o Botão Aparece
+
+O botão "Comprar Curso" agora aparece em:
+- **Página inicial** (`/`) - ao lado de "Começa já"
+- **Página do Curso** (`/o-curso`) - como opção para não membros
+- **Página de checkout** (`/checkout`) - redireciona diretamente para o Stripe
+
+## Componente CheckoutButton
+
+Você pode usar o componente `CheckoutButton` em qualquer lugar:
+
+```tsx
+import CheckoutButton from "./components/CheckoutButton";
+
+export default function MyPage() {
+  return (
+    <CheckoutButton
+      label="Comprar Agora"
+      variant="primary"
+    />
+  );
+}
+```
+
+### Props Disponíveis
+
+- `label` (string): Texto do botão (padrão: "Comprar Curso")
+- `className` (string): Classes CSS adicionais
+- `variant` (string): "primary" ou "secondary" (padrão: "primary")
+
+## Teste em Modo de Desenvolvimento
+
+1. Rode o servidor: `npm run dev`
+2. Acesse `http://localhost:3000`
+3. Clique no botão "Comprar Curso"
+4. Você será redirecionado para o Stripe Payment Link
+
+## Notas de Segurança
+
+- **Nunca** commit a chave secreta do Stripe no repositório
+- O arquivo `.env.local` está no `.gitignore` por padrão
+- Use sempre as chaves de **produção** após testar
+
+## Recursos Adicionais
+
+- [Stripe Payment Links Documentation](https://stripe.com/docs/payments/payment-links)
+- [Stripe Dashboard](https://dashboard.stripe.com)

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,35 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Página de checkout que redireciona para o Stripe Payment Link.
+ */
+
+"use client";
+
+import { useEffect } from "react";
+
+export default function CheckoutPage() {
+  const paymentLink = process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK;
+
+  useEffect(() => {
+    if (paymentLink) {
+      // Redireciona automaticamente para o Stripe Payment Link
+      window.location.href = paymentLink;
+    }
+  }, [paymentLink]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="text-center space-y-4">
+        <h1 className="text-2xl font-semibold">Redirecionando para pagamento...</h1>
+        <p className="text-white/70">Se não for redirecionado automaticamente,</p>
+        {paymentLink && (
+          <a
+            href={paymentLink}
+            className="submit inline-block max-w-sm text-center !no-underline"
+          >
+            clique aqui
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/CheckoutButton.tsx
+++ b/app/components/CheckoutButton.tsx
@@ -1,0 +1,45 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Componente reutilizável para o botão de checkout do Stripe.
+ */
+
+"use client";
+
+interface CheckoutButtonProps {
+  label?: string;
+  className?: string;
+  variant?: "primary" | "secondary";
+}
+
+export default function CheckoutButton({
+  label = "Comprar Curso",
+  className = "",
+  variant = "primary",
+}: CheckoutButtonProps) {
+  const paymentLink = process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK;
+
+  if (!paymentLink) {
+    return (
+      <button disabled className="opacity-50 cursor-not-allowed" title="Payment link não configurado">
+        {label}
+      </button>
+    );
+  }
+
+  const handleCheckout = () => {
+    window.location.href = paymentLink;
+  };
+
+  const buttonClasses =
+    variant === "primary"
+      ? "site-pill-button px-8 py-3 text-[10px] uppercase tracking-[0.15em] shadow-[0_10px_24px_rgba(0,0,0,0.18)] sm:px-10 sm:py-4 sm:text-[11px] sm:tracking-[0.2em]"
+      : "submit inline-block text-center !no-underline";
+
+  return (
+    <button
+      onClick={handleCheckout}
+      className={`${buttonClasses} ${className}`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -6,6 +6,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import CheckoutButton from "../components/CheckoutButton";
 
 const sessionStorageKey = "vp_session";
 
@@ -149,14 +150,17 @@ export default function CoursePage() {
       </div>
 
       {!isLoggedIn && (
-        <div className="text-center space-y-3">
+        <div className="text-center space-y-4">
           <p className="text-sm text-white/70">Crie uma conta ou inicie sessão para aceder ao curso completo com conteúdo teórico e questionários.</p>
-          <Link
-            href="/account"
-            className="submit inline-block max-w-sm text-center !no-underline"
-          >
-            Criar Conta Gratuita
-          </Link>
+          <div className="flex flex-col gap-3 justify-center items-center sm:flex-row sm:gap-4">
+            <Link
+              href="/account"
+              className="submit inline-block max-w-sm text-center !no-underline"
+            >
+              Criar Conta Gratuita
+            </Link>
+            <CheckoutButton label="Comprar Acesso Completo" />
+          </div>
         </div>
       )}
     </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@
 
 import Link from "next/link";
 import ThreePointsCards from "./components/ThreePointsCards";
+import CheckoutButton from "./components/CheckoutButton";
 
 export default function HomePage() {
   return (
@@ -25,13 +26,14 @@ export default function HomePage() {
               <ThreePointsCards />
 
               {/* Mantém o CTA centrado por baixo dos benefícios para reforçar a ação principal. */}
-              <div className="flex justify-center pt-2 sm:pt-4">
+              <div className="flex flex-col gap-3 justify-center pt-2 sm:pt-4 items-center sm:flex-row sm:gap-4">
                 <Link
                   className="site-pill-button px-8 py-3 text-[10px] uppercase tracking-[0.15em] shadow-[0_10px_24px_rgba(0,0,0,0.18)] sm:px-10 sm:py-4 sm:text-[11px] sm:tracking-[0.2em]"
                   href="/about"
                 >
                   Começa já
                 </Link>
+                <CheckoutButton label="Comprar Curso" />
               </div>
             </div>
           </div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "pg": "^8.11.5",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "stripe": "^15.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
This PR integrates Stripe Payment Links into the application, enabling users to purchase course access directly. A new reusable checkout button component has been created and integrated across key pages, with comprehensive setup documentation provided.

## Key Changes
- **New CheckoutButton Component** (`app/components/CheckoutButton.tsx`): A reusable client component that redirects users to the Stripe Payment Link with customizable label, styling, and variant options (primary/secondary)
- **New Checkout Page** (`app/checkout/page.tsx`): A dedicated checkout page that automatically redirects to the Stripe Payment Link with a fallback manual link for users
- **Homepage Integration**: Added "Comprar Curso" button alongside the existing "Começa já" CTA on the homepage
- **Course Page Integration**: Added "Comprar Acesso Completo" button as an alternative to free account creation for non-logged-in users
- **Setup Documentation** (`STRIPE_SETUP.md`): Comprehensive guide covering:
  - Stripe API key configuration
  - Payment Link creation in Stripe Dashboard
  - Environment variable setup
  - Component usage examples
  - Security best practices
- **Dependencies**: Added `stripe` package (v15.0.0) to support Stripe integration

## Implementation Details
- The CheckoutButton component reads the payment link from `NEXT_PUBLIC_STRIPE_PAYMENT_LINK` environment variable
- Graceful fallback: button is disabled if payment link is not configured
- Responsive button styling with support for primary and secondary variants
- Automatic redirect on checkout page load with manual fallback link
- All checkout functionality is client-side using `window.location.href` for simplicity

https://claude.ai/code/session_01Q5545JuWcwNtizUZV2zrwu