### PR TITLE
Make module theory and quiz open as modal overlays and lock background scroll

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -456,6 +456,23 @@ export default function CursoPage() {
     loadProgress();
   }, [router, loadProgress]);
 
+  /*
+   * DESCRIÇÃO DO EFEITO: Bloqueia o scroll da página principal sempre que um módulo
+   * está aberto em modo sobreposto (teoria ou questionário), mantendo o foco no conteúdo.
+   */
+  useEffect(() => {
+    if (!activeModuleId) {
+      document.body.style.overflow = "";
+      return;
+    }
+
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [activeModuleId]);
+
   const getModuleProgress = (moduleId: number): ModuleProgress | undefined => {
     return progress?.modules.find((m) => m.moduleId === moduleId);
   };
@@ -735,20 +752,23 @@ export default function CursoPage() {
 
       {/* Conteúdo do módulo ativo */}
       {activeModule && !quizMode && currentTheoryPage && (
-        <div className="space-y-6">
-          <button
-            type="button"
-            onClick={() => setActiveModuleId(null)}
-            className="text-sm text-[#2a2a2a] font-semibold hover:underline"
-          >
-            &larr; Voltar aos módulos
-          </button>
-
-          <div className="rounded-2xl border border-[#D4B5A0]/30 bg-white p-6 space-y-6">
-            <div>
-              <h2 className="text-2xl font-bold text-[#2a2a2a]">{activeModule.title}</h2>
-              <p className="text-sm text-[#666] mt-2">{activeModule.description}</p>
+        <div className="fixed inset-0 z-[120] bg-black/60 p-3 sm:p-6">
+          <div className="mx-auto flex h-full w-full max-w-[1320px] flex-col rounded-2xl border border-[#D4B5A0]/30 bg-white p-4 sm:p-6">
+            <div className="mb-4">
+              <button
+                type="button"
+                onClick={() => setActiveModuleId(null)}
+                className="text-sm text-[#2a2a2a] font-semibold hover:underline"
+              >
+                &larr; Voltar aos módulos
+              </button>
             </div>
+
+            <div className="space-y-6 overflow-y-auto pr-1 sm:pr-2">
+              <div>
+                <h2 className="text-2xl font-bold text-[#2a2a2a]">{activeModule.title}</h2>
+                <p className="text-sm text-[#666] mt-2">{activeModule.description}</p>
+              </div>
 
             {/* Card de informação rápida — visível apenas na primeira página */}
             {theoryPage === 0 && (
@@ -881,162 +901,169 @@ export default function CursoPage() {
               </div>
             )}
 
-            <div className="flex items-center justify-between gap-3 border-t border-[#D4B5A0]/20 pt-4">
-              <button
-                type="button"
-                onClick={() => setTheoryPage((prev) => Math.max(prev - 1, 0))}
-                disabled={theoryPage === 0}
-                className="site-pill-button-secondary max-w-[180px] disabled:opacity-40"
-              >
-                Página anterior
-              </button>
-              <p className="text-xs text-[#666]">
-                Página {theoryPage + 1} de {allTheoryPages.length}
-              </p>
-              <button
-                type="button"
-                onClick={() => setTheoryPage((prev) => Math.min(prev + 1, allTheoryPages.length - 1))}
-                disabled={isLastTheoryPage}
-                className="submit max-w-[180px] disabled:opacity-40"
-              >
-                Próxima página
-              </button>
+              <div className="flex items-center justify-between gap-3 border-t border-[#D4B5A0]/20 pt-4">
+                <button
+                  type="button"
+                  onClick={() => setTheoryPage((prev) => Math.max(prev - 1, 0))}
+                  disabled={theoryPage === 0}
+                  className="site-pill-button-secondary max-w-[180px] disabled:opacity-40"
+                >
+                  Página anterior
+                </button>
+                <p className="text-xs text-[#666]">
+                  Página {theoryPage + 1} de {allTheoryPages.length}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setTheoryPage((prev) => Math.min(prev + 1, allTheoryPages.length - 1))}
+                  disabled={isLastTheoryPage}
+                  className="submit max-w-[180px] disabled:opacity-40"
+                >
+                  Próxima página
+                </button>
+              </div>
+
+              {activeModule.id === 11 ? (
+                <div className="rounded-2xl border border-[#F66856]/30 bg-[#F5E5DB] p-6 text-center space-y-4">
+                  <p className="text-sm text-[#2a2a2a]">
+                    Este módulo disponibiliza o seu Certificado de Conclusão em PDF com nome personalizado.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={downloadCertificate}
+                    disabled={isDownloadingCertificate}
+                    className="submit max-w-sm disabled:opacity-40"
+                  >
+                    {isDownloadingCertificate ? "A preparar certificado..." : "Descarregar Certificado em PDF"}
+                  </button>
+                </div>
+              ) : (
+                <div className="flex justify-center">
+                  <button
+                    type="button"
+                    onClick={startQuiz}
+                    disabled={!isLastTheoryPage}
+                    className="submit max-w-xs"
+                  >
+                    {isLastTheoryPage ? "Iniciar Questionário" : "Conclua a teoria para iniciar o questionário"}
+                  </button>
+                </div>
+              )}
             </div>
           </div>
-
-          {activeModule.id === 11 ? (
-            <div className="rounded-2xl border border-[#F66856]/30 bg-[#F5E5DB] p-6 text-center space-y-4">
-              <p className="text-sm text-[#2a2a2a]">
-                Este módulo disponibiliza o seu Certificado de Conclusão em PDF com nome personalizado.
-              </p>
-              <button
-                type="button"
-                onClick={downloadCertificate}
-                disabled={isDownloadingCertificate}
-                className="submit max-w-sm disabled:opacity-40"
-              >
-                {isDownloadingCertificate ? "A preparar certificado..." : "Descarregar Certificado em PDF"}
-              </button>
-            </div>
-          ) : (
-            <div className="flex justify-center">
-              <button
-                type="button"
-                onClick={startQuiz}
-                disabled={!isLastTheoryPage}
-                className="submit max-w-xs"
-              >
-                {isLastTheoryPage ? "Iniciar Questionário" : "Conclua a teoria para iniciar o questionário"}
-              </button>
-            </div>
-          )}
         </div>
       )}
 
       {/* Questionário */}
       {activeModule && quizMode && activeModule.quiz.length > 0 && (
-        <div className="space-y-6">
-          <button
-            type="button"
-            onClick={() => setQuizMode(false)}
-            className="text-sm text-[#2a2a2a] font-semibold hover:underline"
-          >
-            &larr; Voltar ao conteúdo
-          </button>
-
-          <div className="rounded-2xl border border-[#D4B5A0]/30 bg-white p-6">
-            <h2 className="text-xl font-bold mb-1 text-[#2a2a2a]">{activeModule.title}</h2>
-            <p className="text-sm text-[#666] mb-6">
-              Responda a todas as questões. Necessita de 60% para concluir o módulo.
-            </p>
-
-            <div className="space-y-6">
-              {activeModule.quiz.map((question, qIdx) => (
-                <div
-                  key={question.id}
-                  className="space-y-3 rounded-lg border border-[#e0ddd8] bg-[#f2f2ee] p-4 sm:p-5"
-                >
-                  <p className="font-semibold text-sm text-[#2a2a2a]">
-                    {qIdx + 1}. {question.question}
-                  </p>
-                  <div className="grid gap-2">
-                    {question.options.map((option, oIdx) => (
-                      <button
-                        key={oIdx}
-                        type="button"
-                        disabled={quizSubmitted}
-                        onClick={() => selectAnswer(question.id, oIdx)}
-                        className={getOptionClass(question, oIdx)}
-                      >
-                        {String.fromCharCode(65 + oIdx)}) {option}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              ))}
+        <div className="fixed inset-0 z-[120] bg-black/60 p-3 sm:p-6">
+          <div className="mx-auto flex h-full w-full max-w-[1320px] flex-col rounded-2xl border border-[#D4B5A0]/30 bg-white p-4 sm:p-6">
+            <div className="mb-4">
+              <button
+                type="button"
+                onClick={() => setQuizMode(false)}
+                className="text-sm text-[#2a2a2a] font-semibold hover:underline"
+              >
+                &larr; Voltar ao conteúdo
+              </button>
             </div>
 
-            {!quizSubmitted && (
-              <div className="mt-8 flex justify-center">
-                <button
-                  type="button"
-                  disabled={!allQuestionsAnswered(activeModule.quiz) || isSaving}
-                  onClick={submitQuiz}
-                  className="submit max-w-xs disabled:opacity-40"
-                >
-                  Submeter Respostas
-                </button>
-              </div>
-            )}
+            <div className="overflow-y-auto pr-1 sm:pr-2">
+              <div className="rounded-2xl border border-[#D4B5A0]/30 bg-white p-6">
+                <h2 className="text-xl font-bold mb-1 text-[#2a2a2a]">{activeModule.title}</h2>
+                <p className="text-sm text-[#666] mb-6">
+                  Responda a todas as questões. Necessita de 60% para concluir o módulo.
+                </p>
 
-            {quizSubmitted && quizScore !== null && (
-              <div className={`mt-8 rounded-xl p-5 text-center ${
-                quizScore >= 60 ? "bg-[#F66856]/15 border border-[#F66856]/40" : "bg-red-100 border border-red-400/40"
-              }`}>
-                <p className="text-2xl font-bold mb-2 text-[#2a2a2a]">
-                  {quizScore >= 60 ? "Parabéns!" : "Tente novamente"}
-                </p>
-                <p className="text-sm mb-1 text-[#2a2a2a]">
-                  Obteve <span className="font-bold text-lg text-[#F66856]">{quizScore}%</span> neste questionário.
-                </p>
-                <p className="text-xs text-[#666] mb-4">
-                  {quizScore >= 60
-                    ? isSaving ? "A guardar progresso..." : "Módulo concluído com sucesso!"
-                    : "Necessita de pelo menos 60% para avançar. Reveja o conteúdo e tente novamente."}
-                </p>
-                <div className="flex justify-center gap-3">
-                  {quizScore >= 60 ? (
+                <div className="space-y-6">
+                  {activeModule.quiz.map((question, qIdx) => (
+                    <div
+                      key={question.id}
+                      className="space-y-3 rounded-lg border border-[#e0ddd8] bg-[#f2f2ee] p-4 sm:p-5"
+                    >
+                      <p className="font-semibold text-sm text-[#2a2a2a]">
+                        {qIdx + 1}. {question.question}
+                      </p>
+                      <div className="grid gap-2">
+                        {question.options.map((option, oIdx) => (
+                          <button
+                            key={oIdx}
+                            type="button"
+                            disabled={quizSubmitted}
+                            onClick={() => selectAnswer(question.id, oIdx)}
+                            className={getOptionClass(question, oIdx)}
+                          >
+                            {String.fromCharCode(65 + oIdx)}) {option}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {!quizSubmitted && (
+                  <div className="mt-8 flex justify-center">
                     <button
                       type="button"
-                      onClick={() => {
-                        setActiveModuleId(null);
-                        setQuizMode(false);
-                      }}
-                      className="submit max-w-xs"
+                      disabled={!allQuestionsAnswered(activeModule.quiz) || isSaving}
+                      onClick={submitQuiz}
+                      className="submit max-w-xs disabled:opacity-40"
                     >
-                      Voltar aos Módulos
+                      Submeter Respostas
                     </button>
-                  ) : (
-                    <>
-                      <button
-                        type="button"
-                        onClick={() => setQuizMode(false)}
-                        className="submit max-w-[200px] !bg-white/20"
-                      >
-                        Rever Conteúdo
-                      </button>
-                      <button
-                        type="button"
-                        onClick={startQuiz}
-                        className="submit max-w-[200px]"
-                      >
-                        Repetir Quiz
-                      </button>
-                    </>
-                  )}
-                </div>
+                  </div>
+                )}
+
+                {quizSubmitted && quizScore !== null && (
+                  <div className={`mt-8 rounded-xl p-5 text-center ${
+                    quizScore >= 60 ? "bg-[#F66856]/15 border border-[#F66856]/40" : "bg-red-100 border border-red-400/40"
+                  }`}>
+                    <p className="text-2xl font-bold mb-2 text-[#2a2a2a]">
+                      {quizScore >= 60 ? "Parabéns!" : "Tente novamente"}
+                    </p>
+                    <p className="text-sm mb-1 text-[#2a2a2a]">
+                      Obteve <span className="font-bold text-lg text-[#F66856]">{quizScore}%</span> neste questionário.
+                    </p>
+                    <p className="text-xs text-[#666] mb-4">
+                      {quizScore >= 60
+                        ? isSaving ? "A guardar progresso..." : "Módulo concluído com sucesso!"
+                        : "Necessita de pelo menos 60% para avançar. Reveja o conteúdo e tente novamente."}
+                    </p>
+                    <div className="flex justify-center gap-3">
+                      {quizScore >= 60 ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setActiveModuleId(null);
+                            setQuizMode(false);
+                          }}
+                          className="submit max-w-xs"
+                        >
+                          Voltar aos Módulos
+                        </button>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => setQuizMode(false)}
+                            className="submit max-w-[200px] !bg-white/20"
+                          >
+                            Rever Conteúdo
+                          </button>
+                          <button
+                            type="button"
+                            onClick={startQuiz}
+                            className="submit max-w-[200px]"
+                          >
+                            Repetir Quiz
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                )}
               </div>
-            )}
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Improve focus and usability by presenting module theory and quizzes as overlay modals that isolate content from the rest of the page.
- Prevent background scrolling and accidental interaction when a module or quiz is open by locking document scroll.
- Surface the PDF certificate action directly inside the relevant module to make downloading more discoverable.

### Description
- Added a `useEffect` that locks `document.body.style.overflow` to `hidden` while `activeModuleId` is set and restores it on cleanup to prevent background scrolling.
- Refactored the module theory view into a centered full-screen overlay (`fixed inset-0`) with a dark backdrop and an internal scrollable container, preserving paging, keywords, tips, and evaluation examples.
- Moved the certificate call-to-action into the module overlay for `activeModule.id === 11` and wired the existing `downloadCertificate` button to that UI while respecting `isDownloadingCertificate` state.
- Refactored the quiz UI into a separate overlay modal with its own header/back control, preserved question rendering and submission logic, and updated buttons/layout classes for the modal presentation.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c4a30b58832eb3fdbc79f9300142)