### PR TITLE
Improve ThreePointsCards styling and link contrast

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -24,10 +24,10 @@ export default function ThreePointsCards() {
       {benefits.map((benefit) => (
         <div
           key={benefit.title}
-          className="flex flex-col items-center gap-2 rounded-2xl p-4 sm:p-5 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-[#F66856]"
+          className="flex flex-col items-center gap-3 rounded-2xl p-6 sm:p-8 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-[#F66856] min-h-[200px] sm:min-h-[220px] justify-center"
         >
           <h3 className="text-xl font-bold text-white">{benefit.title}</h3>
-          <p className="text-xs sm:text-sm leading-5 text-white">{benefit.description}</p>
+          <p className="text-xs sm:text-sm leading-5 text-white text-justify">{benefit.description}</p>
         </div>
       ))}
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1005,14 +1005,14 @@ select {
 }
 
 /* Melhor contraste em links dentro do conteúdo */
-main a:not(.site-pill-button):not(.button-size-login):not(.form-link) {
+main a:not(.site-pill-button):not(.button-size-login):not(.form-link):not(.site-pill-button-secondary) {
   color: #000000;
   text-decoration: none;
   border-bottom: 1px solid rgba(246, 104, 86, 0.3);
   transition: all 0.3s ease;
 }
 
-main a:not(.site-pill-button):not(.button-size-login):not(.form-link):hover {
+main a:not(.site-pill-button):not(.button-size-login):not(.form-link):not(.site-pill-button-secondary):hover {
   border-bottom-color: rgba(246, 104, 86, 0.8);
   color: #000000;
 }


### PR DESCRIPTION
## Summary
Enhanced the visual presentation of the ThreePointsCards component with improved spacing and alignment, while also refining link styling to ensure better contrast and consistency across the site.

## Key Changes
- **ThreePointsCards component styling improvements:**
  - Increased gap between elements from `gap-2` to `gap-3`
  - Increased padding from `p-4 sm:p-5` to `p-6 sm:p-8` for better spacing
  - Added minimum height constraints (`min-h-[200px] sm:min-h-[220px]`) to ensure consistent card heights
  - Added `justify-center` to vertically center content within cards
  - Applied `text-justify` to benefit descriptions for improved text alignment

- **Global link styling refinement:**
  - Updated CSS selectors to exclude `.site-pill-button-secondary` class from the main link styling rules
  - Applied the exclusion to both the base link styles and hover states to prevent unintended styling conflicts

## Implementation Details
The changes maintain the existing hover effects and color scheme while providing a more spacious and visually balanced layout for the benefit cards. The link styling updates ensure that secondary pill buttons are not affected by the general link styling rules, allowing for more granular control over button appearance throughout the site.

https://claude.ai/code/session_01PQVwda4oLUxYTiVuvV9EsZ