### PR TITLE
Add theory content pagination function for balanced distribution

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -369,6 +369,40 @@ const moduleSupportContent: Record<number, TheorySupportContent> = {
   },
 };
 
+/*
+ * DESCRIÇÃO DA FUNÇÃO: Distribui o conteúdo teórico em 4 páginas equilibradas
+ * para garantir profundidade antes de iniciar o questionário.
+ */
+const buildBaseTheoryPages = (content: string[]): TheoryPage[] => {
+  const totalBasePages = 4;
+  const chunkSize = Math.max(1, Math.ceil(content.length / totalBasePages));
+  const pageTitles = [
+    "Página 1 — Antes da avaliação: contexto e objetivos",
+    "Página 2 — Antes da avaliação: preparação operacional",
+    "Página 3 — Durante a avaliação: execução no terreno",
+    "Página 4 — Após a avaliação: análise, relatório e melhoria",
+  ];
+
+  const pages: TheoryPage[] = [];
+
+  for (let pageIndex = 0; pageIndex < totalBasePages; pageIndex += 1) {
+    const start = pageIndex * chunkSize;
+    const end = start + chunkSize;
+    const pageBlocks = content.slice(start, end);
+
+    if (pageBlocks.length === 0) {
+      continue;
+    }
+
+    pages.push({
+      title: pageTitles[pageIndex] ?? `Página ${pageIndex + 1}`,
+      blocks: pageBlocks,
+    });
+  }
+
+  return pages;
+};
+
 function renderBold(text: string): React.ReactNode {
   const parts = text.split(/(\*\*[^*]+\*\*)/g);
   return parts.map((part, i) => {


### PR DESCRIPTION
## Summary
Added a new utility function `buildBaseTheoryPages` to distribute theoretical content across 4 balanced pages before the assessment quiz, ensuring users engage with comprehensive material before evaluation.

## Key Changes
- **New function `buildBaseTheoryPages`**: Distributes content array into 4 equally-sized pages with predefined titles covering the assessment lifecycle:
  - Page 1: Context and objectives (before assessment)
  - Page 2: Operational preparation (before assessment)
  - Page 3: Field execution (during assessment)
  - Page 4: Analysis, reporting, and improvement (after assessment)

## Implementation Details
- Uses `Math.ceil` to calculate chunk size, ensuring even distribution across pages
- Implements `Math.max(1, ...)` to guarantee minimum chunk size of 1 item per page
- Skips empty pages to avoid rendering blank content
- Includes fallback page numbering for safety
- Well-documented with Portuguese comments explaining the function's purpose

https://claude.ai/code/session_01TGXWgKXEHywtpGc1xdZbfG