### PR TITLE
Update homepage benefit cards copy

### DIFF
--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -1,20 +1,18 @@
 "use client";
 
+// Define os três cartões de benefícios apresentados na landing page.
 const benefits = [
   {
-    icon: "📋",
     title: "Aprende",
-    description: "Curso 100% online, ao teu ritmo e sem horários definidos. Aprende quando quiseres, com total flexibilidade.",
+    description: "Curso 100% online, sem horários e ao teu ritmo.",
   },
   {
-    icon: "🎯",
-    title: "Pratica",
-    description: "10 módulos práticos do básico ao avançado — conceitos, ética, metodologia e relatórios profissionais.",
+    title: "Certificado",
+    description: "Direito a documento que comprova conclusão do curso.",
   },
   {
-    icon: "💶",
-    title: "Ganha",
-    description: "15€ a 150€ por missão. Avalia hotéis, restaurantes, lojas e outros negócios. Todos os custos são totalmente suportados pelas marcas.",
+    title: "Oportunidades",
+    description: "Testa produtos, lojas, restaurantes e hotéis sem qualquer custo.",
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Update the three benefit cards on the homepage so the displayed titles and descriptions match the new requested messaging ("Aprende", "Certificado", "Oportunidades") and simplify the card data.

### Description
- Modified `app/components/ThreePointsCards.tsx` to replace the three benefit objects' `title` and `description` text, removed the unused `icon` fields, and added a Portuguese comment describing the component.

### Testing
- Ran `npm run lint` which failed in this environment due to the missing `next` binary (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b29b3fec832ebf34ee9648df629a)