### PR TITLE
Fix mobile text overflow and add white background pricing section

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,7 +2,7 @@
  * DESCRIÇÃO DO FICHEIRO: Este ficheiro implementa a lógica de `app/about/page.tsx` no projeto, incluindo as responsabilidades principais desta unidade.
  */
 
-import Image from 'next/image';
+import CheckoutButton from '../components/CheckoutButton';
 
 export default function AboutPage() {
   const courseAdvantages = [
@@ -72,6 +72,16 @@ export default function AboutPage() {
             </li>
           ))}
         </ul>
+      </article>
+
+      {/* Preço e CTA */}
+      <article className="flex flex-col items-center gap-4 rounded-2xl bg-white p-6 sm:p-8 text-center">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Acesso Completo ao Curso</p>
+          <p className="text-5xl font-bold" style={{ color: "#F66856" }}>19,99€</p>
+          <p className="text-sm text-gray-400">Pagamento único · Acesso vitalício</p>
+        </div>
+        <CheckoutButton label="Comprar Curso Completo" />
       </article>
     </section>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -115,7 +115,6 @@ body em {
 /* Permite destacar textos específicos da home sem ser afetado pela regra global de contraste. */
 .home-title-highlight-text {
   color: #000000 !important;
-  white-space: nowrap;
 }
 
 /* Aplica cor de destaque secundária aos benefícios da home com prioridade sobre a regra global. */

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -115,11 +115,11 @@ export default function CoursePage() {
       </header>
 
       {/* Preço e CTA */}
-      <div className="flex flex-col sm:flex-row items-center justify-between gap-4 rounded-2xl border border-white/20 bg-white/5 p-6 backdrop-blur-sm">
-        <div>
-          <p className="text-sm text-white/60 uppercase tracking-widest font-semibold mb-1">Acesso completo ao curso</p>
-          <p className="text-4xl font-bold" style={{ color: "#F66856" }}>19,99€</p>
-          <p className="text-xs text-white/50 mt-1">Pagamento único · Acesso vitalício</p>
+      <div className="flex flex-col items-center gap-4 rounded-2xl bg-white p-6 sm:p-8 text-center">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Acesso Completo ao Curso</p>
+          <p className="text-5xl font-bold" style={{ color: "#F66856" }}>19,99€</p>
+          <p className="text-sm text-gray-400">Pagamento único · Acesso vitalício</p>
         </div>
         <CheckoutButton label="Comprar Curso Completo" />
       </div>


### PR DESCRIPTION
- Remove white-space: nowrap from home-title-highlight-text causing h1 to overflow on mobile
- Update pricing CTA in /o-curso to white card with dark text
- Add white background pricing section to /about page with price, subtitle and CTA button

https://claude.ai/code/session_01QV5Gfx8Hvx2ZmgBVaJRh8P