### PR TITLE
Fix 'Ver o programa' button link and improve mobile menu

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -23,19 +23,19 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       >
         <div className="relative flex w-full items-center justify-between gap-2 sm:gap-3">
           <Link
-            className="text-[10px] font-black uppercase tracking-[0.25em] text-[color:var(--foreground)] sm:text-sm sm:tracking-[0.35em]"
+            className="order-2 lg:order-first text-[10px] font-black uppercase tracking-[0.25em] text-[color:var(--foreground)] sm:text-sm sm:tracking-[0.35em]"
             href="/"
           >
             CM
           </Link>
 
-          {/* Mantém o menu centrado no cabeçalho em desktop, inclusive na home. */}
-          <div className="lg:absolute lg:left-1/2 lg:-translate-x-1/2">
+          {/* Mobile: hamburger fica à esquerda (order-first); desktop: nav centrada via absolute. */}
+          <div className="order-first lg:order-none lg:absolute lg:left-1/2 lg:-translate-x-1/2">
             <TopNav />
           </div>
 
           {/* Mantém uma única instância das ações para evitar renderização duplicada e navegação menos fluída. */}
-          <div className="max-w-[calc(100%-120px)] sm:max-w-none">
+          <div className="order-last max-w-[calc(100%-120px)] sm:max-w-none">
             <HeaderActions />
           </div>
         </div>

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -112,7 +112,7 @@ export default function TopNav() {
                     isActive
                       ? "bg-[#1d8478]"
                       : "hover:bg-[#1d8478]"
-                  } ${isLast ? "border-b-0" : "border-b border-white/30"}`}
+                  } ${isLast ? "border-b-0" : "border-b border-[#22a094]/20"}`}
                   href={item.href}
                   onClick={closeMenu}
                 >

--- a/app/globals.css
+++ b/app/globals.css
@@ -498,13 +498,13 @@ h6 {
     height: 22px;
   }
 
-  /* Desenha cada traço do símbolo em cinzento e habilita transição para o X. */
+  /* Desenha cada traço do símbolo em verde e habilita transição para o X. */
   .menu-toggle-line {
     display: block;
     width: 100%;
     height: 3px;
     border-radius: 999px;
-    background-color: #e2e0e0;
+    background-color: #22a094;
     transition: all 0.35s ease;
   }
 
@@ -543,8 +543,8 @@ h6 {
     border-radius: 14px;
     will-change: contents;
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18) !important;
-    border: 1px solid rgba(255, 255, 255, 0.1) !important;
-    background: #feb1a5 !important;
+    border: 1px solid rgba(34, 160, 148, 0.2) !important;
+    background: #ffffff !important;
   }
 
   @media (max-width: 480px) {
@@ -555,7 +555,7 @@ h6 {
 
   /* Garante contraste e área de toque confortável nas opções do menu mobile. */
   .mobile-menu-item {
-    color: #ffffff !important;
+    color: #22a094 !important;
     min-height: 48px;
     display: flex;
     align-items: center;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default function HomePage() {
           <div className="mb-16 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
             <CheckoutButton label="Comprar o curso — 19.99€" />
             <Link
-              href="#what-included"
+              href="/o-curso"
               className="site-pill-button-secondary"
             >
               Ver o programa


### PR DESCRIPTION
- 'Ver o programa' now navigates to /o-curso instead of anchoring to #what-included
- Hamburger menu moved to left side on mobile (before CM logo) via flex order
- Mobile menu background changed to white with green (#22a094) text
- Hamburger lines changed to green for visibility on light header
- Menu item dividers updated to subtle teal border

https://claude.ai/code/session_01Q1hKdqxNYJTWiscL89NvUT