### PR TITLE
Update Terms and Conditions for online course offering

### DIFF
--- a/app/termos-e-condicoes/page.tsx
+++ b/app/termos-e-condicoes/page.tsx
@@ -20,70 +20,95 @@ export default function TermosECondicoes() {
       <section className="space-y-4">
         <h2 className="text-2xl font-bold">1. Aceitação dos Termos</h2>
         <p className="text-white/80">
-          Ao aceder e utilizar o portal Cliente Mistério, o utilizador concorda em aceitar integralmente estes termos e condições. Se não concorda com alguma parte destes termos, por favor não utilize o portal.
+          Ao aceder, adquirir ou utilizar o curso disponibilizado no portal Cliente Mistério, o utilizador concorda em aceitar integralmente estes termos e condições. Se não concorda com alguma parte destes termos, por favor não prossiga com a compra ou utilização do curso.
         </p>
       </section>
 
       <section className="space-y-4">
         <h2 className="text-2xl font-bold">2. Serviço Fornecido</h2>
         <p className="text-white/80">
-          O portal Cliente Mistério é um portal de participação cidadã e informação pública que permite aos utilizadores aceder a informações públicas e participar em iniciativas de interesse público. O serviço é fornecido "tal qual está" sem garantias de qualquer tipo.
+          O portal Cliente Mistério comercializa um curso online de formação para quem pretende iniciar a atividade de cliente mistério. O curso inclui módulos de aprendizagem, materiais de apoio e, após conclusão, a emissão de um certificado de participação. O serviço é fornecido em formato digital, acessível através da plataforma online.
         </p>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-bold">3. Responsabilidades do Utilizador</h2>
+        <h2 className="text-2xl font-bold">3. Certificado de Conclusão</h2>
         <p className="text-white/80">
-          O utilizador é integralmente responsável pela confidencialidade das suas credenciais de acesso e pela segurança da sua conta. O utilizador compromete-se a:
+          Após a conclusão do curso, o utilizador recebe um certificado de participação. É expressamente declarado que:
         </p>
         <ul className="list-inside list-disc space-y-2 text-white/80">
-          <li>Não utilizar a plataforma para fins ilegais ou prejudiciais</li>
-          <li>Não tentar obter acesso não autorizado ao sistema</li>
-          <li>Não publicar conteúdo ofensivo, discriminatório ou ilegal</li>
-          <li>Respeitar os direitos de propriedade intelectual de terceiros</li>
-          <li>Informar imediatamente sobre qualquer uso não autorizado da sua conta</li>
+          <li>O certificado <strong>não possui validade legal</strong> nem é reconhecido por qualquer entidade reguladora ou organismo oficial.</li>
+          <li>O certificado serve <strong>exclusivamente como comprovativo</strong> de que o utilizador frequentou e concluiu o curso oferecido pelo portal Cliente Mistério.</li>
+          <li>O certificado não substitui qualquer formação profissional certificada, acreditada ou regulamentada por lei.</li>
+          <li>O Cliente Mistério não garante que o certificado seja aceite por terceiros, empresas ou entidades empregadoras como qualificação profissional.</li>
         </ul>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-bold">4. Propriedade Intelectual</h2>
+        <h2 className="text-2xl font-bold">4. Compra e Pagamento</h2>
         <p className="text-white/80">
-          Todo o conteúdo presente no portal, incluindo textos, gráficos, logos, imagens e software, é propriedade de Cliente Mistério ou dos seus fornecedores de conteúdo e está protegido pelas leis de propriedade intelectual. O utilizador é autorizado a visualizar e copiar o conteúdo apenas para uso pessoal e não comercial.
+          A aquisição do curso é feita mediante pagamento único, processado de forma segura através da plataforma de pagamentos Stripe. Após confirmação do pagamento, o acesso ao curso é ativado de forma imediata. O utilizador concorda que:
+        </p>
+        <ul className="list-inside list-disc space-y-2 text-white/80">
+          <li>O pagamento é processado de forma segura e encriptada.</li>
+          <li>Não são oferecidos reembolsos após o acesso ao curso ter sido disponibilizado, salvo nos casos previstos na legislação do consumidor em vigor.</li>
+          <li>Os preços apresentados incluem IVA à taxa legal em vigor, quando aplicável.</li>
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-bold">5. Responsabilidades do Utilizador</h2>
+        <p className="text-white/80">
+          O utilizador é integralmente responsável pela confidencialidade das suas credenciais de acesso e pela segurança da sua conta. O utilizador compromete-se a:
+        </p>
+        <ul className="list-inside list-disc space-y-2 text-white/80">
+          <li>Não partilhar o acesso ao curso com terceiros.</li>
+          <li>Não reproduzir, distribuir ou comercializar os conteúdos do curso sem autorização expressa.</li>
+          <li>Não utilizar a plataforma para fins ilegais ou prejudiciais.</li>
+          <li>Não tentar obter acesso não autorizado ao sistema.</li>
+          <li>Informar imediatamente sobre qualquer uso não autorizado da sua conta.</li>
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-bold">6. Propriedade Intelectual</h2>
+        <p className="text-white/80">
+          Todo o conteúdo presente no portal e no curso, incluindo textos, gráficos, logos, imagens, vídeos e software, é propriedade de Cliente Mistério ou dos seus fornecedores de conteúdo e está protegido pelas leis de propriedade intelectual. O utilizador é autorizado a aceder ao conteúdo apenas para uso pessoal e não comercial, no âmbito da sua aprendizagem individual.
         </p>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-bold">5. Limitação de Responsabilidade</h2>
+        <h2 className="text-2xl font-bold">7. Limitação de Responsabilidade</h2>
         <p className="text-white/80">
-          Cliente Mistério não será responsável por danos diretos, indiretos, incidentais, especiais ou consequentes resultantes do acesso ou uso do portal, incluindo, mas não limitado a, perda de dados, lucros cessantes ou interrupção do serviço.
+          Cliente Mistério não será responsável por danos diretos, indiretos, incidentais, especiais ou consequentes resultantes do acesso ou uso do portal ou do curso, incluindo, mas não limitado a, perda de dados, lucros cessantes ou interrupção do serviço. O portal não garante resultados profissionais ou de emprego decorrentes da frequência do curso.
         </p>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-bold">6. Privacidade e Dados Pessoais</h2>
+        <h2 className="text-2xl font-bold">8. Privacidade e Dados Pessoais</h2>
         <p className="text-white/80">
-          O tratamento de dados pessoais no portal segue a legislação em vigor. Para informações detalhadas sobre como os seus dados são processados, consulte a nossa política de privacidade.
+          O tratamento de dados pessoais no portal segue a legislação em vigor, nomeadamente o Regulamento Geral sobre a Proteção de Dados (RGPD). Os dados recolhidos são utilizados exclusivamente para a gestão da conta, acesso ao curso e emissão do certificado. Para informações detalhadas sobre como os seus dados são processados, consulte a nossa política de privacidade.
         </p>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-bold">7. Modificações dos Termos</h2>
+        <h2 className="text-2xl font-bold">9. Modificações dos Termos</h2>
         <p className="text-white/80">
-          Cliente Mistério reserva-se o direito de modificar estes termos e condições a qualquer momento. As alterações serão publicadas nesta página e entrarão em vigor imediatamente após a publicação.
+          Cliente Mistério reserva-se o direito de modificar estes termos e condições a qualquer momento. As alterações serão publicadas nesta página e entrarão em vigor imediatamente após a publicação. Recomenda-se a consulta periódica desta página.
         </p>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-bold">8. Lei Aplicável</h2>
+        <h2 className="text-2xl font-bold">10. Lei Aplicável</h2>
         <p className="text-white/80">
-          Estes termos e condições são regidos pelas leis de Portugal. Qualquer disputa decorrente do uso do portal será resolvida nos tribunais competentes de Portugal.
+          Estes termos e condições são regidos pelas leis de Portugal. Qualquer disputa decorrente do uso do portal ou da aquisição do curso será resolvida nos tribunais competentes de Portugal.
         </p>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-bold">9. Contacto</h2>
+        <h2 className="text-2xl font-bold">11. Contacto</h2>
         <p className="text-white/80">
-          Se tiver dúvidas sobre estes termos e condições, por favor contacte-nos através da página de contacto do portal.
+          Se tiver dúvidas sobre estes termos e condições ou sobre o curso, por favor contacte-nos através da página de contacto do portal.
         </p>
       </section>
     </div>


### PR DESCRIPTION
## Summary
Updated the Terms and Conditions page to reflect the platform's shift from a citizen participation portal to an online course provider. The changes clarify the nature of the service, payment terms, certificate validity, and user responsibilities specific to course delivery.

## Key Changes

- **Service Description**: Changed from "citizen participation and public information portal" to "online training course for mystery shopper activity"
- **New Section - Certificate of Completion**: Added comprehensive section clarifying that certificates have no legal validity and are not recognized by regulatory bodies or employers
- **New Section - Purchase and Payment**: Added details about payment processing via Stripe, refund policy, and VAT handling
- **Updated User Responsibilities**: Refined to focus on course-specific obligations (no sharing access, no unauthorized reproduction/distribution)
- **Enhanced Intellectual Property**: Expanded to include video content and clarified usage is limited to personal learning
- **Improved Liability Clause**: Added explicit statement that the platform doesn't guarantee employment or professional results
- **Data Privacy**: Added specific reference to GDPR compliance and clarified data usage purposes
- **Section Numbering**: Renumbered all sections from 9 to 11 total sections to accommodate new content
- **Minor Wording Updates**: Enhanced clarity throughout regarding course-specific language and legal compliance

## Notable Details

- Certificate disclaimer is prominently featured with bullet points to ensure user understanding
- Payment section explicitly mentions Stripe and immediate access activation
- All changes maintain Portuguese language and formal tone appropriate for legal documentation

https://claude.ai/code/session_01GsVeQZsimE1JHbdtoUNij6