### PR TITLE
Endurecer rotas públicas e exigir `SESSION_SECRET` em produção

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ APP_BASE_URL=https://clientemisterio.onrender.com
 
 # Stripe Payment Link
 NEXT_PUBLIC_STRIPE_PAYMENT_LINK=https://buy.stripe.com/xxxxxxxx
+
+# Opcional: expor Swagger/OpenAPI publicamente em produção
+ENABLE_PUBLIC_API_DOCS=false
 ```
 
 ## Instalação e Desenvolvimento
@@ -131,10 +134,13 @@ Esta página carrega o Swagger UI e permite testar os endpoints manualmente no b
 ## Segurança
 
 - **Sessões**: tokens HMAC-SHA256 assinados, armazenados em cookies HTTP-only com SameSite=Lax
+- **Segredo de sessão**: em produção, `SESSION_SECRET` é obrigatório (sem fallback automático)
 - **Senhas**: hash com `scrypt` e salt aleatório; comparação timing-safe
 - **Tokens de email**: gerados aleatoriamente, guardados em hash (SHA-256) na base de dados
 - **SQL**: queries parametrizadas em todos os endpoints (sem risco de SQL injection)
 - **Admin**: papel de administrador definido por variável de ambiente e validado na base de dados
+- **Hardening HTTP**: middleware global adiciona cabeçalhos de segurança (`HSTS`, `X-Frame-Options`, `nosniff`, `COOP`, `Permissions-Policy`)
+- **Exposição técnica controlada**: `/api-docs` e `/api/openapi` ficam ocultos por defeito em produção
 
 ## Deploy no Render
 

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import Script from "next/script";
 
 export const metadata: Metadata = {
@@ -10,7 +11,17 @@ export const metadata: Metadata = {
   description: "Documentação Swagger para testar endpoints manualmente no browser.",
 };
 
+const isPublicApiDocsEnabled = () => {
+  // Permite expor Swagger apenas quando explicitamente autorizado por variável de ambiente.
+  return process.env.ENABLE_PUBLIC_API_DOCS === "true";
+};
+
 export default function ApiDocsPage() {
+  if (process.env.NODE_ENV === "production" && !isPublicApiDocsEnabled()) {
+    // Oculta a rota em produção para reduzir exposição desnecessária de superfície da API.
+    notFound();
+  }
+
   return (
     <main className="min-h-screen bg-[#f8f8f8] px-4 py-6 sm:px-6 md:px-8">
       {/* Título e contexto rápido para orientar quem vai testar endpoints no browser. */}

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -6,7 +6,17 @@ import { NextResponse } from "next/server";
 
 import { openApiDocument } from "@/lib/openapi";
 
+const isPublicApiDocsEnabled = () => {
+  // Permite expor o JSON OpenAPI apenas quando explicitamente autorizado por configuração.
+  return process.env.ENABLE_PUBLIC_API_DOCS === "true";
+};
+
 export const GET = async () => {
+  if (process.env.NODE_ENV === "production" && !isPublicApiDocsEnabled()) {
+    // Evita exposição da documentação técnica da API em ambiente público por defeito.
+    return NextResponse.json({ message: "Recurso não encontrado." }, { status: 404 });
+  }
+
   // Devolve o documento OpenAPI como JSON para o cliente Swagger.
   return NextResponse.json(openApiDocument);
 };

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Define políticas de indexação para motores de busca, protegendo áreas técnicas e privadas.
+ */
+
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: ["/", "/about", "/o-curso", "/contact", "/termos-e-condicoes"],
+      disallow: ["/api", "/api-docs", "/dashboard", "/curso", "/checkout"],
+    },
+  };
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -2,14 +2,13 @@
  * DESCRIÇÃO DO FICHEIRO: Este ficheiro implementa a lógica de `lib/session.ts` no projeto, incluindo as responsabilidades principais desta unidade.
  */
 
-import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 import { cookies } from "next/headers";
 
 const sessionCookieName = "vp_session_token";
 const sessionDurationMs = 1000 * 60 * 60 * 24 * 7;
 let missingSecretWarningDisplayed = false;
-let derivedSecretWarningDisplayed = false;
 
 type SessionPayload = {
   userId: string;
@@ -18,21 +17,10 @@ type SessionPayload = {
   exp: number;
 };
 
-const deriveFallbackSecret = () => {
-  // Deriva uma chave estável para o ambiente atual quando a variável dedicada não foi definida.
-  const databaseUrl = process.env.DATABASE_URL?.trim();
-
-  if (!databaseUrl) {
-    return null;
-  }
-
-  return createHash("sha256").update(databaseUrl).digest("hex");
-};
-
 function getSessionSecret(options: { allowMissing: true }): string | null;
 function getSessionSecret(options?: { allowMissing?: false }): string;
 function getSessionSecret(options?: { allowMissing?: boolean }) {
-  // Obtém a chave principal de assinatura da sessão com suporte a fallback controlado.
+  // Obtém a chave principal de assinatura da sessão e bloqueia fallback implícito em produção.
   const configuredSecret = process.env.SESSION_SECRET?.trim() || process.env.NEXTAUTH_SECRET?.trim();
 
   if (configuredSecret) {
@@ -41,18 +29,6 @@ function getSessionSecret(options?: { allowMissing?: boolean }) {
 
   if (process.env.NODE_ENV !== "production") {
     return "development-only-session-secret";
-  }
-
-  const derivedSecret = deriveFallbackSecret();
-
-  if (derivedSecret) {
-    if (!derivedSecretWarningDisplayed) {
-      // Regista aviso único para incentivar configuração explícita da secret em produção.
-      console.error("SESSION_SECRET_NOT_CONFIGURED_USING_DATABASE_URL_FALLBACK");
-      derivedSecretWarningDisplayed = true;
-    }
-
-    return derivedSecret;
   }
 
   if (!missingSecretWarningDisplayed) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,61 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Middleware global para reforçar segurança HTTP e proteger rotas privadas antes da renderização.
+ */
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const sessionCookieName = "vp_session_token";
+const protectedPaths = ["/dashboard", "/curso", "/checkout"];
+const productionOnlyHiddenPaths = ["/api-docs", "/api/openapi"];
+
+const requiresAuthentication = (pathname: string) => {
+  // Marca rotas privadas que exigem sessão autenticada para acesso público controlado.
+  return protectedPaths.some((path) => pathname === path || pathname.startsWith(`${path}/`));
+};
+
+const shouldHideRouteInProduction = (pathname: string) => {
+  // Esconde documentação técnica em produção quando a exposição pública não está autorizada.
+  const isDocumentationPath = productionOnlyHiddenPaths.some(
+    (path) => pathname === path || pathname.startsWith(`${path}/`),
+  );
+
+  return process.env.NODE_ENV === "production" && process.env.ENABLE_PUBLIC_API_DOCS !== "true" && isDocumentationPath;
+};
+
+const appendSecurityHeaders = (response: NextResponse) => {
+  // Aplica cabeçalhos defensivos para reduzir riscos comuns de segurança no browser.
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
+
+  if (process.env.NODE_ENV === "production") {
+    response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  }
+
+  return response;
+};
+
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+  const hasSessionCookie = Boolean(request.cookies.get(sessionCookieName)?.value);
+
+  if (shouldHideRouteInProduction(pathname)) {
+    return appendSecurityHeaders(new NextResponse("Not Found", { status: 404 }));
+  }
+
+  if (requiresAuthentication(pathname) && !hasSessionCookie) {
+    // Redireciona visitantes sem sessão para login antes de abrir páginas privadas.
+    const redirectUrl = new URL(`/login?next=${encodeURIComponent(`${pathname}${search}`)}`, request.url);
+
+    return appendSecurityHeaders(NextResponse.redirect(redirectUrl));
+  }
+
+  return appendSecurityHeaders(NextResponse.next());
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)"],
+};


### PR DESCRIPTION
### Motivation
- Garantir que a aplicação está segura para ser exposta ao público, reduzindo a superfície técnica visível em produção.
- Evitar exposição acidental da documentação técnica (`/api-docs`, `/api/openapi`) por defeito em ambientes públicos.
- Forçar configuração explícita do segredo de sessão em produção para impedir fallback inseguro na assinatura de tokens.

### Description
- Adiciona `middleware.ts` global que aplica cabeçalhos de segurança HTTP, protege páginas privadas (`/dashboard`, `/curso`, `/checkout`) redirecionando para ` /login` quando não existe sessão, e oculta rotas de documentação técnica em produção por defeito.
- Atualiza `app/api-docs/page.tsx` e `app/api/openapi/route.ts` para só expor o Swagger/OpenAPI quando `ENABLE_PUBLIC_API_DOCS=true` e impedir acesso em produção por defeito.
- Endurece `lib/session.ts` removendo o fallback implícito baseado em `DATABASE_URL` e tornando `SESSION_SECRET` obrigatório em produção, emitindo erro quando ausente.
- Adiciona `app/robots.ts` para instruir motores de busca a não indexarem rotas técnicas e privadas, e atualiza o `README.md` com a nova variável `ENABLE_PUBLIC_API_DOCS` e notas de segurança HTTP.

### Testing
- Executado scan por padrões comuns de segredos com `rg` e não foram encontrados matches que indiquem credenciais inadvertidas no repositório.
- Executado um script de verificação de integridade de rotas internas (checa `href` contra páginas do App Router) e obteve `OK: 13 page routes mapped and internal href checks passed.`
- Tentativa de executar `npm install` falhou por políticas do ambiente (`403 Forbidden` da registry), logo `next` não estava disponível e `npm run lint` não pôde ser executado no ambiente atual.
- Testes de runtime mínimo realizados localmente nos ficheiros modificados (verificação estática e execução de scripts de checagem), sem erros reportados nas alterações aplicadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e77020e0832ea6ad15e7296fb7bb)