### PR TITLE
Simplify course modules display by removing expandable details

### DIFF
--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -150,81 +150,22 @@ export default function CoursePage() {
         {/* Modules Section */}
         <div className="mb-16">
           <h2 className="h3 mb-2">10 Módulos completos</h2>
-          <p className="text-body-sm mb-6">Clica em cada módulo para ver o conteúdo detalhado.</p>
           <div className="space-y-3">
             {courseData.map((module) => (
-              <details
+              <div
                 key={module.id}
-                className="group rounded-lg border border-gray-200 bg-white overflow-hidden"
+                className="rounded-lg border border-gray-200 bg-white px-6 py-4"
               >
-                <summary className="flex cursor-pointer items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50">
-                  <div className="flex items-center gap-4">
-                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-teal-100">
-                      <span className="text-body-sm font-bold text-teal-600">{module.id}</span>
-                    </div>
-                    <div>
-                      <p className="h5">{module.title}</p>
-                      <p className="text-body-xs text-gray-600">{module.description}</p>
-                    </div>
+                <div className="flex items-center gap-4">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-teal-100">
+                    <span className="text-body-sm font-bold text-teal-600">{module.id}</span>
                   </div>
-                  <span className="text-gray-400 group-open:hidden">+</span>
-                  <span className="hidden text-gray-400 group-open:block">−</span>
-                </summary>
-                <div className="border-t border-gray-200 px-6 py-4 bg-gray-50">
-                  {module.keywords && (
-                    <div className="mb-4">
-                      <p className="text-label font-semibold mb-2">Palavras-chave:</p>
-                      <div className="flex flex-wrap gap-2">
-                        {module.keywords.map((keyword) => (
-                          <span key={keyword} className="inline-block px-3 py-1 bg-teal-100 text-teal-700 rounded-full text-xs">
-                            {keyword}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {module.content && module.content.length > 0 && (
-                    <div className="mb-4">
-                      <p className="text-label font-semibold mb-2">Conteúdo:</p>
-                      <ul className="space-y-2">
-                        {module.content.slice(0, 5).map((item, index) => (
-                          <li key={index} className="flex gap-2 text-sm text-gray-700">
-                            <span className="text-teal-600">•</span>
-                            <span>{item}</span>
-                          </li>
-                        ))}
-                        {module.content.length > 5 && (
-                          <li className="text-sm text-gray-600 italic">
-                            + {module.content.length - 5} mais tópicos
-                          </li>
-                        )}
-                      </ul>
-                    </div>
-                  )}
-
-                  {module.benefit && (
-                    <div className="mb-4">
-                      <p className="text-label font-semibold mb-2">Benefício:</p>
-                      <p className="text-sm text-gray-700">{module.benefit}</p>
-                    </div>
-                  )}
-
-                  {module.practicalTip && (
-                    <div className="mb-4 p-3 bg-blue-50 rounded-lg border-l-4 border-blue-500">
-                      <p className="text-label font-semibold text-blue-900 mb-1">💡 Dica Prática:</p>
-                      <p className="text-sm text-blue-800">{module.practicalTip}</p>
-                    </div>
-                  )}
-
-                  {module.warning && (
-                    <div className="p-3 bg-amber-50 rounded-lg border-l-4 border-amber-500">
-                      <p className="text-label font-semibold text-amber-900 mb-1">⚠️ Atenção:</p>
-                      <p className="text-sm text-amber-800">{module.warning}</p>
-                    </div>
-                  )}
+                  <div>
+                    <p className="h5">{module.title}</p>
+                    <p className="text-body-xs text-gray-600">{module.description}</p>
+                  </div>
                 </div>
-              </details>
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
Refactored the course modules section to display module information in a simplified, always-visible format instead of using collapsible details elements.

## Key Changes
- Replaced `<details>` / `<summary>` HTML elements with static `<div>` containers for each module
- Removed the expandable/collapsible functionality and associated toggle indicators (+/−)
- Removed the instructional text "Clica em cada módulo para ver o conteúdo detalhado" (Click on each module to see detailed content)
- Removed all expandable content sections including:
  - Keywords display
  - Content list with truncation
  - Benefit descriptions
  - Practical tips section
  - Warning section
- Simplified module display to show only the module number, title, and description

## Implementation Details
- Module cards now display consistently without hover states or interactive elements
- Reduced visual complexity by removing the gray background and border-top separator that appeared in expanded state
- Maintained the module numbering badge and basic information layout
- All detailed module information (keywords, content, benefits, tips, warnings) is no longer visible to users

https://claude.ai/code/session_01UcdxLExgT56ecgNmPeBHj6