### PR TITLE
Require login before purchase and center price display

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -76,7 +76,7 @@ export default function AboutPage() {
 
       {/* Preço e CTA */}
       <article className="flex flex-col items-center gap-4 rounded-2xl bg-white p-6 sm:p-8 text-center">
-        <div className="space-y-1">
+        <div className="space-y-1 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Acesso Completo ao Curso</p>
           <p className="text-5xl font-bold" style={{ color: "#F66856" }}>19,99€</p>
           <p className="text-sm text-gray-400">Pagamento único · Acesso vitalício</p>

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -6,7 +6,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type RegisterForm = {
   firstName: string;
@@ -23,6 +23,7 @@ type FeedbackState = {
 
 export default function AccountPage() {
   const router = useRouter();
+  const [isCheckout, setIsCheckout] = useState(false);
   const [formData, setFormData] = useState<RegisterForm>({
     firstName: "",
     lastName: "",
@@ -32,6 +33,11 @@ export default function AccountPage() {
   });
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const urlParameters = new URLSearchParams(window.location.search);
+    setIsCheckout(urlParameters.get("checkout") === "1");
+  }, []);
 
   const handleChange = (field: keyof RegisterForm, value: string) => {
     setFormData((previous) => ({ ...previous, [field]: value }));
@@ -72,7 +78,7 @@ export default function AccountPage() {
       }
 
       setFeedback({ type: "success", message: "Registo efetuado com sucesso." });
-      router.push("/login?registered=1");
+      router.push(isCheckout ? "/login?registered=1&checkout=1" : "/login?registered=1");
     } catch {
       setFeedback({
         type: "error",
@@ -88,6 +94,9 @@ export default function AccountPage() {
       <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form max-w-[620px]">
           <h1 className="form-heading">Criar conta</h1>
+          {isCheckout && (
+            <p className="form-feedback mb-4">Para proceder com a compra é necessário criar uma conta ou <a className="form-link" href="/login?checkout=1">iniciar sessão</a>.</p>
+          )}
 
           <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
             <div className="input-group">
@@ -154,7 +163,7 @@ export default function AccountPage() {
                 {isSubmitting ? "A criar..." : "Criar conta"}
               </button>
               <div className="text-center">
-                <Link className="form-link" href="/login">
+                <Link className="form-link" href={isCheckout ? "/login?checkout=1" : "/login"}>
                   Já tenho conta
                 </Link>
               </div>

--- a/app/components/CheckoutButton.tsx
+++ b/app/components/CheckoutButton.tsx
@@ -4,6 +4,8 @@
 
 "use client";
 
+import { useRouter } from "next/navigation";
+
 interface CheckoutButtonProps {
   label?: string;
   className?: string;
@@ -15,6 +17,7 @@ export default function CheckoutButton({
   className = "",
   variant = "primary",
 }: CheckoutButtonProps) {
+  const router = useRouter();
   const paymentLink = process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK;
 
   if (!paymentLink) {
@@ -26,7 +29,12 @@ export default function CheckoutButton({
   }
 
   const handleCheckout = () => {
-    window.location.href = paymentLink;
+    const session = localStorage.getItem("vp_session");
+    if (session) {
+      window.location.href = paymentLink;
+    } else {
+      router.push("/login?checkout=1");
+    }
   };
 
   const buttonClasses =

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -46,13 +46,22 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCheckout, setIsCheckout] = useState(false);
 
   useEffect(() => {
     const urlParameters = new URLSearchParams(window.location.search);
+    const checkout = urlParameters.get("checkout") === "1";
+    setIsCheckout(checkout);
 
     if (urlParameters.get("registered") === "1") {
       // Exibe confirmação de registo concluído e acesso imediato ao login.
-      setFeedback("Conta criada com sucesso. Já pode iniciar sessão.");
+      if (checkout) {
+        setFeedback("Conta criada com sucesso. Inicia sessão para continuar com a compra.");
+      } else {
+        setFeedback("Conta criada com sucesso. Já pode iniciar sessão.");
+      }
+    } else if (checkout) {
+      setFeedback("Para proceder com a compra é necessário iniciar sessão ou criar uma conta.");
     }
 
     // Mantém o utilizador autenticado ao regressar ao ecrã de login.
@@ -60,7 +69,7 @@ export default function LoginPage() {
     const storedUser = localStorage.getItem(userStorageKey);
 
     if (storedSession && storedUser) {
-      router.push("/dashboard");
+      router.push(checkout ? "/checkout" : "/dashboard");
     }
   }, [router]);
 
@@ -108,7 +117,7 @@ export default function LoginPage() {
         localStorage.setItem(userStorageKey, JSON.stringify(normalizedSessionUser));
       }
 
-      router.push("/dashboard");
+      router.push(isCheckout ? "/checkout" : "/dashboard");
     } catch {
       setFeedback("Não foi possível iniciar sessão. Tente novamente.");
     } finally {
@@ -151,7 +160,7 @@ export default function LoginPage() {
                 {isSubmitting ? "A entrar..." : "Entrar"}
               </button>
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <Link className="form-link" href="/account">
+                <Link className="form-link" href={isCheckout ? "/account?checkout=1" : "/account"}>
                   Criar conta
                 </Link>
                 <Link className="form-link" href="/forgot-password">


### PR DESCRIPTION
- CheckoutButton now checks localStorage session before redirecting; unauthenticated users are sent to /login?checkout=1 instead of Stripe
- Login page shows a notice when checkout=1 is present and redirects to /checkout after successful login instead of /dashboard
- Register page preserves checkout=1 param, shows purchase notice, and passes checkout param through to login after registration
- Added explicit text-center to price/subtitle div in about page

https://claude.ai/code/session_01LXyM6ZyXK5bPytTyGanZNP