### PR TITLE
Add Render-safe fallback for missing SESSION_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Esta página carrega o Swagger UI e permite testar os endpoints manualmente no b
 ## Segurança
 
 - **Sessões**: tokens HMAC-SHA256 assinados, armazenados em cookies HTTP-only com SameSite=Lax
-- **Segredo de sessão**: em produção, `SESSION_SECRET` é obrigatório (sem fallback automático)
+- **Segredo de sessão**: em produção, `SESSION_SECRET` é recomendado; em Render existe fallback automático por `RENDER_SERVICE_ID` para evitar indisponibilidade de login
 - **Senhas**: hash com `scrypt` e salt aleatório; comparação timing-safe
 - **Tokens de email**: gerados aleatoriamente, guardados em hash (SHA-256) na base de dados
 - **SQL**: queries parametrizadas em todos os endpoints (sem risco de SQL injection)

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -31,6 +31,14 @@ function getSessionSecret(options?: { allowMissing?: boolean }) {
     return "development-only-session-secret";
   }
 
+  const renderServiceId = process.env.RENDER_SERVICE_ID?.trim();
+
+  if (renderServiceId) {
+    // Em plataformas geridas (ex.: Render), gera uma chave determinística por serviço para evitar quebra total de login.
+    // Nota: continua recomendado definir SESSION_SECRET manualmente para maior controlo de rotação e segurança.
+    return `render-service-secret-${renderServiceId}`;
+  }
+
   if (!missingSecretWarningDisplayed) {
     // Regista aviso único quando não há qualquer fonte para assinar ou validar sessões.
     console.error("SESSION_SECRET_NOT_CONFIGURED");


### PR DESCRIPTION
### Motivation
- Prevent production login failures caused by an unset `SESSION_SECRET` by providing a pragmatic fallback when running on Render.
- Preserve the stricter behavior in development and the explicit error when no secret source exists in production outside Render.

### Description
- Add a deterministic production fallback in `lib/session.ts` that returns `render-service-secret-<RENDER_SERVICE_ID>` when `SESSION_SECRET`/`NEXTAUTH_SECRET` are missing and `RENDER_SERVICE_ID` is present. 
- Keep the existing development fallback (`development-only-session-secret`) when `NODE_ENV !== "production"` and preserve throwing `SESSION_SECRET_NOT_CONFIGURED` when no secret source exists and `allowMissing` is false.
- Update `README.md` security section to note that `SESSION_SECRET` is recommended in production and that Render has an automatic fallback via `RENDER_SERVICE_ID`.
- Retain the existing comments (Portuguese) and English code identifiers as in the project style.

### Testing
- Ran `npm run lint`, which failed because `next` is not available in this environment (`sh: 1: next: not found`).
- Attempted `npm ci` to install dependencies, which was blocked by a `403 Forbidden` from the npm registry, preventing full local validation.
- No other automated tests were run due to the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f9972220832e99397219b62b06d1)