### PR TITLE
Fix spacing in checkout button price label

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -249,7 +249,7 @@ export default function HomePage() {
               </div>
             </div>
 
-            <CheckoutButton label={<>Comprar o curso — <span className="line-through opacity-70">64,99€</span> <span>24,99€</span></>} />
+            <CheckoutButton label={<>Comprar o curso — <span className="line-through opacity-70">64,99€</span> <span> 24,99€</span></>} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Minor formatting fix to improve spacing in the checkout button's price display label.

## Changes
- Added a space before the discounted price (24,99€) in the CheckoutButton label on the homepage
- This ensures consistent spacing between the strikethrough original price and the new discounted price

## Details
The change adds a single space character before the `24,99€` span element, improving the visual presentation of the price comparison in the checkout button label.

https://claude.ai/code/session_01KNx1SrCxnp5cLzpkMQ52HJ