### PR TITLE
Switch email provider from Resend to Gmail SMTP

### DIFF
--- a/GMAIL_SETUP.md
+++ b/GMAIL_SETUP.md
@@ -1,0 +1,73 @@
+# 📧 Configuração de Email com Gmail
+
+Este guia explica como configurar o sistema de envio de emails para verificação de conta e reset de password usando a conta Gmail do negócio.
+
+## 🔑 Passo 1: Habilitar 2-Step Verification (Verificação em 2 Passos)
+
+Para usar uma "App Password" (senha de aplicação), o Gmail requer que a verificação em 2 passos esteja ativada:
+
+1. Aceda à sua [Conta Google](https://myaccount.google.com/)
+2. No menu esquerdo, clique em **Security** (Segurança)
+3. Procure por **2-Step Verification** e clique em **Get Started**
+4. Siga o processo para ativar (vai receber códigos via SMS ou email)
+
+## 🔐 Passo 2: Criar App Password
+
+1. Retorne a [Conta Google](https://myaccount.google.com/) → **Security**
+2. Procure por **App passwords** (apenas visível se 2-Step está ativo)
+3. Selecione:
+   - App: **Mail**
+   - Device: **Windows/Linux/Mac** (ou o seu sistema)
+4. Google vai gerar uma **senha de 16 caracteres** (ex: `abcd efgh ijkl mnop`)
+5. Copie esta senha (sem espaços)
+
+## 🌐 Passo 3: Configurar Variáveis de Ambiente no Render
+
+No dashboard do Render:
+
+1. Aceda ao seu serviço Web
+2. Vá para **Environment**
+3. Adicione as seguintes variáveis:
+
+```
+GMAIL_EMAIL=clientemisterio.suporte@gmail.com
+GMAIL_APP_PASSWORD=abcdefghijklmnop
+EMAIL_TIMEOUT_MS=10000
+```
+
+**Nota:** A senha deve ser os 16 caracteres sem espaços.
+
+## ✅ Verificação
+
+O sistema agora vai:
+
+- **Enviar email de confirmação** quando um utilizador se regista
+- **Enviar email de reset de password** quando clica em "Esqueceu password"
+- O utilizador precisa confirmar o email antes de poder usar a conta
+
+## 🐛 Troubleshooting
+
+### "GMAIL_EMAIL não está definida"
+- Verifique se adicionou a variável no Render
+- Reinicie o serviço após adicionar
+
+### "GMAIL_APP_PASSWORD não está definida"
+- Certifique-se que criou a App Password no Gmail
+- A senha tem 16 caracteres (sem espaços)
+
+### "Erro 535: Username and Password not accepted"
+- Verifique que a App Password está correta
+- Certifique-se que 2-Step Verification está ativado
+- Aguarde alguns minutos após criar a senha
+
+### Emails não são enviados
+- Verifique os logs no Render (Logs tab)
+- Confirme que `GMAIL_EMAIL` é exatamente `clientemisterio.suporte@gmail.com`
+
+## 📝 Notas Importantes
+
+- ✅ A App Password é diferente da password da conta Gmail
+- ✅ Use apenas a App Password nos serviços (nunca a password real)
+- ✅ Os emails de confirmação expiram em 24 horas
+- ✅ Os links de reset de password expiram em 30 minutos
+- ✅ Os usuarios que não confirmarem o email podem tentar confirmar novamente a partir do login

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -4,8 +4,11 @@
 
 import { NextResponse } from "next/server";
 
+import { createEmailConfirmationTemplate } from "@/lib/authEmail";
 import { query } from "@/lib/database";
 import { hashPassword } from "@/lib/password";
+import { sendEmail } from "@/lib/email";
+import { createToken, hashToken } from "@/lib/token";
 
 type RegisterPayload = {
   firstName: string;
@@ -61,6 +64,10 @@ export const POST = async (request: Request) => {
   const firstAdminEmail = process.env.ADMIN_EMAIL?.trim().toLowerCase();
   const shouldBeAdmin = Boolean(firstAdminEmail) && normalizedEmail === firstAdminEmail;
 
+  // Gera token de confirmação de email
+  const confirmationToken = createToken();
+  const confirmationTokenHash = hashToken(confirmationToken);
+
   const result = await query<UserRow>(
     `insert into users (
       first_name,
@@ -70,22 +77,39 @@ export const POST = async (request: Request) => {
       password_hash,
       profile_completed,
       email_confirmed,
+      email_confirmation_token_hash,
       is_admin
     )
-     values ($1, $2, $3, $4, $5, false, true, $6)
+     values ($1, $2, $3, $4, $5, false, false, $6, $7)
      returning id, first_name, last_name, full_name, email, is_admin, created_at`,
-    [firstName, lastName, fullName, normalizedEmail, passwordHash, shouldBeAdmin]
+    [firstName, lastName, fullName, normalizedEmail, passwordHash, confirmationTokenHash, shouldBeAdmin]
   );
 
+  // Envia email de confirmação
+  const user = result.rows[0];
+  if (user) {
+    const template = createEmailConfirmationTemplate(confirmationToken);
+    try {
+      await sendEmail({
+        to: user.email,
+        subject: template.subject,
+        html: template.html,
+      });
+    } catch (error) {
+      // Log do erro mas não falha o registo
+      console.error("Falha ao enviar e-mail de confirmação:", error);
+    }
+  }
+
   return NextResponse.json({
-    message: "Conta criada com sucesso. Já pode iniciar sessão.",
+    message: "Conta criada com sucesso. Confirme o seu e-mail para continuar.",
     user: {
-      id: result.rows[0]?.id,
-      firstName: result.rows[0]?.first_name,
-      lastName: result.rows[0]?.last_name,
-      fullName: result.rows[0]?.full_name,
-      email: result.rows[0]?.email,
-      isAdmin: result.rows[0]?.is_admin ?? false,
+      id: user?.id,
+      firstName: user?.first_name,
+      lastName: user?.last_name,
+      fullName: user?.full_name,
+      email: user?.email,
+      isAdmin: user?.is_admin ?? false,
     },
   });
 };

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -2,6 +2,8 @@
  * DESCRIÇÃO DO FICHEIRO: Este ficheiro implementa a lógica de `lib/email.ts` no projeto, incluindo as responsabilidades principais desta unidade.
  */
 
+import nodemailer from "nodemailer";
+
 type MailPayload = {
   to: string;
   subject: string;
@@ -10,35 +12,33 @@ type MailPayload = {
   replyTo?: string;
 };
 
-type ResendConfig = {
-  apiKey: string;
-  from: string;
-  apiUrl: string;
+type GmailConfig = {
+  email: string;
+  appPassword: string;
   timeoutMs: number;
 };
 
-const defaultSender = "Cliente Mistério <onboarding@resend.dev>";
-const defaultApiUrl = "https://api.resend.com/emails";
+const getGmailConfig = (): GmailConfig => {
+  // Lê configuração do Gmail para envio de e-mails transacionais via SMTP.
+  const email = process.env.GMAIL_EMAIL?.trim() || "";
+  const appPassword = process.env.GMAIL_APP_PASSWORD?.trim() || "";
+  const timeoutMs = Number(process.env.EMAIL_TIMEOUT_MS?.trim() || "10000");
 
-const getResendConfig = (): ResendConfig => {
-  // Lê configuração central do Resend para manter envio consistente entre registo e recuperação de conta.
-  const apiKey = process.env.RESEND_API_KEY?.trim() || "";
-  const from = process.env.RESEND_FROM?.trim() || defaultSender;
-  const apiUrl = process.env.RESEND_API_URL?.trim() || defaultApiUrl;
-  const timeoutMs = Number(process.env.RESEND_TIMEOUT_MS?.trim() || "10000");
+  if (!email) {
+    throw new Error("GMAIL_EMAIL não está definida para envio de e-mails transacionais.");
+  }
 
-  if (!apiKey) {
-    throw new Error("RESEND_API_KEY não está definida para envio de e-mails transacionais.");
+  if (!appPassword) {
+    throw new Error("GMAIL_APP_PASSWORD não está definida para envio de e-mails transacionais.");
   }
 
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    throw new Error("RESEND_TIMEOUT_MS inválida.");
+    throw new Error("EMAIL_TIMEOUT_MS inválida.");
   }
 
   return {
-    apiKey,
-    from,
-    apiUrl,
+    email,
+    appPassword,
     timeoutMs,
   };
 };
@@ -53,41 +53,43 @@ const getSafeErrorMessage = (error: unknown, fallbackMessage: string) => {
 };
 
 export const sendEmail = async (payload: MailPayload) => {
-  // Envia e-mail transacional via API HTTP do Resend para evitar bloqueios de saída em portas SMTP.
-  const config = getResendConfig();
-  const abortController = new AbortController();
-  const timeoutHandle = setTimeout(() => abortController.abort(), config.timeoutMs);
+  // Envia e-mail transacional via SMTP do Gmail para verificação de conta e reset de password.
+  const config = getGmailConfig();
+
+  // Cria transportador SMTP com configuração do Gmail
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: config.email,
+      pass: config.appPassword,
+    },
+  });
 
   try {
-    const response = await fetch(config.apiUrl, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${config.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        from: config.from,
-        to: [payload.to],
+    // Envia o e-mail com timeout
+    const result = await Promise.race([
+      transporter.sendMail({
+        from: config.email,
+        to: payload.to,
         subject: payload.subject,
         html: payload.html,
         text: payload.text,
-        reply_to: payload.replyTo,
+        replyTo: payload.replyTo,
       }),
-      signal: abortController.signal,
-    });
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`Timeout ao enviar e-mail após ${config.timeoutMs}ms.`)),
+          config.timeoutMs
+        )
+      ),
+    ]);
 
-    if (!response.ok) {
-      const responseText = await response.text();
-      throw new Error(`Resend API ${response.status}: ${responseText}`);
-    }
+    return result;
   } catch (error) {
-    const message =
-      error instanceof Error && error.name === "AbortError"
-        ? `Timeout ao enviar e-mail via Resend após ${config.timeoutMs}ms.`
-        : getSafeErrorMessage(error, "Erro desconhecido durante o envio via Resend.");
+    const message = getSafeErrorMessage(error, "Erro desconhecido durante o envio de e-mail via Gmail.");
 
-    throw new Error(`${message} Verifique RESEND_API_KEY/RESEND_FROM e permissões do domínio configurado.`);
-  } finally {
-    clearTimeout(timeoutHandle);
+    throw new Error(
+      `${message} Verifique GMAIL_EMAIL/GMAIL_APP_PASSWORD e permissões da conta. Certifique-se que criou uma "App Password" no Gmail.`
+    );
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "16.1.6",
+        "nodemailer": "^6.9.13",
         "pg": "^8.11.5",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "sharp": "^0.34.5"
+        "sharp": "^0.34.5",
+        "stripe": "^15.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1550,7 +1552,6 @@
       "version": "20.19.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
       "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2497,7 +2498,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2511,7 +2511,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2781,7 +2780,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2893,7 +2891,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2903,7 +2900,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2941,7 +2937,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3589,7 +3584,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3650,7 +3644,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3675,7 +3668,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3763,7 +3755,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3835,7 +3826,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3864,7 +3854,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4847,7 +4836,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5036,6 +5024,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5050,7 +5047,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5485,6 +5481,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5857,7 +5868,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5877,7 +5887,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5894,7 +5903,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5913,7 +5921,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6102,6 +6109,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-15.12.0.tgz",
+      "integrity": "sha512-slTbYS1WhRJXVB8YXU8fgHizkUrM9KJyrw4Dd8pLEwzKHYyQTIE46EePC2MVbSDZdE24o1GdNtzmJV4PrPpmJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/styled-jsx": {
@@ -6432,7 +6452,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "16.1.6",
+    "nodemailer": "^6.9.13",
     "pg": "^8.11.5",
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
## Summary
Migrates the transactional email system from Resend HTTP API to Gmail SMTP using nodemailer. This change enables email confirmation for user registration and password reset functionality.

## Key Changes

- **Email Provider Migration**: Replaced Resend API integration with Gmail SMTP via nodemailer
  - Removed HTTP-based Resend API calls and configuration
  - Implemented SMTP transporter using nodemailer with Gmail authentication
  - Updated environment variables from `RESEND_*` to `GMAIL_*` and `EMAIL_TIMEOUT_MS`

- **User Registration Flow**: Enhanced to require email confirmation
  - Generate and store email confirmation tokens on user creation
  - Send confirmation email immediately after registration
  - Set `email_confirmed` to `false` by default (previously `true`)
  - Updated success message to prompt email confirmation

- **Configuration & Documentation**
  - Added `GMAIL_SETUP.md` with comprehensive setup instructions for Gmail App Passwords
  - Includes 2-Step Verification setup, environment variable configuration, and troubleshooting guide

- **Dependencies**: Added `nodemailer@^6.9.13` for SMTP email handling

## Implementation Details

- Timeout handling now uses `Promise.race()` instead of AbortController for SMTP operations
- Email confirmation tokens are generated and hashed before storage
- Email sending failures during registration are logged but don't block user creation
- Error messages updated to reference Gmail configuration instead of Resend API keys

https://claude.ai/code/session_01U1nRxZhcicj8i4R1TnWV5c