### PR TITLE
Redesign terms page with card-based layout

### DIFF
--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -124,61 +124,103 @@ export default function CoursePage() {
   }, [isCourseModalOpen]);
 
   return (
-    <section className="w-full space-y-8">
-      <header className="w-full rounded-2xl border border-white/20 bg-white/5 p-6 backdrop-blur-sm space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: "#22a094" }}>
-          Formação completa
-        </p>
-
-        <h1 className="text-3xl font-semibold home-title-highlight-text sm:text-4xl lg:text-5xl">O Curso de Cliente Mistério</h1>
-
-        <p className="text-sm sm:text-base leading-6 sm:leading-7">
-          Um curso completo, 100% prático e desenhado para iniciantes. Aprende tudo que precisas para começar a ganhar dinheiro como Cliente Mistério — desde os conceitos básicos até estratégias de carreira avançadas.
-        </p>
-      </header>
-
-      {/* Preço e CTA */}
-      <div className="flex w-full justify-center">
-        <div className="w-full max-w-md rounded-2xl bg-white px-6 py-4 sm:px-10 sm:py-6 text-center">
-          <div className="space-y-1 text-center">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-black text-center">Acesso Completo ao Curso</p>
-            <p className="text-5xl font-bold text-center" style={{ color: "#22a094" }}>19,99€</p>
-            <p className="text-sm text-black text-center">Pagamento único · Acesso vitalício</p>
+    <section className="w-full">
+      <div className="mx-auto w-full max-w-4xl">
+        {/* Header */}
+        <div className="mb-16 space-y-6 sm:space-y-8">
+          {/* Badge */}
+          <div className="inline-flex items-center gap-2 rounded-full bg-teal-50 px-3 py-2">
+            <span className="h-2 w-2 rounded-full bg-teal-500"></span>
+            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-teal-700">Formação Completa</span>
           </div>
-          <CheckoutButton label="Comprar Curso Completo" />
+
+          {/* Title */}
+          <h1 className="text-3xl font-bold leading-tight sm:text-4xl md:text-5xl">
+            O Curso de <span className="text-teal-600">Cliente Mistério</span>
+          </h1>
+
+          {/* Description */}
+          <p className="text-sm sm:text-base leading-7 text-gray-700">
+            Um curso completo, 100% prático e desenhado para iniciantes. Aprende tudo que precisas para começar a ganhar dinheiro como Cliente Mistério — desde os conceitos básicos até estratégias de carreira avançadas.
+          </p>
         </div>
-      </div>
 
-      {/* Benefícios do curso */}
-      <div className="rounded-2xl border border-white/20 bg-white/5 p-6 backdrop-blur-sm">
-        <h3 className="text-2xl font-semibold sm:text-3xl home-title-highlight-text mb-4">Por que fazer este curso?</h3>
-        <div className="grid gap-4 md:grid-cols-3">
-          <div className="rounded-lg border border-[#22a094] bg-[#22a094] p-4">
-            <p className="font-semibold text-white mb-2">✓ Para Iniciantes</p>
-            <p className="text-sm text-white/90">Explicações simples, sem jargão. Começa do zero e aprende no teu ritmo.</p>
+        {/* Pricing Section */}
+        <div className="mb-16 grid gap-8 lg:grid-cols-3">
+          {/* Left Column - Content */}
+          <div className="lg:col-span-2 space-y-8">
+            {/* Por que fazer este curso */}
+            <div className="space-y-4">
+              <h2 className="text-2xl font-bold text-gray-900">Por que fazer este curso?</h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-lg bg-white p-6 shadow-sm">
+                  <p className="font-semibold text-gray-900 mb-2">✓ Para Iniciantes</p>
+                  <p className="text-sm text-gray-600">Explicações simples, sem jargão. Começa do zero e aprende no teu ritmo.</p>
+                </div>
+                <div className="rounded-lg bg-white p-6 shadow-sm">
+                  <p className="font-semibold text-gray-900 mb-2">✓ Prático & Real</p>
+                  <p className="text-sm text-gray-600">Casos reais, dicas profissionais, checklis práticos. Tudo que precisas para ganhar já no mês 1.</p>
+                </div>
+                <div className="rounded-lg bg-white p-6 shadow-sm">
+                  <p className="font-semibold text-gray-900 mb-2">✓ Ganha Desde Já</p>
+                  <p className="text-sm text-gray-600">5€ a 150€+ por missão. Flexibilidade total. Começa quando queres.</p>
+                </div>
+                <div className="rounded-lg bg-white p-6 shadow-sm">
+                  <p className="font-semibold text-gray-900 mb-2">✓ Carreira Escalável</p>
+                  <p className="text-sm text-gray-600">Começa simples, evolui para missões premium. Quanto melhor, mais ganhas.</p>
+                </div>
+                <div className="rounded-lg bg-white p-6 shadow-sm">
+                  <p className="font-semibold text-gray-900 mb-2">✓ Questões & Avaliação</p>
+                  <p className="text-sm text-gray-600">Testes em cada módulo. Certifica-te que compreendeste antes de avançar.</p>
+                </div>
+                <div className="rounded-lg bg-white p-6 shadow-sm">
+                  <p className="font-semibold text-gray-900 mb-2">✓ Comunidade & Apoio</p>
+                  <p className="text-sm text-gray-600">Aprende com outros avaliadores. Dicas, truques e apoio contínuo.</p>
+                </div>
+              </div>
+            </div>
           </div>
-          <div className="rounded-lg border border-[#22a094] bg-[#22a094] p-4">
-            <p className="font-semibold text-white mb-2">✓ Prático & Real</p>
-            <p className="text-sm text-white/90">Casos reais, dicas profissionais, checklis práticos. Tudo que precisas para ganhar já no mês 1.</p>
-          </div>
-          <div className="rounded-lg border border-[#22a094] bg-[#22a094] p-4">
-            <p className="font-semibold text-white mb-2">✓ Ganha Desde Já</p>
-            <p className="text-sm text-white/90">5€ a 150€+ por missão. Flexibilidade total. Começa quando queres.</p>
-          </div>
-          <div className="rounded-lg border border-[#22a094] bg-[#22a094] p-4">
-            <p className="font-semibold text-white mb-2">✓ Carreira Escalável</p>
-            <p className="text-sm text-white/90">Começa simples, evolui para missões premium. Quanto melhor, mais ganhas.</p>
-          </div>
-          <div className="rounded-lg border border-[#22a094] bg-[#22a094] p-4">
-            <p className="font-semibold text-white mb-2">✓ Questões & Avaliação</p>
-            <p className="text-sm text-white/90">Testes em cada módulo. Certifica-te que compreendeste antes de avançar.</p>
-          </div>
-          <div className="rounded-lg border border-[#22a094] bg-[#22a094] p-4">
-            <p className="font-semibold text-white mb-2">✓ Comunidade & Apoio</p>
-            <p className="text-sm text-white/90">Aprende com outros avaliadores. Dicas, truques e apoio contínuo.</p>
+
+          {/* Right Column - Pricing Card */}
+          <div className="h-fit rounded-2xl bg-white p-6 sm:p-8 shadow-sm">
+            <div className="mb-6 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-teal-600">
+                Acesso Completo
+              </p>
+              <div className="space-y-1">
+                <p className="text-4xl font-bold text-gray-900">€19.99</p>
+                <p className="text-xs text-gray-600">Pagamento único · Acesso vitalício</p>
+              </div>
+            </div>
+            <div className="mb-6 space-y-3 border-b border-gray-200 pb-6">
+              <div className="flex items-start gap-3">
+                <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-teal-500">
+                  <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                </div>
+                <p className="text-sm text-gray-700">10 módulos completos</p>
+              </div>
+              <div className="flex items-start gap-3">
+                <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-teal-500">
+                  <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                </div>
+                <p className="text-sm text-gray-700">Certificado de conclusão</p>
+              </div>
+              <div className="flex items-start gap-3">
+                <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-teal-500">
+                  <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                </div>
+                <p className="text-sm text-gray-700">Acesso ilimitado</p>
+              </div>
+            </div>
+            <CheckoutButton label="Comprar curso" />
           </div>
         </div>
-      </div>
 
       {isLoggedIn && (
         <div className="flex justify-center">

--- a/app/termos-e-condicoes/page.tsx
+++ b/app/termos-e-condicoes/page.tsx
@@ -1,5 +1,5 @@
 /*
- * DESCRIÇÃO DO FICHEIRO: Página de Termos e Condições da aplicação.
+ * DESCRIÇÃO DO FICHEIRO: Página de Termos e Condições com novo design.
  */
 
 import type { Metadata } from "next";
@@ -9,116 +9,97 @@ export const metadata: Metadata = {
   description: "Leia os termos e condições de utilização do portal Cliente Mistério.",
 };
 
+const sections = [
+  {
+    number: "1",
+    title: "Aceitação dos Termos",
+    content: "Ao aceder, adquirir ou utilizar o curso disponibilizado no portal Cliente Mistério, o utilizador concorda em aceitar integralmente estes termos e condições. Se não concorda com alguma parte destes termos, por favor não prossiga com a compra ou utilização do curso.",
+  },
+  {
+    number: "2",
+    title: "Serviço Fornecido",
+    content: "O portal Cliente Mistério comercializa um curso online de formação para quem pretende iniciar a atividade de cliente mistério. O curso inclui módulos de aprendizagem, materiais de apoio e, após conclusão, a emissão de um certificado de participação. O serviço é fornecido em formato digital, acessível através da plataforma online.",
+  },
+  {
+    number: "3",
+    title: "Certificado de Conclusão",
+    content: "Após a conclusão do curso, o utilizador recebe um certificado de participação. O certificado não possui validade legal nem é reconhecido por qualquer entidade reguladora. O certificado serve exclusivamente como comprovativo de que o utilizador frequentou e concluiu o curso. O certificado não substitui qualquer formação profissional certificada, acreditada ou regulamentada por lei.",
+  },
+  {
+    number: "4",
+    title: "Compra e Pagamento",
+    content: "A aquisição do curso é feita mediante pagamento único, processado de forma segura através da plataforma de pagamentos Stripe. Após confirmação do pagamento, o acesso ao curso é ativado de forma imediata. Não são oferecidos reembolsos após o acesso ao curso ter sido disponibilizado, salvo nos casos previstos na legislação do consumidor em vigor.",
+  },
+  {
+    number: "5",
+    title: "Responsabilidades do Utilizador",
+    content: "O utilizador é integralmente responsável pela confidencialidade das suas credenciais de acesso e pela segurança da sua conta. O utilizador compromete-se a não partilhar o acesso ao curso com terceiros, não reproduzir ou distribuir os conteúdos, não utilizar a plataforma para fins ilegais e informar imediatamente sobre qualquer uso não autorizado da sua conta.",
+  },
+  {
+    number: "6",
+    title: "Propriedade Intelectual",
+    content: "Todo o conteúdo presente no portal e no curso, incluindo textos, gráficos, logos, imagens, vídeos e software, é propriedade de Cliente Mistério ou dos seus fornecedores de conteúdo e está protegido pelas leis de propriedade intelectual. O utilizador é autorizado a aceder ao conteúdo apenas para uso pessoal e não comercial.",
+  },
+  {
+    number: "7",
+    title: "Limitação de Responsabilidade",
+    content: "Cliente Mistério não será responsável por danos diretos, indiretos, incidentais, especiais ou consequentes resultantes do acesso ou uso do portal ou do curso. O portal não garante resultados profissionais ou de emprego decorrentes da frequência do curso.",
+  },
+  {
+    number: "8",
+    title: "Privacidade e Dados Pessoais",
+    content: "O tratamento de dados pessoais no portal segue a legislação em vigor, nomeadamente o Regulamento Geral sobre a Proteção de Dados (RGPD). Os dados recolhidos são utilizados exclusivamente para a gestão da conta, acesso ao curso e emissão do certificado.",
+  },
+  {
+    number: "9",
+    title: "Modificações dos Termos",
+    content: "Cliente Mistério reserva-se o direito de modificar estes termos e condições a qualquer momento. As alterações serão publicadas nesta página e entrarão em vigor imediatamente após a publicação. Recomenda-se a consulta periódica desta página.",
+  },
+  {
+    number: "10",
+    title: "Lei Aplicável",
+    content: "Estes termos e condições são regidos pelas leis de Portugal. Qualquer disputa decorrente do uso do portal ou da aquisição do curso será resolvida nos tribunais competentes de Portugal.",
+  },
+  {
+    number: "11",
+    title: "Contacto",
+    content: "Se tiver dúvidas sobre estes termos e condições ou sobre o curso, por favor contacte-nos através da página de contacto do portal.",
+  },
+];
+
 export default function TermosECondicoes() {
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-12">
-      {/* Header */}
-      <div className="mb-8 space-y-4 sm:space-y-6">
-        <div className="inline-flex items-center gap-2 rounded-full bg-teal-50 px-3 py-2">
-          <span className="h-2 w-2 rounded-full bg-teal-500"></span>
-          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-teal-700">Política & Regulamento</span>
+    <section className="w-full">
+      <div className="mx-auto w-full max-w-4xl">
+        {/* Header */}
+        <div className="mb-12 space-y-4 sm:space-y-6">
+          <div className="inline-flex items-center gap-2 rounded-full bg-teal-50 px-3 py-2">
+            <span className="h-2 w-2 rounded-full bg-teal-500"></span>
+            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-teal-700">Política & Regulamento</span>
+          </div>
+
+          <div>
+            <h1 className="text-3xl font-bold leading-tight sm:text-4xl md:text-5xl text-gray-900">Termos e Condições de Utilização</h1>
+            <p className="mt-3 text-sm text-gray-600">Última atualização: {new Date().toLocaleDateString("pt-PT")}</p>
+          </div>
         </div>
 
-        <div>
-          <h1 className="text-3xl font-bold leading-tight sm:text-4xl md:text-5xl text-gray-900">Termos e Condições</h1>
-          <p className="mt-3 text-sm text-gray-600">Última atualização: {new Date().toLocaleDateString("pt-PT")}</p>
+        {/* Sections Grid */}
+        <div className="space-y-6">
+
+          {sections.map((section) => (
+            <div key={section.number} className="rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+              <div className="mb-4 flex items-start gap-4">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-teal-100">
+                  <span className="text-lg font-bold text-teal-600">{section.number}</span>
+                </div>
+                <h2 className="text-2xl font-bold text-gray-900">{section.title}</h2>
+              </div>
+              <p className="text-gray-700 leading-7">{section.content}</p>
+            </div>
+          ))}
         </div>
       </div>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">1. Aceitação dos Termos</h2>
-        <p className="text-gray-700">
-          Ao aceder, adquirir ou utilizar o curso disponibilizado no portal Cliente Mistério, o utilizador concorda em aceitar integralmente estes termos e condições. Se não concorda com alguma parte destes termos, por favor não prossiga com a compra ou utilização do curso.
-        </p>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">2. Serviço Fornecido</h2>
-        <p className="text-gray-700">
-          O portal Cliente Mistério comercializa um curso online de formação para quem pretende iniciar a atividade de cliente mistério. O curso inclui módulos de aprendizagem, materiais de apoio e, após conclusão, a emissão de um certificado de participação. O serviço é fornecido em formato digital, acessível através da plataforma online.
-        </p>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">3. Certificado de Conclusão</h2>
-        <p className="text-gray-700">
-          Após a conclusão do curso, o utilizador recebe um certificado de participação. É expressamente declarado que:
-        </p>
-        <ul className="list-inside list-disc space-y-2 text-gray-700">
-          <li>O certificado <strong>não possui validade legal</strong> nem é reconhecido por qualquer entidade reguladora ou organismo oficial.</li>
-          <li>O certificado serve <strong>exclusivamente como comprovativo</strong> de que o utilizador frequentou e concluiu o curso oferecido pelo portal Cliente Mistério.</li>
-          <li>O certificado não substitui qualquer formação profissional certificada, acreditada ou regulamentada por lei.</li>
-          <li>O Cliente Mistério não garante que o certificado seja aceite por terceiros, empresas ou entidades empregadoras como qualificação profissional.</li>
-        </ul>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">4. Compra e Pagamento</h2>
-        <p className="text-gray-700">
-          A aquisição do curso é feita mediante pagamento único, processado de forma segura através da plataforma de pagamentos Stripe. Após confirmação do pagamento, o acesso ao curso é ativado de forma imediata. O utilizador concorda que:
-        </p>
-        <ul className="list-inside list-disc space-y-2 text-gray-700">
-          <li>O pagamento é processado de forma segura e encriptada.</li>
-          <li>Não são oferecidos reembolsos após o acesso ao curso ter sido disponibilizado, salvo nos casos previstos na legislação do consumidor em vigor.</li>
-          <li>Os preços apresentados incluem IVA à taxa legal em vigor, quando aplicável.</li>
-        </ul>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">5. Responsabilidades do Utilizador</h2>
-        <p className="text-gray-700">
-          O utilizador é integralmente responsável pela confidencialidade das suas credenciais de acesso e pela segurança da sua conta. O utilizador compromete-se a:
-        </p>
-        <ul className="list-inside list-disc space-y-2 text-gray-700">
-          <li>Não partilhar o acesso ao curso com terceiros.</li>
-          <li>Não reproduzir, distribuir ou comercializar os conteúdos do curso sem autorização expressa.</li>
-          <li>Não utilizar a plataforma para fins ilegais ou prejudiciais.</li>
-          <li>Não tentar obter acesso não autorizado ao sistema.</li>
-          <li>Informar imediatamente sobre qualquer uso não autorizado da sua conta.</li>
-        </ul>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">6. Propriedade Intelectual</h2>
-        <p className="text-gray-700">
-          Todo o conteúdo presente no portal e no curso, incluindo textos, gráficos, logos, imagens, vídeos e software, é propriedade de Cliente Mistério ou dos seus fornecedores de conteúdo e está protegido pelas leis de propriedade intelectual. O utilizador é autorizado a aceder ao conteúdo apenas para uso pessoal e não comercial, no âmbito da sua aprendizagem individual.
-        </p>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">7. Limitação de Responsabilidade</h2>
-        <p className="text-gray-700">
-          Cliente Mistério não será responsável por danos diretos, indiretos, incidentais, especiais ou consequentes resultantes do acesso ou uso do portal ou do curso, incluindo, mas não limitado a, perda de dados, lucros cessantes ou interrupção do serviço. O portal não garante resultados profissionais ou de emprego decorrentes da frequência do curso.
-        </p>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">8. Privacidade e Dados Pessoais</h2>
-        <p className="text-gray-700">
-          O tratamento de dados pessoais no portal segue a legislação em vigor, nomeadamente o Regulamento Geral sobre a Proteção de Dados (RGPD). Os dados recolhidos são utilizados exclusivamente para a gestão da conta, acesso ao curso e emissão do certificado. Para informações detalhadas sobre como os seus dados são processados, consulte a nossa política de privacidade.
-        </p>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">9. Modificações dos Termos</h2>
-        <p className="text-gray-700">
-          Cliente Mistério reserva-se o direito de modificar estes termos e condições a qualquer momento. As alterações serão publicadas nesta página e entrarão em vigor imediatamente após a publicação. Recomenda-se a consulta periódica desta página.
-        </p>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">10. Lei Aplicável</h2>
-        <p className="text-gray-700">
-          Estes termos e condições são regidos pelas leis de Portugal. Qualquer disputa decorrente do uso do portal ou da aquisição do curso será resolvida nos tribunais competentes de Portugal.
-        </p>
-      </section>
-
-      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">11. Contacto</h2>
-        <p className="text-gray-700">
-          Se tiver dúvidas sobre estes termos e condições ou sobre o curso, por favor contacte-nos através da página de contacto do portal.
-        </p>
-      </section>
-    </div>
+    </section>
   );
 }

--- a/app/termos-e-condicoes/page.tsx
+++ b/app/termos-e-condicoes/page.tsx
@@ -11,32 +11,40 @@ export const metadata: Metadata = {
 
 export default function TermosECondicoes() {
   return (
-    <div className="mx-auto max-w-3xl space-y-8 py-12">
-      <div>
-        <h1 className="text-4xl font-bold">Termos e Condições</h1>
-        <p className="mt-2 text-black/50">Última atualização: {new Date().toLocaleDateString("pt-PT")}</p>
+    <div className="mx-auto w-full max-w-4xl space-y-12">
+      {/* Header */}
+      <div className="mb-8 space-y-4 sm:space-y-6">
+        <div className="inline-flex items-center gap-2 rounded-full bg-teal-50 px-3 py-2">
+          <span className="h-2 w-2 rounded-full bg-teal-500"></span>
+          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-teal-700">Política & Regulamento</span>
+        </div>
+
+        <div>
+          <h1 className="text-3xl font-bold leading-tight sm:text-4xl md:text-5xl text-gray-900">Termos e Condições</h1>
+          <p className="mt-3 text-sm text-gray-600">Última atualização: {new Date().toLocaleDateString("pt-PT")}</p>
+        </div>
       </div>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">1. Aceitação dos Termos</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">1. Aceitação dos Termos</h2>
+        <p className="text-gray-700">
           Ao aceder, adquirir ou utilizar o curso disponibilizado no portal Cliente Mistério, o utilizador concorda em aceitar integralmente estes termos e condições. Se não concorda com alguma parte destes termos, por favor não prossiga com a compra ou utilização do curso.
         </p>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">2. Serviço Fornecido</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">2. Serviço Fornecido</h2>
+        <p className="text-gray-700">
           O portal Cliente Mistério comercializa um curso online de formação para quem pretende iniciar a atividade de cliente mistério. O curso inclui módulos de aprendizagem, materiais de apoio e, após conclusão, a emissão de um certificado de participação. O serviço é fornecido em formato digital, acessível através da plataforma online.
         </p>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">3. Certificado de Conclusão</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">3. Certificado de Conclusão</h2>
+        <p className="text-gray-700">
           Após a conclusão do curso, o utilizador recebe um certificado de participação. É expressamente declarado que:
         </p>
-        <ul className="list-inside list-disc space-y-2 text-black/75">
+        <ul className="list-inside list-disc space-y-2 text-gray-700">
           <li>O certificado <strong>não possui validade legal</strong> nem é reconhecido por qualquer entidade reguladora ou organismo oficial.</li>
           <li>O certificado serve <strong>exclusivamente como comprovativo</strong> de que o utilizador frequentou e concluiu o curso oferecido pelo portal Cliente Mistério.</li>
           <li>O certificado não substitui qualquer formação profissional certificada, acreditada ou regulamentada por lei.</li>
@@ -44,24 +52,24 @@ export default function TermosECondicoes() {
         </ul>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">4. Compra e Pagamento</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">4. Compra e Pagamento</h2>
+        <p className="text-gray-700">
           A aquisição do curso é feita mediante pagamento único, processado de forma segura através da plataforma de pagamentos Stripe. Após confirmação do pagamento, o acesso ao curso é ativado de forma imediata. O utilizador concorda que:
         </p>
-        <ul className="list-inside list-disc space-y-2 text-black/75">
+        <ul className="list-inside list-disc space-y-2 text-gray-700">
           <li>O pagamento é processado de forma segura e encriptada.</li>
           <li>Não são oferecidos reembolsos após o acesso ao curso ter sido disponibilizado, salvo nos casos previstos na legislação do consumidor em vigor.</li>
           <li>Os preços apresentados incluem IVA à taxa legal em vigor, quando aplicável.</li>
         </ul>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">5. Responsabilidades do Utilizador</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">5. Responsabilidades do Utilizador</h2>
+        <p className="text-gray-700">
           O utilizador é integralmente responsável pela confidencialidade das suas credenciais de acesso e pela segurança da sua conta. O utilizador compromete-se a:
         </p>
-        <ul className="list-inside list-disc space-y-2 text-black/75">
+        <ul className="list-inside list-disc space-y-2 text-gray-700">
           <li>Não partilhar o acesso ao curso com terceiros.</li>
           <li>Não reproduzir, distribuir ou comercializar os conteúdos do curso sem autorização expressa.</li>
           <li>Não utilizar a plataforma para fins ilegais ou prejudiciais.</li>
@@ -70,44 +78,44 @@ export default function TermosECondicoes() {
         </ul>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">6. Propriedade Intelectual</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">6. Propriedade Intelectual</h2>
+        <p className="text-gray-700">
           Todo o conteúdo presente no portal e no curso, incluindo textos, gráficos, logos, imagens, vídeos e software, é propriedade de Cliente Mistério ou dos seus fornecedores de conteúdo e está protegido pelas leis de propriedade intelectual. O utilizador é autorizado a aceder ao conteúdo apenas para uso pessoal e não comercial, no âmbito da sua aprendizagem individual.
         </p>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">7. Limitação de Responsabilidade</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">7. Limitação de Responsabilidade</h2>
+        <p className="text-gray-700">
           Cliente Mistério não será responsável por danos diretos, indiretos, incidentais, especiais ou consequentes resultantes do acesso ou uso do portal ou do curso, incluindo, mas não limitado a, perda de dados, lucros cessantes ou interrupção do serviço. O portal não garante resultados profissionais ou de emprego decorrentes da frequência do curso.
         </p>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">8. Privacidade e Dados Pessoais</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">8. Privacidade e Dados Pessoais</h2>
+        <p className="text-gray-700">
           O tratamento de dados pessoais no portal segue a legislação em vigor, nomeadamente o Regulamento Geral sobre a Proteção de Dados (RGPD). Os dados recolhidos são utilizados exclusivamente para a gestão da conta, acesso ao curso e emissão do certificado. Para informações detalhadas sobre como os seus dados são processados, consulte a nossa política de privacidade.
         </p>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">9. Modificações dos Termos</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">9. Modificações dos Termos</h2>
+        <p className="text-gray-700">
           Cliente Mistério reserva-se o direito de modificar estes termos e condições a qualquer momento. As alterações serão publicadas nesta página e entrarão em vigor imediatamente após a publicação. Recomenda-se a consulta periódica desta página.
         </p>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">10. Lei Aplicável</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">10. Lei Aplicável</h2>
+        <p className="text-gray-700">
           Estes termos e condições são regidos pelas leis de Portugal. Qualquer disputa decorrente do uso do portal ou da aquisição do curso será resolvida nos tribunais competentes de Portugal.
         </p>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-2xl font-bold">11. Contacto</h2>
-        <p className="text-black/75">
+      <section className="space-y-4 rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+        <h2 className="text-2xl font-bold text-gray-900">11. Contacto</h2>
+        <p className="text-gray-700">
           Se tiver dúvidas sobre estes termos e condições ou sobre o curso, por favor contacte-nos através da página de contacto do portal.
         </p>
       </section>


### PR DESCRIPTION
## Summary

Redesign da página de Termos e Condições removendo o menu lateral e criando um layout limpo baseado em cards:

### 🎨 Alterações Realizadas

- **Removido menu lateral esquerdo** com índice de seções
- **Criado layout de cards** para cada seção (11 seções)
- **Adicionados badges numerados** (1-11) com indicador visual em teal
- **Melhorada tipografia e espaçamento** para melhor legibilidade
- **Grid responsivo** que funciona em mobile, tablet e desktop
- **Consistência visual** com as restantes páginas do site

### 📐 Layout

- Header com badge "Política & Regulamento"
- Título "Termos e Condições de Utilização"
- Data de última atualização
- Seções em cards brancos com:
  - Badge numerado com fundo teal
  - Título da seção
  - Conteúdo bem formatado
  - Espaçamento consistente

## Test plan

- [ ] Verificar se a página carrega sem erros
- [ ] Validar layout responsivo (mobile, tablet, desktop)
- [ ] Confirmar que todos os badges estão com cores corretas
- [ ] Verificar espaçamento consistente
- [ ] Testar navegação para outras páginas