### PR TITLE
Update ThreePointsCards styling with coral background and white text

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -24,10 +24,11 @@ export default function ThreePointsCards() {
       {benefits.map((benefit) => (
         <div
           key={benefit.title}
-          className="flex flex-col items-center gap-3 rounded-2xl p-6 sm:p-8 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md bg-white min-h-[200px] sm:min-h-[220px] justify-center"
+          className="flex flex-col items-center gap-3 rounded-2xl p-6 sm:p-8 text-center transition duration-300 hover:-translate-y-1 hover:shadow-md min-h-[200px] sm:min-h-[220px] justify-center"
+          style={{ backgroundColor: "#F66856" }}
         >
-          <h3 className="text-xl font-bold text-gray-800">{benefit.title}</h3>
-          <p className="text-xs sm:text-sm leading-5 text-gray-700 text-justify">{benefit.description}</p>
+          <h3 className="text-xl font-bold text-white">{benefit.title}</h3>
+          <p className="text-xs sm:text-sm leading-5 text-white text-justify">{benefit.description}</p>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
Updated the ThreePointsCards component styling to use a coral background color (#F66856) with white text for improved visual contrast and design consistency.

## Key Changes
- Removed `bg-white` class from card container and replaced with inline style `backgroundColor: "#F66856"`
- Changed card title text color from `text-gray-800` to `text-white`
- Changed card description text color from `text-gray-700` to `text-white`

## Implementation Details
The styling changes maintain all existing responsive behavior (padding, min-height breakpoints) and hover effects while updating the color scheme to use a coral background with white text for better visual hierarchy and readability.

https://claude.ai/code/session_01HRnU6XR85ivaBxm4pwnMkw