### PR TITLE
Melhora separação visual das questões dos questionários

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -814,9 +814,12 @@ export default function CursoPage() {
               Responda a todas as questões. Necessita de 60% para concluir o módulo.
             </p>
 
-            <div className="space-y-8">
+            <div className="space-y-6">
               {activeModule.quiz.map((question, qIdx) => (
-                <div key={question.id} className="space-y-3">
+                <div
+                  key={question.id}
+                  className="space-y-3 rounded-lg border border-[#e0ddd8] bg-[#f2f2ee] p-4 sm:p-5"
+                >
                   <p className="font-semibold text-sm text-[#2a2a2a]">
                     {qIdx + 1}. {question.question}
                   </p>


### PR DESCRIPTION
### Motivation
- Melhorar a legibilidade e consistência visual dos questionários ao agrupar cada pergunta com as respetivas respostas dentro de uma caixa que replica o estilo usado nos módulos.

### Description
- Atualizei `app/curso/page.tsx` para envolver cada bloco de `question` + `options` num cartão (`rounded-lg border border-[#e0ddd8] bg-[#f2f2ee] p-4 sm:p-5`) e reduzi o espaçamento da lista de perguntas de `space-y-8` para `space-y-6`.

### Testing
- Executei `npm run lint` no ambiente e a verificação falhou devido a `next: not found` (limitação do ambiente), sem erros de runtime no patch aplicado localmente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c41124b3d8832e8393310818fb0635)