### PR TITLE
Redesign contact page with 2-column layout

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -70,77 +70,164 @@ export default function ContactPage() {
   };
 
   return (
-    <section className="space-y-8">
-      <div className="mx-auto flex w-full max-w-6xl justify-center">
-        <article className="login-form max-w-[620px]">
-          <h1 className="form-heading">Contacto</h1>
-          <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
-            <div className="input-group">
-              <input
-                name="name"
-                onChange={(event) => handleFieldChange("name", event.target.value)}
-                placeholder="Digite o seu nome"
-                required
-                type="text"
-                value={formData.name}
-              />
-              <span className="label">Nome</span>
-            </div>
+    <section className="w-full">
+      <div className="mx-auto w-full max-w-4xl">
+        {/* Header */}
+        <div className="mb-12 space-y-4 sm:space-y-6">
+          <div className="inline-flex items-center gap-2 rounded-full bg-teal-50 px-3 py-2">
+            <span className="h-2 w-2 rounded-full bg-teal-500"></span>
+            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-teal-700">Contacto</span>
+          </div>
 
-            <div className="input-group">
-              <input
-                name="email"
-                onChange={(event) => handleFieldChange("email", event.target.value)}
-                placeholder="nome@exemplo.com"
-                required
-                type="email"
-                value={formData.email}
-              />
-              <span className="label">E-mail</span>
-            </div>
+          <div>
+            <h1 className="text-3xl font-bold leading-tight sm:text-4xl md:text-5xl text-gray-900">Fala connosco</h1>
+            <p className="mt-3 text-sm text-gray-600">
+              Temos algumas dúvidas sobre o curso, o certificado ou o processo de pagamento? Estamos aqui para ajudar.
+            </p>
+          </div>
+        </div>
 
-            <div className="input-group md:col-span-2">
-              <input
-                name="subject"
-                onChange={(event) => handleFieldChange("subject", event.target.value)}
-                placeholder="Ex.: parceria, suporte, imprensa"
-                required
-                type="text"
-                value={formData.subject}
-              />
-              <span className="label">Assunto</span>
-            </div>
+        {/* Content Grid */}
+        <div className="grid gap-8 lg:grid-cols-2">
+          {/* Left Column - Contact Info */}
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <h2 className="text-lg font-bold text-gray-900">Entre em contacto</h2>
 
-            <div className="input-group md:col-span-2">
-              <textarea
-                name="message"
-                onChange={(event) => handleFieldChange("message", event.target.value)}
-                placeholder="Escreva a sua mensagem"
-                required
-                value={formData.message}
-              />
-              <span className="label">Mensagem</span>
-            </div>
-
-            {statusMessage ? (
-              <div className="form-feedback md:col-span-2">
-                <p>{statusMessage}</p>
-                {statusReference ? (
-                  <p className="mt-1 text-xs">
-                    Referência da mensagem: <span className="font-semibold">{statusReference}</span>
-                  </p>
-                ) : null}
+              {/* Email */}
+              <div className="flex items-start gap-4">
+                <div className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-teal-100">
+                  <svg className="h-4 w-4 text-teal-600" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                    <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Email</p>
+                  <a href="mailto:email@clientemisterio.pt" className="text-sm text-gray-600 hover:text-teal-600">
+                    email@clientemisterio.pt
+                  </a>
+                </div>
               </div>
-            ) : null}
 
-            <div className="md:col-span-2 mt-2 space-y-3">
-              <button className="submit" disabled={isSubmitting} type="submit">
+              {/* Phone */}
+              <div className="flex items-start gap-4">
+                <div className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-teal-100">
+                  <svg className="h-4 w-4 text-teal-600" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773c.418 1.265 1.215 2.807 2.453 4.045 1.238 1.238 2.78 2.035 4.045 2.453l.773-1.548a1 1 0 011.06-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2.57c-6.607 0-12-5.393-12-12V3z" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Telefone</p>
+                  <a href="tel:+351912345678" className="text-sm text-gray-600 hover:text-teal-600">
+                    +351 91 234 5678
+                  </a>
+                </div>
+              </div>
+
+              {/* Address */}
+              <div className="flex items-start gap-4">
+                <div className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-teal-100">
+                  <svg className="h-4 w-4 text-teal-600" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Morada</p>
+                  <p className="text-sm text-gray-600">
+                    Rua da Inovação, 10<br />
+                    1900-001 Lisboa, Portugal
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Response Time Badge */}
+            <div className="flex items-center gap-2 rounded-full bg-teal-50 px-4 py-3">
+              <div className="h-2 w-2 rounded-full bg-teal-500"></div>
+              <p className="text-xs font-semibold text-teal-700">Respondemos em até 2 dias úteis</p>
+            </div>
+          </div>
+
+          {/* Right Column - Form */}
+          <div className="rounded-lg bg-white p-6 sm:p-8 shadow-sm">
+            <h2 className="mb-6 text-lg font-bold text-gray-900">Envia-nos uma mensagem</h2>
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              {/* Name and Email Row */}
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="input-group">
+                  <input
+                    name="name"
+                    onChange={(event) => handleFieldChange("name", event.target.value)}
+                    placeholder="O seu nome"
+                    required
+                    type="text"
+                    value={formData.name}
+                  />
+                  <span className="label">Nome</span>
+                </div>
+
+                <div className="input-group">
+                  <input
+                    name="email"
+                    onChange={(event) => handleFieldChange("email", event.target.value)}
+                    placeholder="nome@exemplo.com"
+                    required
+                    type="email"
+                    value={formData.email}
+                  />
+                  <span className="label">E-mail</span>
+                </div>
+              </div>
+
+              {/* Subject */}
+              <div className="input-group">
+                <input
+                  name="subject"
+                  onChange={(event) => handleFieldChange("subject", event.target.value)}
+                  placeholder="Seleciona um assunto"
+                  required
+                  type="text"
+                  value={formData.subject}
+                />
+                <span className="label">Assunto</span>
+              </div>
+
+              {/* Message */}
+              <div className="input-group">
+                <textarea
+                  name="message"
+                  onChange={(event) => handleFieldChange("message", event.target.value)}
+                  placeholder="Descreve a tua questão com o máximo de detalhe possível."
+                  required
+                  value={formData.message}
+                />
+                <span className="label">Mensagem</span>
+              </div>
+
+              {/* Status Message */}
+              {statusMessage ? (
+                <div className="rounded-lg border border-teal-200 bg-teal-50 p-4">
+                  <p className="text-sm text-teal-900">{statusMessage}</p>
+                  {statusReference ? (
+                    <p className="mt-2 text-xs text-teal-700">
+                      Referência: <span className="font-semibold">{statusReference}</span>
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {/* Submit Button */}
+              <button
+                className="submit w-full"
+                disabled={isSubmitting}
+                type="submit"
+              >
                 {isSubmitting ? "A enviar..." : "Enviar mensagem"}
               </button>
-              <p className="text-center text-xs">Responderemos em até 2 dias úteis.</p>
-            </div>
-          </form>
-        </article>
+            </form>
+          </div>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Redesign da página de Contacto com novo layout 2-colunas:

### 🎨 Alterações Realizadas

- **Badge "Contacto"** com estilo teal
- **Novo título**: "Fala connosco"
- **Layout 2-colunas**:
  - **Esquerda**: Informações de contacto (email, telefone, morada) com ícones
  - **Direita**: Formulário de contacto em card branco
- **Ícones decorativos** com fundo teal para info de contacto
- **Badge "Respondemos em até 2 dias úteis"** na coluna esquerda
- **Melhorado formulário** com melhor espaçamento e responsividade
- **Consistência visual** com as restantes páginas

### 📱 Responsive Design
- Mobile: Stack vertical (coluna única)
- Tablet/Desktop: 2-colunas

### 📋 Elementos do Formulário
- Nome e Email em grid (lado a lado)
- Assunto (full-width)
- Mensagem (textarea)
- Botão "Enviar mensagem" (full-width)
- Feedback de status melhorado

## Test plan

- [ ] Verificar se a página carrega sem erros
- [ ] Validar layout responsivo em diferentes tamanhos
- [ ] Testar envio do formulário
- [ ] Confirmar que os ícones estão visíveis
- [ ] Verificar badges estão com cores corretas
- [ ] Validar espaçamento consistente