### PR TITLE
Fix certificate PDF response type incompatibility for Next.js 16

### DIFF
--- a/app/api/course/certificate/route.ts
+++ b/app/api/course/certificate/route.ts
@@ -172,8 +172,12 @@ export const GET = async () => {
   const pdf = buildCertificatePdf(userName, issueDate);
   const fileSafeName = normalizeAscii(userName).replace(/\s+/g, "_") || "participante";
 
-  // Converte para Blob para satisfazer o tipo BodyInit usado pelo NextResponse no build do Next.js 16.
-  const pdfBlob = new Blob([pdf], { type: "application/pdf" });
+  // Cria uma cópia explícita em ArrayBuffer para cumprir o tipo BodyInit esperado pelo Next.js 16.
+  const pdfBinary = new Uint8Array(pdf.byteLength);
+  pdfBinary.set(pdf);
+
+  // Converte para Blob para enviar o ficheiro PDF com Content-Type correto.
+  const pdfBlob = new Blob([pdfBinary], { type: "application/pdf" });
 
   return new NextResponse(pdfBlob, {
     status: 200,


### PR DESCRIPTION
### Motivation
- Corrigir falha no build do Next.js 16 onde o `Uint8Array<ArrayBufferLike>` gerado pelo construtor do PDF não era aceito como `BlobPart`, causando erro de compilação em `app/api/course/certificate/route.ts`.

### Description
- Atualizei `app/api/course/certificate/route.ts` para criar uma cópia explícita com `Uint8Array` respaldada por um `ArrayBuffer` (`pdfBinary`) e usar essa cópia ao construir o `Blob` do PDF.
- Mantive intacta a resposta `NextResponse` e os headers de download (`Content-Type`, `Content-Disposition`, `Cache-Control`) para preservar o comportamento existente.
- A alteração é mínima e visa satisfazer as verificações de tipo do `BodyInit` no build do Next.js 16 sem alterar a lógica do PDF.

### Testing
- Executei `npm run build`, que não concluiu neste ambiente porque o binário `next` não estava disponível localmente, resultando em falha; o erro inicial do TypeScript foi reproduzido a partir do log de build anterior antes da correção.
- Tentei `npm install`, que falhou por restrição de rede/registro (`403 Forbidden` ao buscar `stripe`), impedindo a instalação das dependências e um build completo neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6affb27a4832e82a6c3a5aa7c13bf)