### PR TITLE
Update ThreePointsCards background from gradient to solid white

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -24,7 +24,7 @@ export default function ThreePointsCards() {
       {benefits.map((benefit) => (
         <div
           key={benefit.title}
-          className="flex flex-col items-center gap-3 rounded-2xl p-6 sm:p-8 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-gradient-to-b from-[#F66856] to-white min-h-[200px] sm:min-h-[220px] justify-center"
+          className="flex flex-col items-center gap-3 rounded-2xl p-6 sm:p-8 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-white min-h-[200px] sm:min-h-[220px] justify-center"
         >
           <h3 className="text-xl font-bold text-gray-800">{benefit.title}</h3>
           <p className="text-xs sm:text-sm leading-5 text-gray-700 text-justify">{benefit.description}</p>


### PR DESCRIPTION
## Summary
Updated the background styling of the benefit cards in the ThreePointsCards component from a gradient to a solid white color.

## Changes
- Changed the card background from `bg-gradient-to-b from-[#F66856] to-white` (orange-to-white gradient) to `bg-white` (solid white)
- This simplifies the visual design while maintaining all other card styling including hover effects, padding, and layout

## Details
The modification removes the gradient background that transitioned from an orange/coral color (#F66856) to white, replacing it with a consistent solid white background. All other styling properties remain unchanged, including the rounded corners, padding, hover animations, and minimum height specifications.

https://claude.ai/code/session_01NChQRXP92MPUZecENiQi7W