### PR TITLE
Restrict course visibility and progress to paid users (Stripe webhook + DB changes)

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -23,6 +23,7 @@ type UserRow = {
   gender: string | null;
   profile_completed: boolean;
   is_admin: boolean;
+  has_course_access: boolean;
   password_hash: string;
 };
 
@@ -39,7 +40,7 @@ export const POST = async (request: Request) => {
 
   const normalizedEmail = payload.email.trim().toLowerCase();
   const result = await query<UserRow>(
-    `select id, first_name, last_name, full_name, email, birth_date, gender, profile_completed, is_admin, password_hash
+    `select id, first_name, last_name, full_name, email, birth_date, gender, profile_completed, is_admin, has_course_access, password_hash
      from users
      where email = $1`,
     [normalizedEmail]

--- a/app/api/course/progress/route.ts
+++ b/app/api/course/progress/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from "next/server";
 
 import { query } from "@/lib/database";
+import { hasUserCourseAccess } from "@/lib/courseAccess";
 import { getSession } from "@/lib/session";
 
 type CourseProgressRow = {
@@ -30,6 +31,17 @@ export const GET = async () => {
     return NextResponse.json(
       { message: "É necessário iniciar sessão." },
       { status: 401 }
+    );
+  }
+
+
+
+  const hasCourseAccess = await hasUserCourseAccess(session.userId);
+
+  if (!hasCourseAccess) {
+    return NextResponse.json(
+      { message: "É necessário concluir o pagamento para aceder ao curso." },
+      { status: 403 }
     );
   }
 
@@ -63,6 +75,15 @@ export const PUT = async (request: Request) => {
     return NextResponse.json(
       { message: "É necessário iniciar sessão." },
       { status: 401 }
+    );
+  }
+
+  const hasCourseAccess = await hasUserCourseAccess(session.userId);
+
+  if (!hasCourseAccess) {
+    return NextResponse.json(
+      { message: "É necessário concluir o pagamento para aceder ao curso." },
+      { status: 403 }
     );
   }
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,144 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Webhook do Stripe para libertar acesso ao curso após pagamento confirmado.
+ */
+
+import Stripe from "stripe";
+import { NextResponse } from "next/server";
+
+import { query } from "@/lib/database";
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+const stripeClient = stripeSecretKey
+  ? new Stripe(stripeSecretKey, {
+      apiVersion: "2024-06-20",
+    })
+  : null;
+
+const getPaymentIntentId = (paymentIntent: string | Stripe.PaymentIntent | null): string | null => {
+  // Extrai o ID do Payment Intent independentemente do formato devolvido pelo evento.
+  if (!paymentIntent) {
+    return null;
+  }
+
+  if (typeof paymentIntent === "string") {
+    return paymentIntent;
+  }
+
+  return paymentIntent.id;
+};
+
+const grantCourseAccessByEmail = async (payload: {
+  eventId: string;
+  checkoutSessionId: string;
+  paymentIntentId: string | null;
+  customerEmail: string;
+  amountTotal: number;
+  currency: string;
+}) => {
+  // Atualiza o utilizador e regista a compra de forma idempotente para evitar duplicações.
+  const userResult = await query<{ id: string }>(
+    "select id from users where lower(email) = $1 limit 1",
+    [payload.customerEmail.toLowerCase()]
+  );
+
+  const userId = userResult.rows[0]?.id;
+
+  if (!userId) {
+    throw new Error("USER_NOT_FOUND_FOR_PAID_EMAIL");
+  }
+
+  await query(
+    `insert into course_purchases (
+      user_id,
+      stripe_event_id,
+      stripe_checkout_session_id,
+      stripe_payment_intent_id,
+      stripe_customer_email,
+      amount_total,
+      currency
+    )
+    values ($1, $2, $3, $4, $5, $6, $7)
+    on conflict (stripe_event_id)
+    do nothing`,
+    [
+      userId,
+      payload.eventId,
+      payload.checkoutSessionId,
+      payload.paymentIntentId,
+      payload.customerEmail,
+      payload.amountTotal,
+      payload.currency,
+    ]
+  );
+
+  await query(
+    `update users
+     set has_course_access = true,
+         course_access_granted_at = coalesce(course_access_granted_at, now())
+     where id = $1`,
+    [userId]
+  );
+};
+
+export const POST = async (request: Request) => {
+  if (!stripeClient || !stripeWebhookSecret) {
+    return NextResponse.json(
+      { message: "Configuração do Stripe incompleta para processar webhook." },
+      { status: 500 }
+    );
+  }
+
+  const signature = request.headers.get("stripe-signature");
+
+  if (!signature) {
+    return NextResponse.json({ message: "Assinatura Stripe ausente." }, { status: 400 });
+  }
+
+  const rawBody = await request.text();
+
+  let event: Stripe.Event;
+
+  try {
+    // Valida assinatura do webhook para garantir origem legítima do Stripe.
+    event = stripeClient.webhooks.constructEvent(rawBody, signature, stripeWebhookSecret);
+  } catch {
+    return NextResponse.json({ message: "Webhook Stripe inválido." }, { status: 400 });
+  }
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+
+    if (session.payment_status === "paid") {
+      const customerEmail = session.customer_details?.email?.trim().toLowerCase();
+      const amountTotal = session.amount_total;
+      const currency = session.currency;
+
+      if (!customerEmail || amountTotal === null || !currency) {
+        return NextResponse.json(
+          { message: "Dados do pagamento incompletos para ativar acesso." },
+          { status: 400 }
+        );
+      }
+
+      try {
+        await grantCourseAccessByEmail({
+          eventId: event.id,
+          checkoutSessionId: session.id,
+          paymentIntentId: getPaymentIntentId(session.payment_intent),
+          customerEmail,
+          amountTotal,
+          currency,
+        });
+      } catch {
+        return NextResponse.json(
+          { message: "Não foi possível associar pagamento a uma conta existente." },
+          { status: 404 }
+        );
+      }
+    }
+  }
+
+  return NextResponse.json({ received: true });
+};

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -17,6 +17,7 @@ type UserRow = {
   gender: string | null;
   profile_completed: boolean;
   is_admin: boolean;
+  has_course_access: boolean;
 };
 
 type UpdatePayload = {
@@ -41,7 +42,7 @@ export const GET = async () => {
   }
 
   const result = await query<UserRow>(
-    "select id, first_name, last_name, full_name, email, birth_date, gender, profile_completed, is_admin from users where id = $1",
+    "select id, first_name, last_name, full_name, email, birth_date, gender, profile_completed, is_admin, has_course_access from users where id = $1",
     [session.userId]
   );
 
@@ -60,6 +61,7 @@ export const GET = async () => {
       gender: result.rows[0].gender,
       profileCompleted: result.rows[0].profile_completed,
       isAdmin: result.rows[0].is_admin,
+      hasCourseAccess: result.rows[0].has_course_access,
     },
   });
 };

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -290,10 +290,18 @@ export default function CursoPage() {
   const [quizSubmitted, setQuizSubmitted] = useState(false);
   const [quizScore, setQuizScore] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [accessDenied, setAccessDenied] = useState(false);
 
   const loadProgress = useCallback(async () => {
+    setAccessDenied(false);
+
     try {
       const response = await fetch("/api/course/progress", { credentials: "include" });
+      if (response.status === 403) {
+        setAccessDenied(true);
+        return;
+      }
+
       if (response.ok) {
         const data = (await response.json()) as ProgressData;
         setProgress(data);
@@ -406,6 +414,29 @@ export default function CursoPage() {
 
   if (!isAuthenticated) {
     return <p className="text-sm text-slate-500">A verificar sessão...</p>;
+  }
+
+  if (accessDenied) {
+    return (
+      <section className="w-full space-y-6 bg-white p-8 rounded-2xl">
+        <h1 className="text-3xl font-semibold home-title-highlight-text lg:text-4xl">Curso de Cliente Mistério</h1>
+        <p className="text-base text-[#2a2a2a]">
+          O acesso ao curso só fica disponível após confirmação do pagamento.
+        </p>
+        <div className="flex gap-3">
+          <button className="submit max-w-[220px]" type="button" onClick={() => router.push("/checkout")}>
+            Ir para pagamento
+          </button>
+          <button
+            className="site-pill-button-secondary max-w-[220px]"
+            type="button"
+            onClick={() => router.push("/dashboard")}
+          >
+            Voltar ao dashboard
+          </button>
+        </div>
+      </section>
+    );
   }
 
   const activeModule = activeModuleId ? courseModules.find((m) => m.id === activeModuleId) : null;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ type UserProfile = {
   gender: string;
   profileCompleted: boolean;
   isAdmin: boolean;
+  hasCourseAccess: boolean;
 };
 
 type CourseProgressData = {
@@ -50,6 +51,7 @@ type ProfileResponse = {
     gender: string | null;
     profileCompleted: boolean;
     isAdmin: boolean;
+    hasCourseAccess: boolean;
   };
   message?: string;
 };
@@ -158,6 +160,7 @@ export default function DashboardPage() {
           gender: data.user.gender ?? "",
           profileCompleted: data.user.profileCompleted,
           isAdmin: data.user.isAdmin,
+          hasCourseAccess: data.user.hasCourseAccess,
         };
 
         setProfile(normalizedProfile);
@@ -412,42 +415,60 @@ export default function DashboardPage() {
           <p className="mt-2 text-sm !text-black">Faça a gestão da sua conta e segurança.</p>
         </header>
 
-        {/* Secção do curso com barra de progresso */}
-        <div
-          className="dashboard-top-banner cursor-pointer transition-all hover:shadow-lg"
-          onClick={() => router.push("/curso")}
-          role="link"
-          tabIndex={0}
-          onKeyDown={(e) => { if (e.key === "Enter") router.push("/curso"); }}
-        >
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h2 className="text-lg font-bold !text-black">Curso de Cliente Mistério</h2>
-              <p className="text-xs !text-slate-500 mt-0.5">
-                {courseProgress
-                  ? courseProgress.completedCount === courseProgress.totalModules
-                    ? "Curso concluído — Parabéns!"
-                    : `${courseProgress.completedCount} de ${courseProgress.totalModules} módulos concluídos`
-                  : "Inicie a sua formação profissional"}
-              </p>
+        {/* Secção do curso com barra de progresso apenas para contas com pagamento confirmado. */}
+        {profile.hasCourseAccess ? (
+          <div
+            className="dashboard-top-banner cursor-pointer transition-all hover:shadow-lg"
+            onClick={() => router.push("/curso")}
+            role="link"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                router.push("/curso");
+              }
+            }}
+          >
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h2 className="text-lg font-bold !text-black">Curso de Cliente Mistério</h2>
+                <p className="text-xs !text-slate-500 mt-0.5">
+                  {courseProgress
+                    ? courseProgress.completedCount === courseProgress.totalModules
+                      ? "Curso concluído — Parabéns!"
+                      : `${courseProgress.completedCount} de ${courseProgress.totalModules} módulos concluídos`
+                    : "Inicie a sua formação profissional"}
+                </p>
+              </div>
+              <span className="text-2xl font-bold" style={{ color: "#F66856" }}>
+                {courseProgress?.progressPercent ?? 0}%
+              </span>
             </div>
-            <span className="text-2xl font-bold" style={{ color: "#F66856" }}>
-              {courseProgress?.progressPercent ?? 0}%
-            </span>
+            <div className="h-3 w-full rounded-full bg-slate-200 overflow-hidden">
+              <div
+                className="h-full rounded-full transition-all duration-700"
+                style={{
+                  width: `${courseProgress?.progressPercent ?? 0}%`,
+                  background: "linear-gradient(90deg, #F66856, #F66856)",
+                }}
+              />
+            </div>
+            <p className="mt-2 text-xs !text-slate-400 text-right">Clique para continuar o curso &rarr;</p>
           </div>
-          <div className="h-3 w-full rounded-full bg-slate-200 overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all duration-700"
-              style={{
-                width: `${courseProgress?.progressPercent ?? 0}%`,
-                background: "linear-gradient(90deg, #F66856, #F66856)",
-              }}
-            />
+        ) : (
+          <div className="dashboard-top-banner">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-bold !text-black">Curso de Cliente Mistério</h2>
+                <p className="text-xs !text-slate-500 mt-0.5">
+                  O curso será disponibilizado automaticamente após confirmação do pagamento.
+                </p>
+              </div>
+              <button className="submit max-w-[180px]" type="button" onClick={() => router.push("/checkout")}>
+                Efetuar pagamento
+              </button>
+            </div>
           </div>
-          <p className="mt-2 text-xs !text-slate-400 text-right">
-            Clique para continuar o curso &rarr;
-          </p>
-        </div>
+        )}
 
         <div className="dashboard-layout-shell">
           <aside className="dashboard-sidebar">

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -19,6 +19,8 @@ create table if not exists users (
   password_reset_token_hash text,
   password_reset_expires_at timestamptz,
   is_admin boolean not null default false,
+  has_course_access boolean not null default false,
+  course_access_granted_at timestamptz,
   password_hash text not null,
   created_at timestamptz not null default now()
 );
@@ -35,3 +37,20 @@ create table if not exists course_progress (
   created_at timestamptz not null default now(),
   unique(user_id, module_id)
 );
+
+
+-- Tabela de compras para auditar pagamentos e associar o curso ao utilizador.
+create table if not exists course_purchases (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  stripe_event_id text unique not null,
+  stripe_checkout_session_id text unique not null,
+  stripe_payment_intent_id text,
+  stripe_customer_email text not null,
+  amount_total integer not null,
+  currency text not null,
+  paid_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists course_purchases_user_paid_at_idx on course_purchases(user_id, paid_at desc);

--- a/lib/courseAccess.ts
+++ b/lib/courseAccess.ts
@@ -1,0 +1,19 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Utilitários para validar e consultar o estado de acesso ao curso pago.
+ */
+
+import { query } from "@/lib/database";
+
+type CourseAccessRow = {
+  has_course_access: boolean;
+};
+
+export const hasUserCourseAccess = async (userId: string): Promise<boolean> => {
+  // Consulta o estado de acesso ao curso para o utilizador autenticado.
+  const result = await query<CourseAccessRow>(
+    "select has_course_access from users where id = $1",
+    [userId]
+  );
+
+  return result.rows[0]?.has_course_access === true;
+};

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -45,6 +45,8 @@ const initializeDatabase = async (): Promise<void> => {
           password_reset_token_hash text,
           password_reset_expires_at timestamptz,
           is_admin boolean not null default false,
+          has_course_access boolean not null default false,
+          course_access_granted_at timestamptz,
           password_hash text not null,
           created_at timestamptz not null default now()
         )
@@ -59,6 +61,22 @@ const initializeDatabase = async (): Promise<void> => {
           message text not null,
           email_delivery_status text not null default 'pending',
           email_delivery_error text,
+          created_at timestamptz not null default now()
+        )
+      `);
+
+
+      await pool.query(`
+        create table if not exists course_purchases (
+          id uuid primary key default gen_random_uuid(),
+          user_id uuid not null references users(id) on delete cascade,
+          stripe_event_id text unique not null,
+          stripe_checkout_session_id text unique not null,
+          stripe_payment_intent_id text,
+          stripe_customer_email text not null,
+          amount_total integer not null,
+          currency text not null,
+          paid_at timestamptz not null default now(),
           created_at timestamptz not null default now()
         )
       `);
@@ -97,6 +115,15 @@ const initializeDatabase = async (): Promise<void> => {
 
       await pool.query(
         "create index if not exists contact_messages_created_at_idx on contact_messages(created_at desc)"
+      );
+
+      await pool.query(
+        "alter table users add column if not exists has_course_access boolean not null default false"
+      );
+      await pool.query("alter table users add column if not exists course_access_granted_at timestamptz");
+
+      await pool.query(
+        "create index if not exists course_purchases_user_paid_at_idx on course_purchases(user_id, paid_at desc)"
       );
 
       // Converte contas antigas para o novo formato de nome para evitar dados incompletos.


### PR DESCRIPTION
### Motivation
- Ensure the course and its progress endpoints are only available to users who completed payment by gating access on a per-user `has_course_access` flag.
- Record payments reliably and idempotently so access can be granted after Stripe confirms a successful checkout session.

### Description
- Added database fields and audit table: `users.has_course_access`, `users.course_access_granted_at`, and a new `course_purchases` table, and updated bootstrap logic in `db/schema.sql` and `lib/database.ts` to create/alter these objects.
- Implemented a Stripe webhook endpoint at `app/api/stripe/webhook/route.ts` that validates the webhook signature, logs purchases to `course_purchases`, and sets `has_course_access` on the matching user by email.
- Added a small helper `lib/courseAccess.ts` with `hasUserCourseAccess` and used it to protect the course progress API (`app/api/course/progress/route.ts`) returning `403` when unpaid.
- Exposed `hasCourseAccess` in `/api/user` (and included the column when reading users on login) and updated frontend pages so the dashboard only shows the course card as actionable for paid users and the course page shows a locked state with CTA to `/checkout` for unpaid users.

### Testing
- Ran `npm run lint` which failed because the `next` binary is not available in this environment before installing dependencies (`next` not found). 
- Ran `npm ci` which could not complete due to a `403 Forbidden` from the npm registry in this environment, so dependency installation and further checks were blocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d1008bd0832eb82241516a720e79)