### PR TITLE
Add local nodemailer type declarations to unblock TypeScript build

### DIFF
--- a/nodemailer.d.ts
+++ b/nodemailer.d.ts
@@ -1,0 +1,30 @@
+declare module "nodemailer" {
+  export type SendMailOptions = {
+    from?: string;
+    to: string;
+    subject: string;
+    html?: string;
+    text?: string;
+    replyTo?: string;
+  };
+
+  export type Transporter = {
+    sendMail: (mailOptions: SendMailOptions) => Promise<unknown>;
+  };
+
+  export type TransportOptions = {
+    service: string;
+    auth: {
+      user: string;
+      pass: string;
+    };
+  };
+
+  export function createTransport(options: TransportOptions): Transporter;
+
+  const nodemailer: {
+    createTransport: typeof createTransport;
+  };
+
+  export default nodemailer;
+}


### PR DESCRIPTION
### Motivation
- The Next.js TypeScript build failed with `Could not find a declaration file for module 'nodemailer'` when `lib/email.ts` imports `nodemailer`. 
- Installing `@types/nodemailer` is blocked in this environment (npm registry returned `403 Forbidden`), so a local ambient declaration file is required to unblock builds.

### Description
- Added a local `nodemailer.d.ts` ambient declaration file with minimal typings for `createTransport`, `Transporter`, and `SendMailOptions` and exported a default `nodemailer` object. 
- The file defines `TransportOptions` (with `service` and `auth`) and a `sendMail` method returning `Promise<unknown>` to satisfy the TypeScript compiler. 
- No runtime application logic was changed; only TypeScript declaration artifacts were added to satisfy type checking.

### Testing
- Attempted `npm i -D @types/nodemailer` and it failed with `403 Forbidden` from the npm registry. 
- Ran `npm run build` and TypeScript no longer errors on missing `nodemailer` types, but the build still fails later due to a missing environment variable `DATABASE_URL`. 
- The added `nodemailer.d.ts` resolves the original TypeScript compile error for `nodemailer`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0e88333c832eabeb6450a649055c)