### PR TITLE
Fix: aplicar alinhamento justificado à esquerda em todas as páginas

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,6 +87,8 @@ body {
   font-weight: 400;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+  text-align: justify;
+  text-align-last: left;
   position: relative;
   overflow-x: hidden;
 }


### PR DESCRIPTION
Adiciona text-align: justify e text-align-last: left ao body em globals.css, garantindo que todo o texto apareça justificado com a última linha alinhada à esquerda em todas as páginas da aplicação.

https://claude.ai/code/session_01L2zVPtsfxmHp8S2jTUKXuB