### PR TITLE
Add Swagger UI and OpenAPI spec ( /api-docs, /api/openapi )

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ npm start
 
 A base de dados é inicializada automaticamente na primeira execução (`lib/database.ts` cria as tabelas se não existirem).
 
+## Swagger (Teste no Browser)
+
+Com a aplicação em execução (`npm run dev`), abra: `http://localhost:3000/api-docs`
+
+Esta página carrega o Swagger UI e permite testar os endpoints manualmente no browser.
+
 ## Rotas da API
 
 | Método | Endpoint | Descrição |

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -1,0 +1,56 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Página pública que centraliza a documentação e teste manual da API através do Swagger UI carregado por CDN.
+ */
+
+import type { Metadata } from "next";
+import Script from "next/script";
+
+export const metadata: Metadata = {
+  title: "API Docs | Cliente Mistério",
+  description: "Documentação Swagger para testar endpoints manualmente no browser.",
+};
+
+export default function ApiDocsPage() {
+  return (
+    <main className="min-h-screen bg-[#f8f8f8] px-4 py-6 sm:px-6 md:px-8">
+      {/* Título e contexto rápido para orientar quem vai testar endpoints no browser. */}
+      <header className="mx-auto mb-4 max-w-6xl">
+        <h1 className="text-2xl font-bold text-[#171717]">Swagger API Explorer</h1>
+        <p className="mt-2 text-sm text-[#4a4a4a]">
+          Use esta página para testar todos os endpoints disponíveis da aplicação.
+        </p>
+      </header>
+
+      {/* Folha de estilos oficial do Swagger UI para renderização da interface. */}
+      <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+
+      {/* Container onde o Swagger UI será montado no cliente. */}
+      <section className="mx-auto max-w-6xl overflow-hidden rounded-xl border border-[#e7e7e7] bg-white p-2 shadow-sm">
+        <div id="swagger-ui" />
+      </section>
+
+      {/* Script oficial do Swagger UI carregado no browser. */}
+      <Script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" strategy="afterInteractive" />
+
+      {/* Inicializa o Swagger apontando para o JSON OpenAPI da própria app. */}
+      <Script id="swagger-ui-init" strategy="afterInteractive">
+        {`
+          window.onload = function () {
+            if (!window.SwaggerUIBundle) {
+              return;
+            }
+
+            window.SwaggerUIBundle({
+              url: '/api/openapi',
+              dom_id: '#swagger-ui',
+              deepLinking: true,
+              displayRequestDuration: true,
+              persistAuthorization: true,
+              presets: [window.SwaggerUIBundle.presets.apis],
+            });
+          };
+        `}
+      </Script>
+    </main>
+  );
+}

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -1,0 +1,12 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Expõe a especificação OpenAPI em JSON para ser consumida pelo Swagger UI no browser.
+ */
+
+import { NextResponse } from "next/server";
+
+import { openApiDocument } from "@/lib/openapi";
+
+export const GET = async () => {
+  // Devolve o documento OpenAPI como JSON para o cliente Swagger.
+  return NextResponse.json(openApiDocument);
+};

