### PR TITLE
Center pricing section text in about and o-curso pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -76,7 +76,7 @@ export default function AboutPage() {
 
       {/* Preço e CTA */}
       <article className="flex flex-col items-center gap-4 rounded-2xl bg-white p-6 sm:p-8 text-center">
-        <div className="space-y-1 text-center">
+        <div className="w-full space-y-1 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Acesso Completo ao Curso</p>
           <p className="text-5xl font-bold" style={{ color: "#F66856" }}>19,99€</p>
           <p className="text-sm text-gray-400">Pagamento único · Acesso vitalício</p>

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -116,7 +116,7 @@ export default function CoursePage() {
 
       {/* Preço e CTA */}
       <div className="flex flex-col items-center gap-4 rounded-2xl bg-white p-6 sm:p-8 text-center">
-        <div className="space-y-1 text-center">
+        <div className="w-full space-y-1 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Acesso Completo ao Curso</p>
           <p className="text-5xl font-bold" style={{ color: "#F66856" }}>19,99€</p>
           <p className="text-sm text-gray-400">Pagamento único · Acesso vitalício</p>


### PR DESCRIPTION
Add w-full to inner pricing div so text-center applies across the full card width, ensuring price, payment info, and lifetime access text are properly centered.

https://claude.ai/code/session_012dzjxEmu19tnH8A5Mb34VS