### PR TITLE
Redesign ThreePointsCards with solid background and updated styling

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -24,11 +24,10 @@ export default function ThreePointsCards() {
       {benefits.map((benefit) => (
         <div
           key={benefit.title}
-          className="flex flex-col items-center gap-2 rounded-2xl border border-black/10 bg-white/60 p-4 sm:p-5 text-center backdrop-blur-sm transition duration-300 hover:-translate-y-1 hover:border-[#F66856] hover:shadow-md"
+          className="flex flex-col items-center gap-2 rounded-2xl p-4 sm:p-5 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-[#F66856]"
         >
-          <span className="text-2xl" aria-hidden="true">{benefit.icon}</span>
-          <h3 className="text-base font-bold text-black">{benefit.title}</h3>
-          <p className="text-xs sm:text-sm leading-5 text-black/70">{benefit.description}</p>
+          <h3 className="text-base font-bold text-white">{benefit.title}</h3>
+          <p className="text-xs sm:text-sm leading-5 text-white">{benefit.description}</p>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
Updated the ThreePointsCards component with a new visual design featuring a solid background color and simplified styling approach.

## Key Changes
- Changed card background from semi-transparent white (`bg-white/60 backdrop-blur-sm`) to solid coral/salmon color (`bg-[#F66856]`)
- Removed border styling (`border border-black/10`) and hover border color change (`hover:border-[#F66856]`)
- Removed the icon element and its associated styling
- Updated text colors from black to white for better contrast against the new background:
  - Card title: `text-black` → `text-white`
  - Card description: `text-black/70` → `text-white`
- Simplified hover state by removing the border color change (now only applies shadow effect)

## Implementation Details
The redesign shifts from a subtle, glassmorphic card style to a bold, solid-colored approach with improved visual hierarchy through the use of the brand color (#F66856) as the primary background.

https://claude.ai/code/session_01SJp7yPDeNwTN2fqyi8jP7o