### PR TITLE
Ajustar largura da secção 'Formação completa' e compactar caixa de preço

### DIFF
--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -102,24 +102,24 @@ export default function CoursePage() {
 
   return (
     <section className="w-full space-y-8">
-      <header className="space-y-3">
+      <header className="w-full rounded-2xl border border-white/20 bg-white/5 p-6 backdrop-blur-sm space-y-3">
         <p className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: "#F66856" }}>
           Formação completa
         </p>
 
         <h1 className="text-3xl font-semibold home-title-highlight-text sm:text-4xl lg:text-5xl">O Curso de Cliente Mistério</h1>
 
-        <p className="max-w-3xl text-sm sm:text-base leading-6 sm:leading-7">
+        <p className="max-w-4xl text-sm sm:text-base leading-6 sm:leading-7">
           Um curso completo, 100% prático e desenhado para INICIANTES. Aprende tudo que precisas para começar a ganhar dinheiro como Cliente Mistério — desde os conceitos básicos até estratégias de carreira avançadas.
         </p>
       </header>
 
       {/* Preço e CTA */}
-      <div className="flex flex-col items-center gap-3 rounded-2xl bg-white px-6 py-4 sm:px-10 sm:py-6 text-center">
-        <div className="w-full space-y-1 text-center">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500 text-center">Acesso Completo ao Curso</p>
+      <div className="mx-auto inline-flex w-auto flex-col items-center gap-3 rounded-2xl bg-white px-6 py-4 sm:px-10 sm:py-6 text-center">
+        <div className="space-y-1 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-black text-center">Acesso Completo ao Curso</p>
           <p className="text-5xl font-bold text-center" style={{ color: "#F66856" }}>19,99€</p>
-          <p className="text-sm text-gray-400 text-center">Pagamento único · Acesso vitalício</p>
+          <p className="text-sm text-black text-center">Pagamento único · Acesso vitalício</p>
         </div>
         <CheckoutButton label="Comprar Curso Completo" />
       </div>


### PR DESCRIPTION
### Motivation
- Garantir que a primeira secção "Formação completa / O Curso de Cliente Mistério" usa o mesmo padrão visual e largura das restantes secções da página.
- Fazer com que a caixa branca de preço/CTA dimensione-se ao conteúdo interno em vez de esticar-se pela largura total da página.
- Aplicar a cor preta aos textos "Acesso Completo ao Curso" e "Pagamento único · Acesso vitalício" conforme especificado.

### Description
- Atualizado o cabeçalho para envolver o bloco inicial com as classes `w-full rounded-2xl border border-white/20 bg-white/5 p-6 backdrop-blur-sm` e aumentar `max-w-3xl` para `max-w-4xl` no parágrafo de descrição para manter proporção visual; arquivo modificado: `app/o-curso/page.tsx`.
- Alterada a caixa de preço de um container com largura completa para um bloco centrado que ajusta à largura do conteúdo usando `mx-auto inline-flex w-auto flex-col items-center ...` para reduzir a largura da caixa.
- Corrigidas as cores dos textos do cartão de preço para preto alterando as classes para `text-black` nos elementos correspondentes.

### Testing
- Executado `npm run lint` e a verificação falhou no ambiente com a mensagem `sh: 1: next: not found` devido à ausência do binário `next` no PATH do ambiente.
- Não foram executados outros testes automatizados neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cccc13e0832e8a63a4c831673a7a)