### PR TITLE
Update mobile menu styling and course page UI elements

### DIFF
--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -74,7 +74,7 @@ export default function TopNav() {
 
       {/* Renderiza menu vertical no mobile com área clicável confortável e ordem visual consistente. */}
       {isMenuOpen ? (
-        <nav className="mobile-menu-container absolute right-3 top-[80px] z-40 sm:right-4 sm:top-[84px] flex flex-col overflow-hidden rounded-[10px] border border-[color:var(--line)] shadow-sm lg:hidden min-w-[200px]">
+        <nav className="mobile-menu-container absolute right-3 top-[80px] z-40 sm:right-4 sm:top-[84px] flex flex-col overflow-hidden rounded-[10px] border border-[color:var(--line)] shadow-sm lg:hidden min-w-[200px] !bg-[#feb1a5]">
           {navigationItems.map((item, index) => {
             const isActive = pathname === item.href;
             const isLast = index === navigationItems.length - 1;
@@ -82,11 +82,11 @@ export default function TopNav() {
             return (
               <Link
                 key={item.href}
-                className={`mobile-menu-item px-4 sm:px-5 py-3 sm:py-4 text-sm sm:text-base font-semibold transition ${
+                className={`mobile-menu-item px-4 sm:px-5 py-3 sm:py-4 text-sm sm:text-base font-semibold transition !text-white ${
                   isActive
-                    ? "bg-[#111111]"
-                    : "hover:bg-[#111111]"
-                } ${isLast ? "border-b-0" : "border-b border-[color:var(--line)]"}`}
+                    ? "bg-[#ff9b7f]"
+                    : "hover:bg-[#ff9b7f]"
+                } ${isLast ? "border-b-0" : "border-b border-white/30"}`}
                 href={item.href}
                 onClick={closeMenu}
               >

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -503,7 +503,7 @@ export default function CursoPage() {
                       {completed ? "\u2713" : mod.id}
                     </div>
                     <div className="min-w-0">
-                      <h3 className="font-semibold text-sm truncate">{mod.title}</h3>
+                      <h3 className="font-semibold text-sm break-words">{mod.title}</h3>
                       <p className="text-xs text-white/60 mt-0.5">{mod.description}</p>
                     </div>
                   </div>
@@ -531,7 +531,7 @@ export default function CursoPage() {
           <button
             type="button"
             onClick={() => setActiveModuleId(null)}
-            className="text-sm home-title-highlight-text font-semibold hover:underline"
+            className="text-sm text-white font-semibold hover:underline"
           >
             &larr; Voltar aos módulos
           </button>
@@ -590,7 +590,7 @@ export default function CursoPage() {
                 type="button"
                 onClick={() => setTheoryPage((prev) => Math.max(prev - 1, 0))}
                 disabled={theoryPage === 0}
-                className="submit max-w-[180px] !bg-white/15 disabled:opacity-40"
+                className="site-pill-button-secondary max-w-[180px] disabled:opacity-40"
               >
                 Página anterior
               </button>
@@ -627,7 +627,7 @@ export default function CursoPage() {
           <button
             type="button"
             onClick={() => setQuizMode(false)}
-            className="text-sm home-title-highlight-text font-semibold hover:underline"
+            className="text-sm text-white font-semibold hover:underline"
           >
             &larr; Voltar ao conteúdo
           </button>


### PR DESCRIPTION
## Summary
This PR updates the styling of the mobile navigation menu and refines several UI elements in the course page for improved visual consistency and user experience.

## Key Changes

### Mobile Menu Styling (TopNav.tsx)
- Changed mobile menu background color from dark (`#111111`) to a coral/salmon tone (`#feb1a5`)
- Updated active and hover states for menu items to use `#ff9b7f` instead of `#111111`
- Added white text color to menu items for better contrast against the new background
- Updated border color between menu items from `var(--line)` to `white/30` for visual consistency

### Course Page Updates (curso/page.tsx)
- **Module Title Display**: Changed from `truncate` to `break-words` to allow multi-line titles instead of cutting them off
- **Back Navigation Links**: Updated two "Voltar" (back) buttons to use plain `text-white` instead of `home-title-highlight-text` class for consistency
- **Previous Page Button**: Replaced custom `submit !bg-white/15` styling with `site-pill-button-secondary` class for standardized button styling

## Implementation Details
These changes appear to be part of a design system update, moving away from dark-themed navigation elements toward a warmer color palette while improving text wrapping behavior and using more consistent component classes throughout the course interface.

https://claude.ai/code/session_017QBWXCgpwyXC9sCjqtb8hT