### PR TITLE
Fix: simplify course modules display

### DIFF
--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -8,9 +8,21 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import CheckoutButton from "../components/CheckoutButton";
-import { courseModules as courseData } from "../curso/courseData";
 
 const sessionStorageKey = "vp_session";
+
+const courseModules = [
+  { number: 1, title: 'Enquadramento do Cliente Mistério' },
+  { number: 2, title: 'Mercado e Oportunidades' },
+  { number: 3, title: 'Perfil, Conduta e Ética Profissional' },
+  { number: 4, title: 'Metodologia de Avaliação e Critérios de Qualidade' },
+  { number: 5, title: 'Preparação da Missão' },
+  { number: 6, title: 'Execução no Terreno' },
+  { number: 7, title: 'Recolha e Gestão de Evidências' },
+  { number: 8, title: 'Elaboração do Relatório e Submissão' },
+  { number: 9, title: 'Remuneração, Reembolsos e Rentabilidade' },
+  { number: 10, title: 'Desenvolvimento Profissional e Plano de Ação' },
+];
 
 export default function CoursePage() {
   const router = useRouter();
@@ -150,81 +162,20 @@ export default function CoursePage() {
         {/* Modules Section */}
         <div className="mb-16">
           <h2 className="h3 mb-2">10 Módulos completos</h2>
-          <p className="text-body-sm mb-6">Clica em cada módulo para ver o conteúdo detalhado.</p>
+          <p className="text-body-sm mb-6">Acesso completo a todos os módulos após a compra.</p>
           <div className="space-y-3">
-            {courseData.map((module) => (
-              <details
-                key={module.id}
-                className="group rounded-lg border border-gray-200 bg-white overflow-hidden"
+            {courseModules.map((module) => (
+              <div
+                key={module.number}
+                className="rounded-lg border border-gray-200 bg-white px-6 py-4"
               >
-                <summary className="flex cursor-pointer items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50">
-                  <div className="flex items-center gap-4">
-                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-teal-100">
-                      <span className="text-body-sm font-bold text-teal-600">{module.id}</span>
-                    </div>
-                    <div>
-                      <p className="h5">{module.title}</p>
-                      <p className="text-body-xs text-gray-600">{module.description}</p>
-                    </div>
+                <div className="flex items-center gap-4">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-teal-100">
+                    <span className="text-body-sm font-bold text-teal-600">{module.number}</span>
                   </div>
-                  <span className="text-gray-400 group-open:hidden">+</span>
-                  <span className="hidden text-gray-400 group-open:block">−</span>
-                </summary>
-                <div className="border-t border-gray-200 px-6 py-4 bg-gray-50">
-                  {module.keywords && (
-                    <div className="mb-4">
-                      <p className="text-label font-semibold mb-2">Palavras-chave:</p>
-                      <div className="flex flex-wrap gap-2">
-                        {module.keywords.map((keyword) => (
-                          <span key={keyword} className="inline-block px-3 py-1 bg-teal-100 text-teal-700 rounded-full text-xs">
-                            {keyword}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {module.content && module.content.length > 0 && (
-                    <div className="mb-4">
-                      <p className="text-label font-semibold mb-2">Conteúdo:</p>
-                      <ul className="space-y-2">
-                        {module.content.slice(0, 5).map((item, index) => (
-                          <li key={index} className="flex gap-2 text-sm text-gray-700">
-                            <span className="text-teal-600">•</span>
-                            <span>{item}</span>
-                          </li>
-                        ))}
-                        {module.content.length > 5 && (
-                          <li className="text-sm text-gray-600 italic">
-                            + {module.content.length - 5} mais tópicos
-                          </li>
-                        )}
-                      </ul>
-                    </div>
-                  )}
-
-                  {module.benefit && (
-                    <div className="mb-4">
-                      <p className="text-label font-semibold mb-2">Benefício:</p>
-                      <p className="text-sm text-gray-700">{module.benefit}</p>
-                    </div>
-                  )}
-
-                  {module.practicalTip && (
-                    <div className="mb-4 p-3 bg-blue-50 rounded-lg border-l-4 border-blue-500">
-                      <p className="text-label font-semibold text-blue-900 mb-1">💡 Dica Prática:</p>
-                      <p className="text-sm text-blue-800">{module.practicalTip}</p>
-                    </div>
-                  )}
-
-                  {module.warning && (
-                    <div className="p-3 bg-amber-50 rounded-lg border-l-4 border-amber-500">
-                      <p className="text-label font-semibold text-amber-900 mb-1">⚠️ Atenção:</p>
-                      <p className="text-sm text-amber-800">{module.warning}</p>
-                    </div>
-                  )}
+                  <p className="h5">{module.title}</p>
                 </div>
-              </details>
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
Simplified the course modules display on the `/o-curso` page by removing the expansion functionality. Modules are now displayed as a simple list with just their titles and numbers.

## Changes
- Removed expandable `<details>` sections
- Display modules as a static list with clean design
- Show module numbers in colored circles
- Updated descriptive text to indicate full access after purchase

## Testing
The page renders correctly with all 10 modules displayed in a clean, simple format.