### PR TITLE
Update course page color scheme for info boxes

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -564,24 +564,24 @@ export default function CursoPage() {
 
                 {/* Dica Prática */}
                 {activeModule.practicalTip && (
-                  <div className="rounded-lg border border-emerald-400/30 bg-emerald-900/10 p-4">
-                    <p className="text-xs font-semibold text-emerald-300 uppercase mb-2">💡 Dica Prática</p>
+                  <div className="rounded-lg border border-[#fde1dd]/30 bg-[#fde1dd]/10 p-4">
+                    <p className="text-xs font-semibold text-[#fde1dd] uppercase mb-2">Dica Prática</p>
                     <p className="text-sm text-white/85">{activeModule.practicalTip}</p>
                   </div>
                 )}
 
                 {/* Benefício */}
                 {activeModule.benefit && (
-                  <div className="rounded-lg border border-sky-400/30 bg-sky-900/10 p-4">
-                    <p className="text-xs font-semibold text-sky-300 uppercase mb-2">⭐ Por que isto importa</p>
+                  <div className="rounded-lg border border-[#f99589]/30 bg-[#f99589]/10 p-4">
+                    <p className="text-xs font-semibold text-[#f99589] uppercase mb-2">Por que isto importa</p>
                     <p className="text-sm text-white/85">{activeModule.benefit}</p>
                   </div>
                 )}
 
                 {/* Aviso */}
                 {activeModule.warning && (
-                  <div className="rounded-lg border border-rose-400/30 bg-rose-900/10 p-4">
-                    <p className="text-xs font-semibold text-rose-300 uppercase mb-2">⚠️ Aviso Importante</p>
+                  <div className="rounded-lg border border-[#fbc3bb]/30 bg-[#fbc3bb]/10 p-4">
+                    <p className="text-xs font-semibold text-[#fbc3bb] uppercase mb-2">Aviso Importante</p>
                     <p className="text-sm text-white/85">{activeModule.warning}</p>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
Updated the color scheme for informational boxes (Practical Tip, Benefit, and Warning sections) on the course page to use a custom coral/pink palette instead of the previous emerald, sky, and rose Tailwind colors.

## Changes
- **Practical Tip box**: Changed from emerald (`emerald-400/30`, `emerald-900/10`, `emerald-300`) to coral pink (`#fde1dd`)
- **Benefit box**: Changed from sky blue (`sky-400/30`, `sky-900/10`, `sky-300`) to coral (`#f99589`)
- **Warning box**: Changed from rose (`rose-400/30`, `rose-900/10`, `rose-300`) to light coral (`#fbc3bb`)
- Removed emoji icons (💡, ⭐, ⚠️) from section labels while keeping the text labels

## Implementation Details
- Replaced Tailwind color utilities with custom hex color values using opacity modifiers
- Maintained the same visual hierarchy and spacing (border, background, padding)
- Kept all text styling consistent with the rest of the page

https://claude.ai/code/session_01WeSyd58LidHszFkkgmezHJ