### PR TITLE
docs: add course writing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,11 @@ Configura as variáveis de ambiente no painel do Render antes do primeiro deploy
 ## Licença
 
 Todos os direitos reservados © Cliente Mistério. O conteúdo do curso e a plataforma não podem ser reproduzidos ou distribuídos sem autorização expressa.
+
+## Diretrizes de Escrita do Curso
+
+1. Sempre que o conteúdo do curso for apresentado em formato de pontos, cada ideia deve aparecer num parágrafo separado e numerado, em vez de texto corrido.
+
+2. Termos essenciais podem ser destacados com **negrito** para melhorar a leitura e a hierarquia visual do conteúdo.
+
+3. Evitar o uso de emojis, ícones e travessões como marcador de lista para manter uma apresentação mais natural e editorial.


### PR DESCRIPTION
### Motivation

- Formalizar orientações editoriais para o conteúdo do curso, impondo parágrafos numerados para pontos, permitindo **negrito** para destaque e evitando emojis, ícones e travessões.

### Description

- Adicionei a secção `Diretrizes de Escrita do Curso` no `README.md` com três regras numeradas que documentam o estilo desejado.

### Testing

- Alteração apenas de documentação; executei `git status --short`, `git log -1 --oneline` e confirmei o commit `docs: add course writing guidelines` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c7c765e4832e81a2d1d9c8955c86)