### PR TITLE
Add course statistics dashboard and module list header

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -675,6 +675,22 @@ export default function CursoPage() {
         </p>
       </header>
 
+      {/* Estatísticas do curso */}
+      <div className="grid grid-cols-3 gap-4">
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-[#D4B5A0]/30 bg-white p-6">
+          <p className="text-3xl font-bold text-[#2a2a2a]">{totalModules}</p>
+          <p className="text-xs text-[#666] mt-2 font-medium">Módulos Alvo</p>
+        </div>
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-[#D4B5A0]/30 bg-white p-6">
+          <p className="text-3xl font-bold text-[#2a2a2a]">{totalModules - (progress?.completedCount ?? 0)}</p>
+          <p className="text-xs text-[#666] mt-2 font-medium">Lecionados</p>
+        </div>
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-[#D4B5A0]/30 bg-white p-6">
+          <p className="text-3xl font-bold text-[#2a2a2a]">{completedCount}</p>
+          <p className="text-xs text-[#666] mt-2 font-medium">Completados</p>
+        </div>
+      </div>
+
       {/* Barra de progresso global */}
       <div className="rounded-2xl border border-[#D4B5A0]/30 bg-white p-5">
         <div className="flex items-center justify-between text-sm mb-3">
@@ -694,7 +710,21 @@ export default function CursoPage() {
 
       {/* Lista de módulos */}
       {!activeModule && (
-        <div className="space-y-3">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-[#2a2a2a]">Módulos do curso</h2>
+            <div className="flex gap-4 text-sm">
+              <div className="text-right">
+                <span className="font-bold text-[#22a094]">{totalModules}</span>
+                <p className="text-xs text-[#666]">Disponíveis</p>
+              </div>
+              <div className="text-right">
+                <span className="font-bold text-[#2a2a2a]">{completedCount}</span>
+                <p className="text-xs text-[#666]">Concluídos</p>
+              </div>
+            </div>
+          </div>
+          <div className="space-y-3">
           {courseModules.map((mod) => {
             const modProgress = getModuleProgress(mod.id);
             const unlocked = isModuleUnlocked(mod.id);
@@ -747,6 +777,7 @@ export default function CursoPage() {
               </button>
             );
           })}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Enhanced the course page UI with a statistics dashboard displaying course metrics and added a header section to the modules list with availability and completion counters.

## Key Changes
- **Statistics Dashboard**: Added a new 3-column grid section displaying:
  - Total target modules
  - Remaining modules to be taught (calculated as total minus completed)
  - Completed modules count

- **Module List Header**: Added a header section above the modules list containing:
  - "Módulos do curso" title
  - Quick stats showing total available modules and completed count
  - Right-aligned layout for the statistics

- **Layout Improvements**: 
  - Adjusted spacing from `space-y-3` to `space-y-4` for the modules container
  - Wrapped the module list items in an additional div to maintain proper spacing hierarchy

## Implementation Details
- Statistics cards use consistent styling with rounded borders, white background, and the existing color palette (#D4B5A0 for borders, #2a2a2a for text)
- Module header stats use the teal accent color (#22a094) for "Disponíveis" count
- All metrics are dynamically calculated from existing state variables (`totalModules`, `completedCount`, `progress`)

https://claude.ai/code/session_01YP6jNvUNxrEhPK7cbnJDBb