### PR TITLE
Fix spacing in checkout button price labels

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,7 @@ export default function HomePage() {
 
           {/* CTA Buttons */}
           <div className="mb-16 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
-            <CheckoutButton label={<>Comprar o curso — <span className="line-through opacity-70">64,99€</span> <span> 24,99€</span></>} />
+            <CheckoutButton label={<>Comprar o curso — <span className="line-through opacity-70">64,99€</span>  <span>24,99€</span></>} />
             <Link
               href="/o-curso"
               className="site-pill-button-secondary"
@@ -249,7 +249,7 @@ export default function HomePage() {
               </div>
             </div>
 
-            <CheckoutButton label={<>Comprar o curso — <span className="line-through opacity-70">64,99€</span> <span> 24,99€</span></>} />
+            <CheckoutButton label={<>Comprar o curso — <span className="line-through opacity-70">64,99€</span>  <span>24,99€</span></>} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
This PR fixes inconsistent spacing in the checkout button price labels throughout the homepage.

## Changes
- Standardized spacing between the strikethrough original price and the discounted price in checkout button labels
- Updated two instances of the CheckoutButton component to use consistent double-space formatting between price elements
- Changes made on lines 34 and 252 in `app/page.tsx`

## Details
The spacing between the struck-through original price (64,99€) and the new discounted price (24,99€) was inconsistent. This fix ensures uniform formatting across all checkout buttons by using a consistent spacing pattern in the JSX markup.

https://claude.ai/code/session_012VpX9XDARAWsy2dUbxz8Wt