### PR TITLE
Add secondary pill button variant and update homepage CTA

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -250,6 +250,57 @@ h6 {
     cursor: not-allowed;
   }
 
+  /* Variante secundária do botão com fundo branco e texto laranja */
+  .site-pill-button-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: inherit;
+    cursor: pointer;
+    font-weight: 500;
+    font-size: 14px;
+    padding: 0.6em 1.2em;
+    color: #F66856;
+    background: white;
+    border: 2px solid #F66856;
+    box-shadow: 0 0.5em 1.2em -0.5em rgba(246, 104, 86, 0.2);
+    letter-spacing: 0.05em;
+    border-radius: 20em;
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    white-space: nowrap;
+    will-change: transform;
+    touch-action: manipulation;
+    width: auto;
+    min-width: auto;
+  }
+
+  @media (max-width: 640px) {
+    .site-pill-button-secondary {
+      min-height: 40px;
+      padding: 0.6em 1em;
+      font-size: 13px;
+      border-radius: 18em;
+    }
+  }
+
+  /* Estado hover */
+  .site-pill-button-secondary:hover {
+    box-shadow: 0 0.4em 1.2em -0.5em rgba(246, 104, 86, 0.4);
+    background: #fff5f1;
+  }
+
+  /* Estado ativo */
+  .site-pill-button-secondary:active {
+    box-shadow: 0 0.2em 0.8em -0.5em rgba(246, 104, 86, 0.4);
+    opacity: 0.9;
+  }
+
+  /* Estado desativado */
+  .site-pill-button-secondary:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+  }
+
   /* Botão toggle moderno com feedback visual */
   .menu-toggle-button {
     display: inline-flex;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,10 +28,10 @@ export default function HomePage() {
               {/* Mantém o CTA centrado por baixo dos benefícios para reforçar a ação principal. */}
               <div className="flex flex-col gap-3 justify-center pt-2 sm:pt-4 items-center sm:flex-row sm:gap-4">
                 <Link
-                  className="site-pill-button px-8 py-3 text-[10px] uppercase tracking-[0.15em] shadow-[0_10px_24px_rgba(0,0,0,0.18)] sm:px-10 sm:py-4 sm:text-[11px] sm:tracking-[0.2em]"
+                  className="site-pill-button-secondary px-8 py-3 text-[10px] uppercase tracking-[0.15em] shadow-[0_10px_24px_rgba(0,0,0,0.18)] sm:px-10 sm:py-4 sm:text-[11px] sm:tracking-[0.2em]"
                   href="/about"
                 >
-                  Começa já
+                  Sabe mais
                 </Link>
                 <CheckoutButton label="Comprar Curso" />
               </div>


### PR DESCRIPTION
## Summary
This PR introduces a new secondary variant of the pill button component with an orange text and white background design, and updates the homepage to use this new variant for the "Sabe mais" call-to-action.

## Key Changes
- **New `.site-pill-button-secondary` CSS class**: A secondary button variant featuring:
  - White background with orange (#F66856) text and border
  - Subtle shadow and hover effects with background color shift to light orange (#fff5f1)
  - Responsive design with adjusted padding and font size on mobile (max-width: 640px)
  - Disabled state styling with reduced opacity
  - Smooth transitions using cubic-bezier easing

- **Homepage CTA update**: 
  - Changed the first call-to-action button from primary to secondary variant
  - Updated button text from "Começa já" to "Sabe mais"
  - Maintains existing responsive padding and text styling

## Implementation Details
- The secondary button follows the same design patterns as the primary button with consistent spacing, border-radius (20em), and interactive states
- Includes proper accessibility considerations with disabled state styling
- Uses `will-change: transform` for performance optimization on interactive elements
- Mobile breakpoint adjustments ensure usability on smaller screens

https://claude.ai/code/session_0197mG85TEzJWAXXHtJiEbLF