### PR TITLE
Center pricing box text by overriding text-align-last

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -89,6 +89,14 @@ body {
   -webkit-font-smoothing: antialiased;
   text-align: justify;
   text-align-last: left;
+}
+
+/* Override text-align-last so .text-center elements are not affected by the body's text-align-last: left */
+.text-center {
+  text-align-last: center;
+}
+
+body {
   position: relative;
   overflow-x: hidden;
 }


### PR DESCRIPTION
The body had text-align-last: left which inherited to all elements, making single-line text appear left-aligned even with text-center class. Adding .text-center { text-align-last: center } fixes the pricing box.

https://claude.ai/code/session_01184AD5FSmXGnWYSz4qgRiy