### PR TITLE
Replace Montserrat font with Outfit for improved readability

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,12 +3,12 @@
  */
 
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Montserrat } from "next/font/google";
+import { Geist, Geist_Mono, Outfit } from "next/font/google";
 import AppShell from "./components/AppShell";
 import "./globals.css";
 
-// Define a fonte principal com estilo geométrico para reforçar o visual editorial.
-const montserrat = Montserrat({
+// Define a fonte principal Basenji para melhor legibilidade.
+const outfit = Outfit({
   variable: "--font-montserrat",
   subsets: ["latin"],
   weight: ["400", "500", "600", "700", "900"],
@@ -56,7 +56,7 @@ export default function RootLayout({
   return (
     <html lang="pt">
       <body
-        className={`${montserrat.variable} ${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
+        className={`${outfit.variable} ${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
       >
         <AppShell>{children}</AppShell>
       </body>


### PR DESCRIPTION
## Summary
This PR updates the primary font used in the application from Montserrat to Outfit to improve overall readability and visual consistency.

## Changes
- Replaced `Montserrat` font import with `Outfit` from `next/font/google`
- Updated the font variable initialization from `montserrat` to `outfit`
- Updated the CSS class binding in the root layout body element to use the new `outfit.variable`
- Updated the comment to reflect the new font choice and its purpose

## Implementation Details
- The font configuration maintains the same weight options (400, 500, 600, 700, 900) and Latin subset
- The CSS variable name `--font-montserrat` remains unchanged to avoid breaking existing styles that may reference it
- The change is applied globally through the root layout component, affecting all pages in the application

https://claude.ai/code/session_01A6WZFFfH9e3LcVHySe84Jv