### PR TITLE
Refactor About page layout and update color styling

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,18 +12,13 @@ export default function AboutPage() {
     'Estratégias para conseguir mais avaliações e aumentar o rendimento',
   ];
 
-  const highlightMetrics = [
-    { value: '4', label: 'Vantagens principais do curso' },
-    { value: '100%', label: 'Foco em aplicação prática no terreno' },
-  ];
-
   return (
     <section className="space-y-8 sm:space-y-12 pb-4">
       {/* Mantém a estrutura de duas colunas sem cartão branco para seguir o estilo da landing page. */}
       <article className="grid w-full gap-6 sm:gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
         {/* Preserva o conteúdo da página e ajusta a hierarquia para texto branco com destaques amarelos. */}
         <div className="space-y-4 sm:space-y-6">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-white">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: "#F66856" }}>
             Sobre a Cliente Mistério
           </p>
 
@@ -48,42 +43,8 @@ export default function AboutPage() {
             transformares isto num extra mensal realista.
           </p>
 
-          {/* Exibe métricas curtas para reforçar visualmente os benefícios sem alterar conteúdo. */}
-          <div className="grid gap-2 sm:gap-3 sm:grid-cols-2">
-            {highlightMetrics.map((metric) => (
-              <div
-                key={metric.label}
-                className="rounded-2xl border border-white/30 px-3 sm:px-4 py-2 sm:py-3"
-              >
-                <p className="text-xl sm:text-2xl font-bold home-title-highlight-text">{metric.value}</p>
-                <p className="text-xs sm:text-sm font-medium">{metric.label}</p>
-              </div>
-            ))}
-          </div>
         </div>
 
-        {/* Usa imagem existente do projeto para manter coerência com os recursos atuais. */}
-        <div className="relative mx-auto w-full max-w-md">
-          <div className="absolute -left-2 sm:-left-4 -top-2 sm:-top-4 h-full w-full rounded-[28px] border-2 border-white/40" />
-          <div className="relative overflow-hidden rounded-[28px] border border-white/20 p-2 sm:p-3">
-            <Image
-              src="/images/IMG_2622.png"
-              alt="Formação de cliente mistério"
-              width={900}
-              height={1200}
-              className="h-[300px] sm:h-[430px] w-full rounded-2xl object-cover"
-              priority
-            />
-            <div className="absolute bottom-4 sm:bottom-8 left-4 sm:left-8 rounded-xl bg-black/65 px-3 sm:px-4 py-2 sm:py-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] home-title-highlight-text">
-                Curso estruturado
-              </p>
-              <p className="text-xs sm:text-sm font-medium">
-                Do básico ao avançado com foco em resultados reais.
-              </p>
-            </div>
-          </div>
-        </div>
       </article>
 
       {/* Mantém a secção de vantagens sem caixa branca, reforçando o contraste de texto. */}

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -9,7 +9,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 const navigationItems = [
-  { href: "/", label: "Home" },
+  { href: "/", label: "Página Inicial" },
   { href: "/about", label: "Sobre" },
   { href: "/o-curso", label: "O Curso" },
   { href: "/contact", label: "Contacto" },

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -438,7 +438,7 @@ export default function CursoPage() {
   return (
     <section className="w-full space-y-8 bg-[#E8D5C8] p-8 rounded-2xl">
       <header className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] home-title-highlight-text">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: "#F66856" }}>
           Formação completa
         </p>
         <h1 className="text-3xl font-semibold home-title-highlight-text lg:text-4xl">

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -103,7 +103,7 @@ export default function CoursePage() {
   return (
     <section className="w-full space-y-8">
       <header className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] home-title-highlight-text">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: "#F66856" }}>
           Formação completa
         </p>
 


### PR DESCRIPTION
## Summary
This PR simplifies the About page layout by removing the metrics section and image component, while standardizing color styling across multiple pages to use an inline coral color (#F66856) instead of CSS class-based highlighting.

## Key Changes
- **About page layout**: Removed the `highlightMetrics` array and its associated grid display component that showed "4 Vantagens principais" and "100% Foco em aplicação prática"
- **About page image section**: Removed the entire right-column image component including the decorative border, Image element, and overlay caption
- **Color styling**: Replaced `home-title-highlight-text` CSS class with inline `style={{ color: "#F66856" }}` on section headers in:
  - `app/about/page.tsx` (About section label)
  - `app/curso/page.tsx` (Formação completa section label)
  - `app/o-curso/page.tsx` (Formação completa section label)
- **Navigation**: Updated TopNav label from "Home" to "Página Inicial" for Portuguese localization consistency

## Implementation Details
- The About page now displays only the left-column text content in a single-column layout
- Color changes use inline styles for more explicit control over the coral accent color (#F66856)
- The grid layout structure remains but now only contains the text content section
- All changes maintain the existing spacing and typography hierarchy

https://claude.ai/code/session_01Vqa5emLiHCWL9aFXVdWEuS