--- a/lib/openapi.ts
+++ b/lib/openapi.ts
@@ -1,0 +1,352 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Define a especificação OpenAPI 3.1 utilizada para gerar o Swagger UI da aplicação.
+ */
+
+export const openApiDocument = {
+  openapi: "3.1.0",
+  info: {
+    title: "Cliente Mistério API",
+    version: "1.0.0",
+    description:
+      "Documentação interativa da API para autenticação, perfil, progresso do curso, contacto e webhook Stripe.",
+  },
+  servers: [
+    {
+      url: "/",
+      description: "Servidor atual (local ou produção)",
+    },
+  ],
+  tags: [
+    { name: "Auth", description: "Registo, login, logout e recuperação de password." },
+    { name: "User", description: "Gestão de perfil e palavra-passe." },
+    { name: "Course", description: "Gestão de progresso do curso." },
+    { name: "Contact", description: "Envio de mensagens de contacto." },
+    { name: "Stripe", description: "Integração de webhook Stripe." },
+  ],
+  components: {
+    securitySchemes: {
+      sessionCookie: {
+        type: "apiKey",
+        in: "cookie",
+        name: "session",
+        description: "Cookie HTTP-only de sessão criado após login.",
+      },
+    },
+    schemas: {
+      ErrorResponse: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      RegisterRequest: {
+        type: "object",
+        properties: {
+          firstName: { type: "string", example: "João" },
+          lastName: { type: "string", example: "Silva" },
+          email: { type: "string", format: "email", example: "joao@example.com" },
+          password: { type: "string", format: "password", example: "StrongPass123" },
+          confirmPassword: { type: "string", format: "password", example: "StrongPass123" },
+        },
+        required: ["firstName", "lastName", "email", "password", "confirmPassword"],
+      },
+      LoginRequest: {
+        type: "object",
+        properties: {
+          email: { type: "string", format: "email", example: "joao@example.com" },
+          password: { type: "string", format: "password", example: "StrongPass123" },
+        },
+        required: ["email", "password"],
+      },
+      ForgotPasswordRequest: {
+        type: "object",
+        properties: {
+          email: { type: "string", format: "email", example: "joao@example.com" },
+        },
+        required: ["email"],
+      },
+      ResetPasswordRequest: {
+        type: "object",
+        properties: {
+          token: { type: "string", example: "token-from-email" },
+          newPassword: { type: "string", format: "password", example: "NewStrongPass123" },
+          confirmPassword: { type: "string", format: "password", example: "NewStrongPass123" },
+        },
+        required: ["token", "newPassword", "confirmPassword"],
+      },
+      UserProfileUpdateRequest: {
+        type: "object",
+        properties: {
+          email: { type: "string", format: "email", example: "joao@example.com" },
+          firstName: { type: "string", example: "João" },
+          lastName: { type: "string", example: "Silva" },
+          birthDate: { type: "string", format: "date", example: "1994-04-10" },
+          gender: { type: "string", enum: ["male", "female"], example: "male" },
+        },
+        required: ["email", "firstName", "lastName", "birthDate", "gender"],
+      },
+      UserPasswordUpdateRequest: {
+        type: "object",
+        properties: {
+          currentPassword: { type: "string", format: "password", example: "OldPass123" },
+          newPassword: { type: "string", format: "password", example: "NewPass123" },
+          confirmNewPassword: { type: "string", format: "password", example: "NewPass123" },
+        },
+        required: ["currentPassword", "newPassword", "confirmNewPassword"],
+      },
+      ContactRequest: {
+        type: "object",
+        properties: {
+          name: { type: "string", example: "Maria Santos" },
+          email: { type: "string", format: "email", example: "maria@example.com" },
+          subject: { type: "string", example: "Dúvida sobre o curso" },
+          message: { type: "string", example: "Gostava de saber mais detalhes sobre o módulo 3." },
+        },
+        required: ["name", "email", "subject", "message"],
+      },
+      CourseProgressUpsertRequest: {
+        type: "object",
+        properties: {
+          moduleId: { type: "integer", minimum: 1, maximum: 10, example: 1 },
+          quizScore: { type: "number", minimum: 0, maximum: 100, example: 85 },
+          quizAnswers: {
+            type: "object",
+            additionalProperties: { type: "number" },
+            example: { q1: 2, q2: 1 },
+          },
+        },
+        required: ["moduleId", "quizScore", "quizAnswers"],
+      },
+    },
+  },
+  paths: {
+    "/api/auth/register": {
+      post: {
+        tags: ["Auth"],
+        summary: "Registar novo utilizador",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/RegisterRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Conta criada com sucesso." },
+          "400": { description: "Dados inválidos.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "409": { description: "E-mail já registado.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+    },
+    "/api/auth/login": {
+      post: {
+        tags: ["Auth"],
+        summary: "Autenticar utilizador",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/LoginRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Login efetuado com sucesso." },
+          "400": { description: "Campos obrigatórios em falta.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "401": { description: "Credenciais inválidas.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+    },
+    "/api/auth/logout": {
+      post: {
+        tags: ["Auth"],
+        summary: "Terminar sessão",
+        responses: {
+          "200": { description: "Sessão terminada com sucesso." },
+        },
+      },
+    },
+    "/api/auth/confirm-email": {
+      get: {
+        tags: ["Auth"],
+        summary: "Confirmar e-mail",
+        parameters: [
+          {
+            name: "token",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+            description: "Token de confirmação recebido por e-mail.",
+          },
+        ],
+        responses: {
+          "307": { description: "Redireciona para página de login com resultado da confirmação." },
+        },
+      },
+    },
+    "/api/auth/forgot-password": {
+      post: {
+        tags: ["Auth"],
+        summary: "Pedir recuperação de password",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ForgotPasswordRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Resposta neutra por segurança." },
+          "400": { description: "Dados inválidos.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+    },
+    "/api/auth/reset-password": {
+      post: {
+        tags: ["Auth"],
+        summary: "Redefinir password",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ResetPasswordRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Password atualizada com sucesso." },
+          "400": { description: "Token inválido ou dados incorretos.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+    },
+    "/api/user": {
+      get: {
+        tags: ["User"],
+        summary: "Obter perfil do utilizador autenticado",
+        security: [{ sessionCookie: [] }],
+        responses: {
+          "200": { description: "Perfil devolvido com sucesso." },
+          "401": { description: "Sem sessão válida.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+      put: {
+        tags: ["User"],
+        summary: "Atualizar perfil do utilizador autenticado",
+        security: [{ sessionCookie: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UserProfileUpdateRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Perfil atualizado com sucesso." },
+          "400": { description: "Dados inválidos.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "401": { description: "Sem sessão válida.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "409": { description: "E-mail já em uso.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+    },
+    "/api/user/password": {
+      put: {
+        tags: ["User"],
+        summary: "Atualizar password do utilizador autenticado",
+        security: [{ sessionCookie: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UserPasswordUpdateRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Password atualizada com sucesso." },
+          "400": { description: "Dados inválidos.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "401": { description: "Sem sessão válida ou password atual incorreta.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+    },
+    "/api/contact": {
+      post: {
+        tags: ["Contact"],
+        summary: "Enviar mensagem de contacto",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ContactRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Mensagem processada com sucesso." },
+          "400": { description: "Dados inválidos.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "502": { description: "Mensagem registada mas envio de e-mail falhou." },
+          "503": { description: "Modo sandbox do provider de e-mail." },
+        },
+      },
+    },
+    "/api/course/progress": {
+      get: {
+        tags: ["Course"],
+        summary: "Consultar progresso do curso",
+        security: [{ sessionCookie: [] }],
+        responses: {
+          "200": { description: "Progresso devolvido com sucesso." },
+          "401": { description: "Sem sessão válida.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "403": { description: "Sem acesso ao curso.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+      put: {
+        tags: ["Course"],
+        summary: "Guardar progresso de módulo",
+        security: [{ sessionCookie: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CourseProgressUpsertRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Progresso guardado com sucesso." },
+          "400": { description: "Dados inválidos.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "401": { description: "Sem sessão válida.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "403": { description: "Sem acesso ao curso.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        },
+      },
+    },
+    "/api/stripe/webhook": {
+      post: {
+        tags: ["Stripe"],
+        summary: "Receber eventos do Stripe",
+        description:
+          "Endpoint técnico para o Stripe. Requer header stripe-signature e payload assinado; normalmente não é usado manualmente pelo browser.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                description: "Payload bruto do Stripe (estrutura varia por evento).",
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Evento processado." },
+          "400": { description: "Assinatura ausente/inválida ou payload incompleto.", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+          "404": { description: "Pagamento sem utilizador associado." },
+          "500": { description: "Configuração Stripe incompleta." },
+        },
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION
### Motivation
- Provide an interactive, in-browser API explorer to simplify manual testing and developer onboarding.
- Centralize and expose an OpenAPI 3.1 document for the app so the Swagger UI can load accurate endpoint metadata.
- Document the new developer-facing route in the README for easier discovery.

### Description
- Added a public Swagger UI page at `app/api-docs/page.tsx` that loads the Swagger assets from CDN and mounts the UI in the browser.
- Added a JSON endpoint at `app/api/openapi/route.ts` which returns the OpenAPI document exported from `lib/openapi.ts`.
- Added `lib/openapi.ts` containing the OpenAPI 3.1 specification describing authentication, user, course, contact and Stripe webhook endpoints and a cookie-based `session` security scheme.
- Updated `README.md` with instructions to access the Swagger UI during development at `http://localhost:3000/api-docs`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d7d13144832eb000470def73eb2a)