### PR TITLE
Refactor LanguageSwitcher to use emoji flags and improve styling

### DIFF
--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -5,26 +5,25 @@ import { useLanguage } from "@/app/context/LanguageContext";
 export default function LanguageSwitcher() {
   const { language, setLanguage } = useLanguage();
 
+  const buttonClass = (isActive: boolean) =>
+    `flex items-center justify-center gap-1 px-3 py-1.5 rounded-md border-2 font-medium text-sm transition-all ${
+      isActive
+        ? "border-[#22a094] bg-teal-50 text-gray-900 shadow-sm"
+        : "border-transparent text-gray-600 hover:bg-gray-100"
+    }`;
+
   return (
-    <div className="flex items-center justify-center gap-2 py-2">
+    <div className="flex items-center justify-center gap-1">
       <button
         type="button"
         onClick={() => setLanguage("pt")}
         aria-label="Português"
         aria-pressed={language === "pt"}
-        className={`flex h-7 w-10 items-center justify-center overflow-hidden rounded-sm border-2 transition-all ${
-          language === "pt"
-            ? "border-[#22a094] opacity-100 shadow-sm"
-            : "border-transparent opacity-60 hover:opacity-100"
-        }`}
+        className={buttonClass(language === "pt")}
         title="Português"
       >
-        <svg viewBox="0 0 600 400" className="h-full w-full" xmlns="http://www.w3.org/2000/svg">
-          <rect width="240" height="400" fill="#006600" />
-          <rect x="240" width="360" height="400" fill="#FF0000" />
-          <circle cx="240" cy="200" r="80" fill="#FFFF00" stroke="#000" strokeWidth="2" />
-          <circle cx="240" cy="200" r="55" fill="#0033A0" />
-        </svg>
+        <span className="text-lg">🇵🇹</span>
+        <span className="hidden sm:inline">PT</span>
       </button>
 
       <button
@@ -32,20 +31,11 @@ export default function LanguageSwitcher() {
         onClick={() => setLanguage("en")}
         aria-label="English"
         aria-pressed={language === "en"}
-        className={`flex h-7 w-10 items-center justify-center overflow-hidden rounded-sm border-2 transition-all ${
-          language === "en"
-            ? "border-[#22a094] opacity-100 shadow-sm"
-            : "border-transparent opacity-60 hover:opacity-100"
-        }`}
+        className={buttonClass(language === "en")}
         title="English"
       >
-        <svg viewBox="0 0 60 40" className="h-full w-full" xmlns="http://www.w3.org/2000/svg">
-          <rect width="60" height="40" fill="#012169" />
-          <path d="M0,0 L60,40 M60,0 L0,40" stroke="#FFFFFF" strokeWidth="6" />
-          <path d="M0,0 L60,40 M60,0 L0,40" stroke="#C8102E" strokeWidth="3" />
-          <path d="M30,0 L30,40 M0,20 L60,20" stroke="#FFFFFF" strokeWidth="10" />
-          <path d="M30,0 L30,40 M0,20 L60,20" stroke="#C8102E" strokeWidth="6" />
-        </svg>
+        <span className="text-lg">🇬🇧</span>
+        <span className="hidden sm:inline">EN</span>
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
Simplified the LanguageSwitcher component by replacing custom SVG flag implementations with emoji flags and text labels, while improving the overall styling consistency and responsiveness.

## Key Changes
- **Replaced SVG flags with emoji flags**: Removed complex SVG implementations for Portuguese and English flags, replacing them with native emoji flags (🇵🇹 and 🇬🇧)
- **Added text labels**: Included language code labels (PT/EN) that are hidden on mobile and visible on larger screens using Tailwind's `sm:` breakpoint
- **Extracted button styling**: Created a reusable `buttonClass` function to eliminate duplicate className logic between the two language buttons
- **Improved styling**:
  - Updated active state styling with better visual feedback (teal border, light background, shadow)
  - Improved inactive state with transparent border and hover effect
  - Reduced container gap from `gap-2` to `gap-1` for tighter spacing
  - Removed vertical padding from container (`py-2`)
- **Enhanced accessibility**: Maintained existing `aria-label` and `aria-pressed` attributes for screen readers

## Implementation Details
The new `buttonClass` function uses a ternary operator to conditionally apply active/inactive styles, reducing code duplication and making future style updates easier. The emoji + text approach is more maintainable than custom SVG flags and provides better performance.

https://claude.ai/code/session_01Krp8eNhtLavHKneVdJvUxM