### PR TITLE
Update ThreePointsCards benefit descriptions and messaging

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -4,17 +4,17 @@ const benefits = [
   {
     icon: "📋",
     title: "Aprende",
-    description: "10 módulos práticos do básico ao avançado — conceitos, ética, metodologia e relatórios profissionais.",
+    description: "Curso 100% online, ao teu ritmo e sem horários definidos. Aprende quando quiseres, com total flexibilidade.",
   },
   {
     icon: "🎯",
     title: "Pratica",
-    description: "Checklists reais, cenários do terreno e técnicas para passares despercebido em qualquer avaliação.",
+    description: "10 módulos práticos do básico ao avançado — conceitos, ética, metodologia e relatórios profissionais.",
   },
   {
     icon: "💶",
     title: "Ganha",
-    description: "5€ a 150€+ por missão. Flexibilidade total, sem patrão. Começa a ganhar já no primeiro mês.",
+    description: "15€ a 150€ por missão. Avalia hotéis, restaurantes, lojas e outros negócios. Todos os custos são totalmente suportados pelas marcas.",
   },
 ];
 


### PR DESCRIPTION
## Summary
Updated the benefit card descriptions in the ThreePointsCards component to better reflect the course offering and earning potential. The changes reorganize the messaging across the three cards and adjust the financial expectations for users.

## Key Changes
- **"Aprende" card**: Changed from listing course content (10 modules, concepts, ethics, methodology) to emphasizing flexibility and self-paced learning (100% online, learn at your own pace, no fixed schedules)
- **"Pratica" card**: Replaced practical techniques messaging with the detailed course content description (10 modules from basic to advanced covering concepts, ethics, methodology, and professional reports)
- **"Ganha" card**: Updated earning potential from "5€ to 150€+" to "15€ to 150€" and expanded the description to clarify the types of evaluations (hotels, restaurants, shops, etc.) and that all costs are covered by brands

## Notable Details
The reorganization creates a clearer narrative flow: first highlighting the learning flexibility, then the structured course content, and finally the earning opportunities with more transparent information about mission types and cost coverage.

https://claude.ai/code/session_018aqYUoCSHE8sXiu1xuBvCM