### PR TITLE
Add bg-gray-50 background color to all page sections

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -21,7 +21,7 @@ export default function AboutPage() {
   ];
 
   return (
-    <section className="w-full">
+    <section className="w-full bg-gray-50">
       <div className="mx-auto w-full max-w-4xl">
         {/* Main Content */}
         <div className="mb-16 space-y-6 sm:space-y-8">

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -90,7 +90,7 @@ export default function AccountPage() {
   };
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-8 bg-gray-50">
       <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form max-w-[620px]">
           <h1 className="form-heading">Criar conta</h1>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -70,7 +70,7 @@ export default function ContactPage() {
   };
 
   return (
-    <section className="w-full">
+    <section className="w-full bg-gray-50">
       <div className="mx-auto w-full max-w-4xl">
         {/* Header */}
         <div className="mb-12 space-y-4 sm:space-y-6">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -415,7 +415,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-8 bg-gray-50">
       {mustCompleteProfile && (
         <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/40 p-4">
           <div className="login-form w-full max-w-2xl">

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -45,7 +45,7 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-8 bg-gray-50">
       <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <h1 className="form-heading">Recuperar password</h1>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -120,7 +120,7 @@ export default function LoginPage() {
   };
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-8 bg-gray-50">
       <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <h1 className="form-heading">Login</h1>

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -21,7 +21,7 @@ export default function CoursePage() {
   }, []);
 
   return (
-    <section className="w-full">
+    <section className="w-full bg-gray-50">
       <div className="mx-auto w-full max-w-5xl">
         {/* Header Section */}
         <div className="mb-16 grid gap-8 lg:grid-cols-2">

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -26,7 +26,7 @@ export default function ResetPasswordPage() {
 // ainda não estão disponíveis durante o render inicial.
 function ResetPasswordLoadingState() {
   return (
-    <section className="space-y-8">
+    <section className="space-y-8 bg-gray-50">
       <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <p className="text-center text-sm">A carregar formulário de recuperação...</p>
@@ -74,7 +74,7 @@ function ResetPasswordContent() {
   };
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-8 bg-gray-50">
       <div className="mx-auto flex w-full max-w-6xl justify-center">
         <article className="login-form">
           <h1 className="form-heading">Definir password</h1>

--- a/app/termos-e-condicoes/page.tsx
+++ b/app/termos-e-condicoes/page.tsx
@@ -69,7 +69,7 @@ const sections = [
 
 export default function TermosECondicoes() {
   return (
-    <section className="w-full">
+    <section className="w-full bg-gray-50">
       <div className="mx-auto w-full max-w-4xl">
         {/* Header */}
         <div className="mb-12 space-y-4 sm:space-y-6">


### PR DESCRIPTION
## Summary
This PR adds a consistent light gray background color (`bg-gray-50`) to the main section elements across all page components, improving visual consistency and providing better visual separation of page content.

## Changes Made
- Added `bg-gray-50` class to the main `<section>` element in the following pages:
  - Reset Password page (both loading state and main content)
  - About page
  - Account/Sign Up page
  - Contact page
  - Dashboard page
  - Forgot Password page
  - Login page
  - Course page (o-curso)
  - Terms and Conditions page (termos-e-condicoes)

## Implementation Details
- The background color is applied consistently to the root section element of each page
- Uses Tailwind CSS's `bg-gray-50` utility class (a very light gray: `#f9fafb`)
- This change provides a subtle but unified visual treatment across all major pages
- No functional changes to page behavior or layout structure

https://claude.ai/code/session_01GANFtSXfAQJ93VDywok8bk