### PR TITLE
Add tagline subtitle below main heading on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,11 @@ export default function HomePage() {
                 Cliente Mistério
               </h1>
 
+              {/* Tagline por baixo do título principal */}
+              <p className="text-center text-sm sm:text-base text-gray-700">
+                O único curso de Cliente Mistério em Portugal — aprende a ganhar enquanto avalias!
+              </p>
+
               {/* Exibe os 3 pontos principais em cards animados. */}
               <ThreePointsCards />
 


### PR DESCRIPTION
## Summary
Added a descriptive tagline subtitle below the main "Cliente Mistério" heading on the homepage to better communicate the unique value proposition of the course.

## Changes
- Added a new paragraph element with centered text below the main h1 heading
- Tagline text: "O único curso de Cliente Mistério em Portugal — aprende a ganhar enquanto avalias!"
- Styled with responsive text sizing (sm:text-base on mobile, text-sm default) and gray-700 text color
- Positioned before the ThreePointsCards component

## Implementation Details
- Uses Tailwind CSS classes for styling and responsive design
- Maintains consistent spacing and alignment with existing layout
- Includes a comment explaining the purpose of the new element

https://claude.ai/code/session_01BcHEFs2Rpyo8vAW73b2x8H