### PR TITLE
Standardize typography hierarchy across all pages

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -19,8 +19,8 @@ export default function CheckoutPage() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center space-y-4">
-        <h1 className="text-2xl font-semibold">Redirecionando para pagamento...</h1>
-        <p className="text-white/70">Se não for redirecionado automaticamente,</p>
+        <h1 className="text-3xl font-semibold home-title-highlight-text">Redirecionando para pagamento...</h1>
+        <p className="text-sm sm:text-base leading-6 sm:leading-7">Se não for redirecionado automaticamente,</p>
         {paymentLink && (
           <a
             href={paymentLink}

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -107,16 +107,16 @@ export default function CoursePage() {
           Formação completa
         </p>
 
-        <h1 className="text-3xl font-semibold home-title-highlight-text lg:text-4xl">O Curso de Cliente Mistério</h1>
+        <h1 className="text-3xl font-semibold home-title-highlight-text sm:text-4xl lg:text-5xl">O Curso de Cliente Mistério</h1>
 
-        <p className="max-w-3xl text-base leading-7">
+        <p className="max-w-3xl text-sm sm:text-base leading-6 sm:leading-7">
           Um curso completo, 100% prático e desenhado para INICIANTES. Aprende tudo que precisas para começar a ganhar dinheiro como Cliente Mistério — desde os conceitos básicos até estratégias de carreira avançadas.
         </p>
       </header>
 
       {/* Benefícios do curso */}
       <div className="rounded-2xl border border-white/20 bg-white/5 p-6 backdrop-blur-sm">
-        <h3 className="text-lg font-semibold mb-4">Por que fazer este curso?</h3>
+        <h3 className="text-2xl font-semibold sm:text-3xl home-title-highlight-text mb-4">Por que fazer este curso?</h3>
         <div className="grid gap-4 md:grid-cols-3">
           <div className="rounded-lg border border-[#F66856] bg-[#F66856] p-4">
             <p className="font-semibold text-white mb-2">✓ Para Iniciantes</p>
@@ -157,7 +157,7 @@ export default function CoursePage() {
       )}
 
       <div className="space-y-3">
-        <h3 className="text-lg font-semibold mt-8 mb-4">10 Módulos Completos</h3>
+        <h3 className="text-2xl font-semibold sm:text-3xl home-title-highlight-text mt-8 mb-4">10 Módulos Completos</h3>
         {courseModules.map((moduleItem, idx) => {
           const emojis = ["🔍", "📈", "🎭", "✅", "📋", "👀", "📸", "📝", "💰", "🚀"];
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,12 +18,12 @@ export default function HomePage() {
             {/* Agrupa o texto e o botão num bloco centralizado para melhorar a hierarquia visual. */}
             <div className="flex w-full max-w-3xl flex-col items-center space-y-4 text-center sm:space-y-6">
               {/* Destaca a mensagem principal no centro com texto preto, sem caixa vermelha. */}
-              <h1 className="h-auto min-h-0 rounded-3xl px-6 py-4 text-center text-2xl leading-tight whitespace-normal sm:px-8 sm:py-5 sm:text-4xl lg:text-5xl text-black">
+              <h1 className="h-auto min-h-0 rounded-3xl px-6 py-4 text-center text-3xl font-semibold leading-tight sm:px-8 sm:py-5 sm:text-4xl lg:text-5xl home-title-highlight-text">
                 Cliente Mistério
               </h1>
 
               {/* Tagline por baixo do título principal */}
-              <p className="text-center text-sm sm:text-base text-gray-700">
+              <p className="text-center text-sm sm:text-base leading-6 sm:leading-7">
                 O único curso de Cliente Mistério em Portugal — aprende a ganhar enquanto avalias!
               </p>
 


### PR DESCRIPTION
Apply consistent sizing for titles (text-3xl→5xl), section headings (text-2xl→3xl), and body text (text-sm sm:text-base) using about/page.tsx as the reference standard.

https://claude.ai/code/session_0131T7hLF2t64c8z6qhi53w8