### PR TITLE
Replace Outfit font with custom Basenji font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,23 @@
 
 @import "tailwindcss";
 
+/* Declarações de fontes customizadas Basenji */
+@font-face {
+  font-family: "Basenji";
+  src: url("/fonts/Basenji-SemiBold.otf") format("opentype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Basenji";
+  src: url("/fonts/Basenji-SemiBoldSlanted.otf") format("opentype");
+  font-weight: 600;
+  font-style: italic;
+  font-display: swap;
+}
+
 :root {
   --background: #e2e0e0;
   --foreground: #000000;
@@ -29,7 +46,7 @@
   --color-primary-soft: var(--primary-soft);
   --color-accent: var(--accent);
   --color-line: var(--line);
-  --font-sans: var(--font-montserrat);
+  --font-sans: "Basenji", sans-serif;
   --font-mono: var(--font-geist-mono);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,17 +3,9 @@
  */
 
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Outfit } from "next/font/google";
+import { Geist, Geist_Mono } from "next/font/google";
 import AppShell from "./components/AppShell";
 import "./globals.css";
-
-// Define a fonte principal Basenji para melhor legibilidade.
-const outfit = Outfit({
-  variable: "--font-montserrat",
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700", "900"],
-  display: "swap",
-});
 
 // Mantém as fontes auxiliares para áreas técnicas sem quebrar compatibilidade.
 const geistSans = Geist({
@@ -56,7 +48,8 @@ export default function RootLayout({
   return (
     <html lang="pt">
       <body
-        className={`${outfit.variable} ${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} bg-[color:var(--background)] text-[color:var(--foreground)] antialiased`}
+        style={{ fontFamily: "Basenji, sans-serif" }}
       >
         <AppShell>{children}</AppShell>
       </body>


### PR DESCRIPTION
## Summary
This PR replaces the Google Fonts "Outfit" font with a custom "Basenji" font that is self-hosted locally. The change improves font loading performance and provides better control over typography.

## Key Changes
- **Removed Google Font dependency**: Eliminated the `Outfit` font import from `next/font/google` in `layout.tsx`
- **Added custom font declarations**: Defined two `@font-face` rules in `globals.css` for Basenji font variants:
  - `Basenji-SemiBold.otf` (font-weight: 600, normal style)
  - `Basenji-SemiBoldSlanted.otf` (font-weight: 600, italic style)
- **Updated CSS variable**: Changed `--font-sans` from `var(--font-montserrat)` to `"Basenji", sans-serif` in the `:root` selector
- **Simplified layout component**: Removed the `outfit` font variable from the body className and replaced it with an inline `fontFamily` style

## Implementation Details
- Both font files are expected to be located in the `/public/fonts/` directory
- Used `font-display: swap` for optimal font loading behavior
- The custom fonts are now the primary sans-serif font throughout the application
- Geist fonts remain as auxiliary fonts for technical areas

https://claude.ai/code/session_01NVbcJo5AMhPmQW7eu78hgE