### PR TITLE
Rebrand contact email and project name to clientemisterio

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -17,7 +17,7 @@ type ContactMessageRow = {
   id: string;
 };
 
-const contactRecipient = "vozpublica.contacto@gmail.com";
+const contactRecipient = "clientemisterio.suporte@gmail.com";
 
 const sanitizeText = (value: string) => value.replace(/\s+/g, " ").trim();
 
@@ -147,7 +147,7 @@ export async function POST(request: Request) {
       return NextResponse.json(
         {
           message:
-            "A sua mensagem foi registada, mas o envio para vozpublica.contacto@gmail.com falhou porque a conta de e-mail está em modo de testes. Verifique a configuração do domínio no Resend.",
+            "A sua mensagem foi registada, mas o envio para clientemisterio.suporte@gmail.com falhou porque a conta de e-mail está em modo de testes. Verifique a configuração do domínio no Resend.",
           reference: contactId,
         },
         { status: 503 },
@@ -157,7 +157,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         message:
-          "A sua mensagem foi registada, mas não foi possível enviar o e-mail para vozpublica.contacto@gmail.com neste momento.",
+          "A sua mensagem foi registada, mas não foi possível enviar o e-mail para clientemisterio.suporte@gmail.com neste momento.",
         reference: contactId,
       },
       { status: 502 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vozpublica",
+  "name": "clientemisterio",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vozpublica",
+      "name": "clientemisterio",
       "version": "0.1.0",
       "dependencies": {
         "next": "^16.2.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vozpublica",
+  "name": "clientemisterio",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: vozpublica
+    name: clientemisterio
     env: node
     plan: free
     buildCommand: npm ci && npm run build


### PR DESCRIPTION
## Summary
This PR updates the project branding from "vozpublica" to "clientemisterio" across configuration and contact handling files.

## Key Changes
- Updated contact recipient email from `vozpublica.contacto@gmail.com` to `clientemisterio.suporte@gmail.com` in the contact API route
- Updated error messages to reference the new email address in both test mode and general failure scenarios
- Updated project name in `package.json` from "vozpublica" to "clientemisterio"
- Updated service name in `render.yaml` deployment configuration from "vozpublica" to "clientemisterio"

## Implementation Details
All references to the old branding have been consistently replaced throughout the contact form API and configuration files. The changes ensure that contact form submissions and error messages will now reference the correct support email address and project identity.

https://claude.ai/code/session_01E4sBLBwpawn1f2h2RW5Enf