### PR TITLE
feat: abrir curso em modal expandido

### DIFF
--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -95,10 +95,33 @@ const courseModules = [
 
 export default function CoursePage() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isCourseModalOpen, setIsCourseModalOpen] = useState(false);
 
   useEffect(() => {
     setIsLoggedIn(Boolean(localStorage.getItem(sessionStorageKey)));
   }, []);
+
+  /*
+   * DESCRIÇÃO DO EFEITO: Fecha o modal com a tecla ESC e bloqueia o scroll da página
+   * enquanto o curso está aberto em janela sobreposta.
+   */
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsCourseModalOpen(false);
+      }
+    };
+
+    if (isCourseModalOpen) {
+      document.body.style.overflow = "hidden";
+      window.addEventListener("keydown", handleEscape);
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", handleEscape);
+    };
+  }, [isCourseModalOpen]);
 
   return (
     <section className="w-full space-y-8">
@@ -159,12 +182,13 @@ export default function CoursePage() {
 
       {isLoggedIn && (
         <div className="flex justify-center">
-          <Link
-            href="/curso"
-            className="submit inline-block max-w-sm text-center !no-underline"
+          <button
+            type="button"
+            onClick={() => setIsCourseModalOpen(true)}
+            className="submit inline-block max-w-sm text-center"
           >
             Aceder ao Curso Completo
-          </Link>
+          </button>
         </div>
       )}
 
@@ -208,6 +232,32 @@ export default function CoursePage() {
             >
               Criar Conta Gratuita
             </Link>
+          </div>
+        </div>
+      )}
+
+      {isCourseModalOpen && (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 p-3 sm:p-6">
+          <div className="flex h-[95vh] w-full max-w-[1400px] flex-col overflow-hidden rounded-2xl border border-white/20 bg-white shadow-2xl">
+            <div className="flex items-center justify-between border-b border-black/10 px-4 py-3 sm:px-6">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#F66856]">Curso em ecrã expandido</p>
+                <p className="text-sm font-medium text-black sm:text-base">Visualização focada para estudar sem scroll na página principal</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsCourseModalOpen(false)}
+                className="rounded-full border border-black/15 px-3 py-1.5 text-sm font-semibold text-black transition hover:bg-black/5"
+              >
+                Fechar
+              </button>
+            </div>
+
+            <iframe
+              title="Curso completo de Cliente Mistério"
+              src="/curso"
+              className="h-full w-full border-0"
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Permitir que o curso seja consultado num ecrã sobreposto em vez de exigir navegação para outra página, oferecendo leitura expandida sem scroll da landing. 
- Melhorar a experiência do utilizador ao focar o conteúdo do curso e evitar distrações da página principal.

### Description
- Substitui o `Link` para `/curso` por um `button` que abre um modal controlado pela flag de estado `isCourseModalOpen` no ficheiro `app/o-curso/page.tsx`.
- Adiciona um `useEffect` que regista o fecho do modal com a tecla `Escape` e bloqueia o scroll da página de fundo definindo `document.body.style.overflow = "hidden"` enquanto o modal está aberto.
- Renderiza o conteúdo do curso dentro de um `iframe` com layout expandido (`h-[95vh]` e `max-w-[1400px]`) e inclui um header com título e botão `Fechar` para encerrar o modal.
- Mantém a aparência e o CTA de compra (`CheckoutButton`) inalterados, e adiciona um backdrop escuro (`bg-black/70`) e z-index elevado para foco visual.

### Testing
- Executado `npm run lint`, que falhou com `sh: 1: next: not found` devido à ausência de dependências do ambiente (falha).
- Executado `npm ci`, que falhou com erro `403 Forbidden` ao buscar o pacote `stripe` no registry, impedindo a instalação das dependências (falha).
- Validado localmente a alteração de ficheiro e commit realizado em `app/o-curso/page.tsx` com a mensagem `feat: abrir curso em modal expandido` (sucesso do commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c4a30b58832eb3fdbc79f9300142)