### PR TITLE
Simplify About page layout and remove max-width constraints

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -15,7 +15,7 @@ export default function AboutPage() {
   return (
     <section className="space-y-8 sm:space-y-12 pb-4">
       {/* Mantém a estrutura de duas colunas sem cartão branco para seguir o estilo da landing page. */}
-      <article className="grid w-full gap-6 sm:gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+      <article className="w-full">
         {/* Preserva o conteúdo da página e ajusta a hierarquia para texto branco com destaques amarelos. */}
         <div className="space-y-4 sm:space-y-6">
           <p className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: "#F66856" }}>
@@ -26,18 +26,18 @@ export default function AboutPage() {
             Atua com método e consistência
           </h1>
 
-          <p className="max-w-2xl text-sm sm:text-base leading-6 sm:leading-7">
+          <p className="text-sm sm:text-base leading-6 sm:leading-7">
             Um Cliente Mistério é um cliente "normal" contratado para avaliar serviços
             (atendimento, rapidez, qualidade e cumprimento de regras) e, ao mesmo tempo, gerar
             rendimento extra por cada avaliação realizada.
           </p>
 
-          <p className="max-w-2xl text-sm sm:text-base leading-6 sm:leading-7">
+          <p className="text-sm sm:text-base leading-6 sm:leading-7">
             Quanto melhor e mais consistente fores, mais convites costumas receber para novas
             visitas e análises.
           </p>
 
-          <p className="max-w-2xl text-sm sm:text-base leading-6 sm:leading-7">
+          <p className="text-sm sm:text-base leading-6 sm:leading-7">
             Neste curso, vais aprender do básico ao avançado como fazer visitas sem falhas,
             entregar relatórios profissionais e aumentar a tua taxa de aprovação para
             transformares isto num extra mensal realista.


### PR DESCRIPTION
## Summary
Refactored the About page layout to use a simpler, single-column structure and removed unnecessary max-width constraints from paragraph elements.

## Key Changes
- Changed the article grid layout from a two-column responsive layout (`lg:grid-cols-[1.1fr_0.9fr]`) to a full-width single column (`w-full`)
- Removed `max-w-2xl` class from all three paragraph elements to allow them to span the full width of their container
- Simplified the overall layout structure while maintaining responsive text sizing

## Implementation Details
The changes streamline the About page to follow a more linear, single-column design pattern. The removal of the grid layout and max-width constraints suggests a shift toward a simpler, more straightforward content presentation that better aligns with the page's visual hierarchy and user experience goals.

https://claude.ai/code/session_01GgL8FSCpxagoiaNWcgPUAJ