### PR TITLE
Combine price range into single line with nowrap

### DIFF
--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -47,8 +47,7 @@ export default function CoursePage() {
                 <p className="text-body-xs">Módulos</p>
               </div>
               <div className="text-center">
-                <p className="h4 text-teal-600">5€–</p>
-                <p className="h4 text-teal-600">150€+</p>
+                <p className="h4 text-teal-600 whitespace-nowrap">5€–150€+</p>
                 <p className="text-body-xs">Por mês</p>
               </div>
               <div className="text-center">


### PR DESCRIPTION
## Summary
Refactored the pricing display on the course page to show the price range as a single line instead of two separate lines.

## Key Changes
- Combined the two separate price range elements (`5€–` and `150€+`) into a single paragraph
- Added `whitespace-nowrap` class to prevent the price range from wrapping across multiple lines
- Maintains the same visual styling with `h4` heading and `text-teal-600` color classes

## Implementation Details
This change improves the layout by ensuring the price range stays on a single line, providing a cleaner and more compact presentation of the pricing information in the course overview section.

https://claude.ai/code/session_014neSnF9QqKUmm7EHjTTeEj