### PR TITLE
Fix text color contrast in cards and home title highlights

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -103,10 +103,17 @@ body em {
   color: var(--foreground) !important;
 }
 
+/* Permite texto branco nos cards mesmo com regra global */
+.bg-\[\#F66856\] p,
+.bg-\[\#F66856\] span {
+  color: white !important;
+}
+
 
 /* Permite destacar textos específicos da home sem ser afetado pela regra global de contraste. */
 .home-title-highlight-text {
   color: #000000 !important;
+  white-space: nowrap;
 }
 
 /* Aplica cor de destaque secundária aos benefícios da home com prioridade sobre a regra global. */


### PR DESCRIPTION
## Summary
This PR improves text visibility and contrast in specific UI components by adding targeted CSS rules for card text colors and preventing text wrapping in home title highlights.

## Key Changes
- Added white text color override for paragraphs and spans within cards with `#F66856` background to ensure proper contrast and readability
- Added `white-space: nowrap` to `.home-title-highlight-text` class to prevent unintended text wrapping on home title highlights

## Implementation Details
- The new card text color rule uses `!important` to override the global contrast rule that was affecting text visibility on the colored background
- The `white-space: nowrap` property ensures home title highlights maintain their intended single-line layout

https://claude.ai/code/session_018yLB9Z1BrEdtZHeT9U4g5p