### PR TITLE
Update About page headline text

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -23,7 +23,7 @@ export default function AboutPage() {
           </p>
 
           <h1 className="text-3xl font-semibold leading-tight home-title-highlight-text sm:text-4xl lg:text-5xl">
-            Aprende a atuar como cliente real com método e consistência.
+            Atua com método e consistência
           </h1>
 
           <p className="max-w-2xl text-sm sm:text-base leading-6 sm:leading-7">


### PR DESCRIPTION
## Summary
Updated the main headline text on the About page to be more concise and direct.

## Changes
- Modified the h1 headline from "Aprende a atuar como cliente real com método e consistência." to "Atua com método e consistência"
  - Removed the "Aprende a" (Learn to) prefix
  - Removed the "como cliente real" (as a real client) phrase
  - Removed the trailing period
  - Result is a shorter, more action-oriented headline

## Details
The change simplifies the messaging while maintaining the core concept of acting with method and consistency. The new text is more direct and imperative in tone.

https://claude.ai/code/session_016DY14SgQzAbKZbDHRft7vW