### PR TITLE
feat: apply Google Sans site-wide

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,32 +3,9 @@
  */
 
 @import "tailwindcss";
+@import url("https://fonts.cdnfonts.com/css/google-sans");
 
-/* Declarações de fontes customizadas CreatoDisplay */
-@font-face {
-  font-family: "CreatoDisplay";
-  src: url("/fonts/CreatoDisplay-Regular.otf") format("opentype");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "CreatoDisplay";
-  src: url("/fonts/CreatoDisplay-Medium.otf") format("opentype");
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "CreatoDisplay";
-  src: url("/fonts/CreatoDisplay-Bold.otf") format("opentype");
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-
+/* Google Sans carregada via CDN para aplicar tipografia global do site. */
 /* Declarações de fontes customizadas Basenji (fallback) */
 @font-face {
   font-family: "Basenji";
@@ -70,13 +47,13 @@
   --color-primary-soft: var(--primary-soft);
   --color-accent: var(--accent);
   --color-line: var(--line);
-  --font-sans: "CreatoDisplay", sans-serif;
+  --font-sans: "Google Sans", sans-serif;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: "CreatoDisplay", sans-serif;
+  font-family: "Google Sans", sans-serif;
   font-weight: 400;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -129,14 +106,14 @@ select {
   border-color: var(--line) !important;
 }
 
-/* Força todos os elementos tipográficos principais a usar CreatoDisplay em negrito. */
+/* Força todos os elementos tipográficos principais a usar Google Sans em negrito. */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: "CreatoDisplay", sans-serif;
+  font-family: "Google Sans", sans-serif;
   font-weight: 700;
 }
 
@@ -145,7 +122,7 @@ h6 {
   .cssbuttons-io-button {
     display: flex;
     align-items: center;
-    font-family: "CreatoDisplay", sans-serif;
+    font-family: "Google Sans", sans-serif;
     cursor: pointer;
     font-weight: 500;
     font-size: 14px;
@@ -187,7 +164,7 @@ h6 {
     border: none;
     padding: 0.6em 1.2em;
     margin: 0;
-    font-family: "CreatoDisplay", sans-serif;
+    font-family: "Google Sans", sans-serif;
     font-size: inherit;
     position: relative;
     display: inline-flex;
@@ -231,7 +208,7 @@ h6 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: "CreatoDisplay", sans-serif;
+    font-family: "Google Sans", sans-serif;
     cursor: pointer;
     font-weight: 500;
     font-size: 14px;
@@ -300,7 +277,7 @@ h6 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: "CreatoDisplay", sans-serif;
+    font-family: "Google Sans", sans-serif;
     cursor: pointer;
     font-weight: 500;
     font-size: 14px;
@@ -738,7 +715,7 @@ h6 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: "CreatoDisplay", sans-serif;
+  font-family: "Google Sans", sans-serif;
 }
 
 @media (max-width: 480px) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
     <html lang="pt">
       <body
         className="bg-[color:var(--background)] text-[color:var(--foreground)] antialiased"
-        style={{ fontFamily: "CreatoDisplay, sans-serif" }}
+        style={{ fontFamily: "Google Sans, sans-serif" }}
       >
         <AppShell>{children}</AppShell>
       </body>


### PR DESCRIPTION
### Motivation
- Replace the existing local font (`CreatoDisplay`) with `Google Sans` to apply a consistent, Google-hosted typography across the whole site.
- Ensure all global typography variables and explicit component rules use the new font so the UI is visually consistent.

### Description
- Added CDN import for Google Sans in `app/globals.css` and removed the local `CreatoDisplay` `@font-face` blocks so the site loads the font from the CDN.
- Updated theme variable `--font-sans` to `"Google Sans", sans-serif` and set `body` `font-family` to `"Google Sans", sans-serif` in `app/globals.css`.
- Replaced explicit `CreatoDisplay` references with `Google Sans` in headings, button styles and shared component rules inside `app/globals.css` to ensure all text elements inherit the new font.
- Aligned inline layout style in `app/layout.tsx` to `"Google Sans", sans-serif` so server-rendered HTML matches the global CSS.

### Testing
- Ran `npm run lint` which failed in this environment with `next: not found` because project dependencies / Next.js binary are not available in the container, so linting could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e85c80a0832e8382915b1a9b51d6)