### PR TITLE
Update ThreePointsCards with gradient background and improved text contrast

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -24,10 +24,10 @@ export default function ThreePointsCards() {
       {benefits.map((benefit) => (
         <div
           key={benefit.title}
-          className="flex flex-col items-center gap-3 rounded-2xl p-6 sm:p-8 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-[#F66856] min-h-[200px] sm:min-h-[220px] justify-center"
+          className="flex flex-col items-center gap-3 rounded-2xl p-6 sm:p-8 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-gradient-to-b from-[#F66856] to-white min-h-[200px] sm:min-h-[220px] justify-center"
         >
-          <h3 className="text-xl font-bold text-white">{benefit.title}</h3>
-          <p className="text-xs sm:text-sm leading-5 text-white text-justify">{benefit.description}</p>
+          <h3 className="text-xl font-bold text-gray-800">{benefit.title}</h3>
+          <p className="text-xs sm:text-sm leading-5 text-gray-700 text-justify">{benefit.description}</p>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
Updated the ThreePointsCards component styling to use a gradient background and improve text readability with better color contrast.

## Key Changes
- Changed card background from solid `bg-[#F66856]` to a gradient `bg-gradient-to-b from-[#F66856] to-white` for a more modern appearance
- Updated title text color from white to `text-gray-800` for better contrast against the gradient background
- Updated description text color from white to `text-gray-700` for improved readability

## Implementation Details
The gradient flows from the original coral/salmon color at the top to white at the bottom, creating a softer visual transition. The text color adjustments ensure proper contrast and legibility across the gradient, particularly in the lower portions of the card where the background becomes lighter.

https://claude.ai/code/session_0172UDLq6KgTFMZsbF125eB3