### PR TITLE
Update course progress labels to Portuguese

### DIFF
--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -691,11 +691,11 @@ export default function CursoPage() {
         </div>
         <div className="flex flex-col items-center justify-center rounded-2xl border border-[#D4B5A0]/30 bg-white p-6">
           <p className="text-3xl font-bold text-[#2a2a2a]">{totalModules - (progress?.completedCount ?? 0)}</p>
-          <p className="text-xs text-[#666] mt-2 font-medium">Lecionados</p>
+          <p className="text-xs text-[#666] mt-2 font-medium">Em falta</p>
         </div>
         <div className="flex flex-col items-center justify-center rounded-2xl border border-[#D4B5A0]/30 bg-white p-6">
           <p className="text-3xl font-bold text-[#2a2a2a]">{completedCount}</p>
-          <p className="text-xs text-[#666] mt-2 font-medium">Completados</p>
+          <p className="text-xs text-[#666] mt-2 font-medium">Finalizado(s)</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Updated the course progress tracking labels to use more accurate Portuguese terminology that better reflects the meaning of each metric.

## Changes
- Changed "Lecionados" to "Em falta" for the remaining modules counter - this label now correctly indicates modules that are still pending/missing
- Changed "Completados" to "Finalizado(s)" for the completed modules counter - this provides a more natural Portuguese phrasing for completed items

## Details
These label updates improve clarity in the course progress dashboard by using terminology that more accurately describes what each metric represents to Portuguese-speaking users.

https://claude.ai/code/session_01LMwKnT7KjsrKzeeABR5NUJ