### PR TITLE
Add Module 11 (Certificate) and API to generate personalized PDF certificate

### DIFF
--- a/app/api/course/certificate/route.ts
+++ b/app/api/course/certificate/route.ts
@@ -1,0 +1,183 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: API para gerar o Certificado de Conclusão em PDF com o nome do utilizador autenticado.
+ */
+
+import { NextResponse } from "next/server";
+
+import { query } from "@/lib/database";
+import { hasUserCourseAccess } from "@/lib/courseAccess";
+import { getSession } from "@/lib/session";
+
+type UserRow = {
+  full_name: string;
+};
+
+type CompletionRow = {
+  completed_count: string;
+};
+
+/*
+ * DESCRIÇÃO DA FUNÇÃO: Escapa caracteres especiais para evitar quebra de sintaxe dentro de objetos de texto PDF.
+ */
+const escapePdfText = (value: string): string => {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/\r?\n/g, " ");
+};
+
+/*
+ * DESCRIÇÃO DA FUNÇÃO: Normaliza texto para ASCII básico para garantir compatibilidade com fonte standard do PDF.
+ */
+const normalizeAscii = (value: string): string => {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\x20-\x7E]/g, "")
+    .trim();
+};
+
+/*
+ * DESCRIÇÃO DA FUNÇÃO: Constrói um PDF simples (1 página) com identidade visual da plataforma.
+ */
+const buildCertificatePdf = (studentName: string, issueDate: string): Uint8Array => {
+  const safeName = escapePdfText(normalizeAscii(studentName) || "Participante");
+  const safeDate = escapePdfText(issueDate);
+
+  const contentStream = [
+    "q",
+    "1 1 1 rg",
+    "0 0 842 595 re f",
+    "Q",
+    "q",
+    "0.9647 0.4078 0.3373 rg",
+    "36 540 770 24 re f",
+    "Q",
+    "q",
+    "0.8314 0.7098 0.6275 rg",
+    "36 28 770 16 re f",
+    "Q",
+    "BT",
+    "/F2 20 Tf",
+    "0.9647 0.4078 0.3373 rg",
+    "210 500 Td",
+    "(CERTIFICADO DE CONCLUSAO) Tj",
+    "ET",
+    "BT",
+    "/F1 15 Tf",
+    "0.1647 0.1647 0.1647 rg",
+    "120 455 Td",
+    "(Certificamos que) Tj",
+    "ET",
+    "BT",
+    "/F2 34 Tf",
+    "0.1647 0.1647 0.1647 rg",
+    "120 405 Td",
+    `(${safeName}) Tj`,
+    "ET",
+    "BT",
+    "/F1 15 Tf",
+    "0.1647 0.1647 0.1647 rg",
+    "120 360 Td",
+    "(concluiu com sucesso o Curso de Cliente Misterio.) Tj",
+    "ET",
+    "BT",
+    "/F1 12 Tf",
+    "0.4 0.4 0.4 rg",
+    "120 320 Td",
+    `(Data de emissao: ${safeDate}) Tj`,
+    "ET",
+    "BT",
+    "/F1 12 Tf",
+    "0.4 0.4 0.4 rg",
+    "120 110 Td",
+    "(Cliente Misterio  Plataforma Oficial) Tj",
+    "ET",
+  ].join("\n");
+
+  const objects = [
+    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+    "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n",
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 842 595] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >>\nendobj\n",
+    "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>\nendobj\n",
+    `6 0 obj\n<< /Length ${Buffer.byteLength(contentStream, "utf8")} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
+  ];
+
+  let pdf = "%PDF-1.4\n";
+  const xrefPositions: number[] = [0];
+
+  for (const object of objects) {
+    xrefPositions.push(Buffer.byteLength(pdf, "utf8"));
+    pdf += object;
+  }
+
+  const xrefStart = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+
+  for (let index = 1; index < xrefPositions.length; index += 1) {
+    pdf += `${xrefPositions[index].toString().padStart(10, "0")} 00000 n \n`;
+  }
+
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF`;
+
+  return new Uint8Array(Buffer.from(pdf, "utf8"));
+};
+
+export const GET = async () => {
+  // Valida sessão ativa para garantir emissão do certificado apenas ao utilizador autenticado.
+  const session = await getSession();
+
+  if (!session?.userId) {
+    return NextResponse.json({ message: "É necessário iniciar sessão." }, { status: 401 });
+  }
+
+  // Reforça regra de negócio: apenas alunos com acesso ao curso podem gerar certificado.
+  const hasCourse = await hasUserCourseAccess(session.userId);
+
+  if (!hasCourse) {
+    return NextResponse.json(
+      { message: "É necessário concluir o pagamento para aceder ao certificado." },
+      { status: 403 }
+    );
+  }
+
+  // Garante que os módulos de formação (1 a 10) foram concluídos antes da emissão final.
+  const completionResult = await query<CompletionRow>(
+    "select count(*) as completed_count from course_progress where user_id = $1 and completed = true and module_id between 1 and 10",
+    [session.userId]
+  );
+
+  const completedModules = parseInt(completionResult.rows[0]?.completed_count ?? "0", 10);
+
+  if (completedModules < 10) {
+    return NextResponse.json(
+      { message: "Conclua os módulos 1 a 10 para desbloquear o certificado." },
+      { status: 403 }
+    );
+  }
+
+  // Carrega o nome completo do aluno para personalizar o PDF.
+  const userResult = await query<UserRow>("select full_name from users where id = $1", [session.userId]);
+  const userName = userResult.rows[0]?.full_name?.trim() || "Participante";
+
+  const issueDate = new Intl.DateTimeFormat("pt-PT", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(new Date());
+
+  const pdf = buildCertificatePdf(userName, issueDate);
+  const fileSafeName = normalizeAscii(userName).replace(/\s+/g, "_") || "participante";
+
+  return new NextResponse(pdf, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename=certificado_${fileSafeName}.pdf`,
+      "Cache-Control": "no-store",
+    },
+  });
+};

--- a/app/api/course/progress/route.ts
+++ b/app/api/course/progress/route.ts
@@ -22,7 +22,7 @@ type SubmitPayload = {
   quizAnswers: Record<string, number>;
 };
 
-const totalModules = 10;
+const totalModules = 11;
 
 export const GET = async () => {
   const session = await getSession();

--- a/app/curso/courseData.ts
+++ b/app/curso/courseData.ts
@@ -1859,4 +1859,28 @@ export const courseModules: CourseModule[] = [
  },
  ],
  },
+ {
+ id: 11,
+ title: "Módulo 11 — Certificado de Conclusão",
+ description: "Emissão do certificado final com nome do formando.",
+ keywords: ["Certificado", "Conclusão", "PDF", "Nome Personalizado"],
+ practicalTip: "Descarrega o certificado e guarda uma cópia no teu portefólio profissional.",
+ warning: "O certificado só fica disponível após conclusão dos módulos 1 a 10.",
+ benefit: "Comprovas formalmente a conclusão da formação de Cliente Mistério.",
+ content: [
+  "Este módulo final existe apenas para disponibilizar o certificado oficial do curso.",
+  "Após concluir os módulos anteriores, podes gerar e descarregar o teu certificado em PDF já com o teu nome.",
+  "Guarda o documento para partilhar no teu CV, LinkedIn e candidaturas a missões premium.",
+ ],
+ pages: [
+  {
+   title: "Página 1 — Emissão do Certificado",
+   blocks: [
+    "Parabéns por chegares ao fim do curso. Neste módulo final, o objetivo é simples: gerar o teu certificado oficial de conclusão.",
+    "Clica no botão de descarga para obteres um PDF com o teu nome, data de emissão e design alinhado com as cores da plataforma.",
+   ],
+  },
+ ],
+ quiz: [],
+ },
 ];

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -424,6 +424,7 @@ export default function CursoPage() {
   const [quizSubmitted, setQuizSubmitted] = useState(false);
   const [quizScore, setQuizScore] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isDownloadingCertificate, setIsDownloadingCertificate] = useState(false);
   const [accessDenied, setAccessDenied] = useState(false);
 
   const loadProgress = useCallback(async () => {
@@ -525,6 +526,55 @@ export default function CursoPage() {
     }
   };
 
+  /*
+   * DESCRIÇÃO DA FUNÇÃO: Marca o módulo 11 como concluído e inicia a descarga do certificado PDF personalizado.
+   */
+  const downloadCertificate = async () => {
+    if (isDownloadingCertificate) return;
+
+    setIsDownloadingCertificate(true);
+
+    try {
+      await fetch("/api/course/progress", {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          moduleId: 11,
+          quizScore: 100,
+          quizAnswers: {},
+        }),
+      });
+
+      const certificateResponse = await fetch("/api/course/certificate", {
+        method: "GET",
+        credentials: "include",
+      });
+
+      if (!certificateResponse.ok) return;
+
+      const pdfBlob = await certificateResponse.blob();
+      const objectUrl = URL.createObjectURL(pdfBlob);
+      const downloadAnchor = document.createElement("a");
+      const contentDisposition = certificateResponse.headers.get("content-disposition");
+      const fileNameMatch = contentDisposition?.match(/filename=([^;]+)/i);
+      const fileName = fileNameMatch?.[1]?.replace(/\"/g, "").trim() || "certificado.pdf";
+
+      downloadAnchor.href = objectUrl;
+      downloadAnchor.download = fileName;
+      document.body.appendChild(downloadAnchor);
+      downloadAnchor.click();
+      document.body.removeChild(downloadAnchor);
+      URL.revokeObjectURL(objectUrl);
+
+      await loadProgress();
+    } catch {
+      // Silently fail.
+    } finally {
+      setIsDownloadingCertificate(false);
+    }
+  };
+
   const allQuestionsAnswered = (quiz: QuizQuestion[]): boolean => {
     return quiz.every((q) => quizAnswers[q.id] !== undefined);
   };
@@ -590,7 +640,7 @@ export default function CursoPage() {
   const currentTheoryPage = allTheoryPages[theoryPage];
   const isLastTheoryPage = theoryPage === allTheoryPages.length - 1;
   const completedCount = progress?.completedCount ?? 0;
-  const totalModules = progress?.totalModules ?? 10;
+  const totalModules = progress?.totalModules ?? 11;
   const progressPercent = progress?.progressPercent ?? 0;
 
   return (
@@ -854,21 +904,37 @@ export default function CursoPage() {
             </div>
           </div>
 
-          <div className="flex justify-center">
-            <button
-              type="button"
-              onClick={startQuiz}
-              disabled={!isLastTheoryPage}
-              className="submit max-w-xs"
-            >
-              {isLastTheoryPage ? "Iniciar Questionário" : "Conclua a teoria para iniciar o questionário"}
-            </button>
-          </div>
+          {activeModule.id === 11 ? (
+            <div className="rounded-2xl border border-[#F66856]/30 bg-[#F5E5DB] p-6 text-center space-y-4">
+              <p className="text-sm text-[#2a2a2a]">
+                Este módulo disponibiliza o seu Certificado de Conclusão em PDF com nome personalizado.
+              </p>
+              <button
+                type="button"
+                onClick={downloadCertificate}
+                disabled={isDownloadingCertificate}
+                className="submit max-w-sm disabled:opacity-40"
+              >
+                {isDownloadingCertificate ? "A preparar certificado..." : "Descarregar Certificado em PDF"}
+              </button>
+            </div>
+          ) : (
+            <div className="flex justify-center">
+              <button
+                type="button"
+                onClick={startQuiz}
+                disabled={!isLastTheoryPage}
+                className="submit max-w-xs"
+              >
+                {isLastTheoryPage ? "Iniciar Questionário" : "Conclua a teoria para iniciar o questionário"}
+              </button>
+            </div>
+          )}
         </div>
       )}
 
       {/* Questionário */}
-      {activeModule && quizMode && (
+      {activeModule && quizMode && activeModule.quiz.length > 0 && (
         <div className="space-y-6">
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Disponibilizar um Módulo 11 cujo único propósito é emitir um Certificado de Conclusão com o nome do formando e as cores do site.
- Permitir que o certificado seja descarregado em PDF já com o nome do utilizador autenticado e que a emissão marque o módulo final como concluído.

### Description
- Adicionado o `Módulo 11 — Certificado de Conclusão` em `app/curso/courseData.ts` com página dedicada à emissão do certificado.
- Atualizada a API de progresso para considerar `totalModules = 11` em `app/api/course/progress/route.ts` (cálculo e validação de módulo válido).
- Implementada nova rota `GET /api/course/certificate` em `app/api/course/certificate/route.ts` que valida sessão, verifica acesso ao curso, assegura que os módulos 1–10 estão concluídos, obtém o `full_name` do utilizador e gera um PDF simples (uma página) com nome, data de emissão, paleta visual e nome de ficheiro personalizado.
- Atualizada a UI em `app/curso/page.tsx` para: mostrar CTA específico no Módulo 11, iniciar download do PDF via `fetch("/api/course/certificate")`, marcar o módulo 11 como concluído (`PUT /api/course/progress` com `moduleId: 11`) e evitar renderização do quiz em módulos sem perguntas.

### Testing
- Executado `npm run lint` no ambiente de mudança, que falhou devido a dependências do projeto não estarem instaladas (comando `next` indisponível). Resultado: falha (ambiente).
- Executado `npx tsc --noEmit`, que falhou por ausência/ausência de tipos e dependências do projeto no ambiente atual; os erros reportados são globais e não introduzidos por esta alteração. Resultado: falha (ambiente).
- Verificadas alterações locais e commit criado com mensagem: `Adicionar módulo 11 com certificado PDF personalizado`; os novos/alterados principais ficheiros são `app/curso/courseData.ts`, `app/curso/page.tsx`, `app/api/course/progress/route.ts` e `app/api/course/certificate/route.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ac5df390832ebb78d7fed0cd69d2)