### PR TITLE
Add logout functionality to header actions

### DIFF
--- a/app/components/HeaderActions.tsx
+++ b/app/components/HeaderActions.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 type SessionUser = {
@@ -19,7 +19,16 @@ const sessionStorageKey = "vp_session";
 
 export default function HeaderActions() {
   const pathname = usePathname();
+  const router = useRouter();
   const [sessionUser, setSessionUser] = useState<SessionUser | null>(null);
+
+  async function handleLogout() {
+    await fetch("/api/auth/logout", { method: "POST" });
+    localStorage.removeItem(userStorageKey);
+    localStorage.removeItem(sessionStorageKey);
+    setSessionUser(null);
+    router.push("/");
+  }
 
   useEffect(() => {
     // Lê a sessão guardada no browser para alternar ação entre login e dashboard.
@@ -55,12 +64,20 @@ export default function HeaderActions() {
           Login
         </Link>
       ) : (
-        <Link
-          className="site-pill-button px-6 sm:px-8 py-2 sm:py-3 text-[10px] uppercase tracking-[0.12em] sm:text-[12px] sm:tracking-[0.15em]"
-          href="/dashboard"
-        >
-          Dashboard
-        </Link>
+        <>
+          <Link
+            className="site-pill-button px-6 sm:px-8 py-2 sm:py-3 text-[10px] uppercase tracking-[0.12em] sm:text-[12px] sm:tracking-[0.15em]"
+            href="/dashboard"
+          >
+            Dashboard
+          </Link>
+          <button
+            onClick={handleLogout}
+            className="site-pill-button-secondary px-6 sm:px-8 py-2 sm:py-3 text-[10px] uppercase tracking-[0.12em] sm:text-[12px] sm:tracking-[0.15em]"
+          >
+            Terminar Sessão
+          </button>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Added a logout feature to the HeaderActions component, allowing authenticated users to end their session and return to the home page.

## Key Changes
- Imported `useRouter` hook from `next/navigation` for client-side navigation
- Created `handleLogout()` async function that:
  - Calls the `/api/auth/logout` POST endpoint
  - Clears user and session data from localStorage
  - Resets the session state
  - Redirects user to home page
- Updated the authenticated user header to display both "Dashboard" and "Terminar Sessão" (Logout) buttons
- Applied secondary button styling to the logout button for visual distinction

## Implementation Details
The logout button is only displayed when a user is authenticated (in the else branch of the conditional rendering). The logout process clears both the user storage key and session storage key before redirecting, ensuring a complete session cleanup.

https://claude.ai/code/session_01Nb7J8V1TYy7B54DjVRGysU