### PR TITLE
Fix Render startup port binding for Next.js service

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0 -p ${PORT:-3000}",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Render reported a `Port scan timeout reached, no open ports detected` because the Next.js process was not explicitly bound to the container interface/port, so the start command was updated to ensure the app listens on `0.0.0.0` and the runtime `PORT`.

### Description
- Updated the `start` script in `package.json` to `next start -H 0.0.0.0 -p ${PORT:-3000}` so the server binds to `0.0.0.0` and uses Render's `PORT` env var with a `3000` fallback.

### Testing
- Ran `npm run build` (failed because `next` was not installed in this environment) and `npm ci` (failed with `403 Forbidden` when fetching the `stripe` package), so full local validation of the change could not be completed automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ba7cf434832e8ce859b75a0d9937)