### PR TITLE
Corrige ortografia PT-PT e uniformiza placeholders de email

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ ClienteMisterio/
 ├── lib/
 │   ├── database.ts         # Pool PostgreSQL com auto-inicialização
 │   ├── session.ts          # Gestão de sessões com HMAC-SHA256
-│   ├── password.ts         # Hash de senhas com scrypt
-│   ├── token.ts            # Tokens para confirmação de email e reset de senha
+│   ├── password.ts         # Hash de palavras-passe com scrypt
+│   ├── token.ts            # Tokens para confirmação de email e reposição de palavra-passe
 │   ├── email.ts            # Wrapper da API Resend
 │   ├── authEmail.ts        # Templates de email transacional
 │   └── admin.ts            # Verificação de permissões de administrador
@@ -122,8 +122,8 @@ Esta página carrega o Swagger UI e permite testar os endpoints manualmente no b
 | POST | `/api/auth/login` | Autenticação |
 | POST | `/api/auth/logout` | Terminar sessão |
 | GET | `/api/auth/confirm-email` | Confirmação de email por token |
-| POST | `/api/auth/forgot-password` | Pedido de reset de senha |
-| POST | `/api/auth/reset-password` | Redefinir senha com token |
+| POST | `/api/auth/forgot-password` | Pedido de reposição de palavra-passe |
+| POST | `/api/auth/reset-password` | Redefinir palavra-passe com token |
 | GET | `/api/user` | Obter perfil do utilizador autenticado |
 | PUT | `/api/user` | Atualizar dados de perfil |
 | PUT | `/api/user/password` | Alterar senha |

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -124,7 +124,7 @@ export default function AccountPage() {
             <div className="input-group md:col-span-2">
               <input
                 name="email"
-                placeholder="voce@email.com"
+                placeholder="nome@exemplo.com"
                 type="email"
                 value={formData.email}
                 onChange={(event) => handleChange("email", event.target.value)}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -91,7 +91,7 @@ export default function ContactPage() {
               <input
                 name="email"
                 onChange={(event) => handleFieldChange("email", event.target.value)}
-                placeholder="voce@email.com"
+                placeholder="nome@exemplo.com"
                 required
                 type="email"
                 value={formData.email}

--- a/app/curso/courseData.ts
+++ b/app/curso/courseData.ts
@@ -1798,7 +1798,7 @@ export const courseModules: CourseModule[] = [
    scenario: "Estás no fim do mês 1. Tens 8 missões feitas, taxa aprovação 92%. Como procedes mês 2?",
    correctApproach: "Análise: 92% é bom, mas precisa >95%. Próximo mês: (1) Foco em qualidade, não quantidade — 5 missões mas PERFEITAS. (2) Pede feedback específico de 2 agências. (3) Tenta 1 setor novo (telecomunicações, farmácia) para diversificar. (4) Revê cada relatório rejeitado (entende padrão de erro). (5) Objetivos mês 2: 10 missões com 97%+ aprovação, pelo menos 2 de setores novos."
 ,
-   incorrectApproach: "Quer 'ganhar mais rápido', tenta 20 missões em mês 2, qualidade cai para 85% aprovação, reputação destrói-se. Mano a reparar leva 3-4 meses."
+   incorrectApproach: "Quer 'ganhar mais rápido', tenta 20 missões em mês 2, a qualidade cai para 85% de aprovação e a reputação destrói-se. Reparar esse dano pode levar 3-4 meses."
   }
  ],
  quiz: [

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -53,7 +53,7 @@ export default function ForgotPasswordPage() {
             <div className="input-group">
               <input
                 name="email"
-                placeholder="voce@email.com"
+                placeholder="nome@exemplo.com"
                 type="email"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -128,7 +128,7 @@ export default function LoginPage() {
             <div className="input-group">
               <input
                 name="email"
-                placeholder="voce@email.com"
+                placeholder="nome@exemplo.com"
                 type="email"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}


### PR DESCRIPTION
### Motivation
- Corrigir variações de termos para português de Portugal e melhorar consistência do texto visível na aplicação e na documentação. 
- Standardizar placeholders de e-mail para um exemplo neutro e claro para utilizadores. 
- Ajustar uma frase do conteúdo do curso que estava pouco natural em PT-PT.

### Description
- Atualiza o `README.md` para usar `palavras-passe` e termos PT-PT em endpoints (`reposição/redefinir palavra-passe`).
- Substitui placeholders de e-mail para `nome@exemplo.com` em `app/account/page.tsx`, `app/contact/page.tsx`, `app/login/page.tsx` e `app/forgot-password/page.tsx`.
- Reescreve uma frase em `app/curso/courseData.ts` para uma formulação natural em português europeu (`Reparar esse dano pode levar 3-4 meses`).
- Alterações aplicadas diretamente nos ficheiros: `README.md`, `app/account/page.tsx`, `app/contact/page.tsx`, `app/login/page.tsx`, `app/forgot-password/page.tsx`, `app/curso/courseData.ts`.

### Testing
- Procuras direcionadas com `rg` para localizar ocorrências de termos antigos foram usadas antes e depois das alterações para validar as substituições; os ficheiros modificados foram atualizados conforme esperado. 
- Tentativa de executar `npm run lint` foi efetuada, mas a task falhou no ambiente atual porque o binário `next`/dependências não estão disponíveis (`next: not found`).
- Não foram executados testes end-to-end adicionais devido às limitações do ambiente de build/run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8b6b2300832eadf2c5f0705ed285)