### PR TITLE
Fix Next.js build error in certificate API response body type

### DIFF
--- a/app/api/course/certificate/route.ts
+++ b/app/api/course/certificate/route.ts
@@ -172,7 +172,10 @@ export const GET = async () => {
   const pdf = buildCertificatePdf(userName, issueDate);
   const fileSafeName = normalizeAscii(userName).replace(/\s+/g, "_") || "participante";
 
-  return new NextResponse(pdf, {
+  // Converte para Blob para satisfazer o tipo BodyInit usado pelo NextResponse no build do Next.js 16.
+  const pdfBlob = new Blob([pdf], { type: "application/pdf" });
+
+  return new NextResponse(pdfBlob, {
     status: 200,
     headers: {
       "Content-Type": "application/pdf",


### PR DESCRIPTION
### Motivation
- Corrigir o erro de tipagem que ocorria durante o `next build` ao passar um `Uint8Array` diretamente para `NextResponse`, que gerava: `Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BodyInit | null | undefined'`.

### Description
- Atualizei `app/api/course/certificate/route.ts` para converter o `Uint8Array` do PDF para um `Blob` (`application/pdf`) antes de criar o `NextResponse`, preservando os cabeçalhos de download e o nome do ficheiro. 
- A mudança garante que o corpo da resposta satisfaça o tipo `BodyInit` exigido pelo runtime/TypeScript do Next.js 16.

### Testing
- Executado `next build` na pipeline original que mostrou o erro de tipagem (falha do build) e foi a motivação da correção (erro reportado no log de build). 
- Tentado `npm run build` localmente após a alteração, mas falhou com `sh: 1: next: not found` neste ambiente, impedindo verificação completa do build aqui. 
- Tentado `npm install` localmente, mas a instalação foi bloqueada pelo registry (`403 Forbidden` ao buscar `stripe`), impedindo a execução completa dos testes de build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ae23eeb0832ebb57f9a58237f768)