### PR TITLE
Reduce font sizes across all pages for improved readability

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -12,7 +12,7 @@
 .page {
   background: var(--background);
   color: #111827;
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.65;
   font-family: "Google Sans", sans-serif;
 }
@@ -50,7 +50,7 @@
   letter-spacing: -0.035em;
   line-height: 0.98;
   color: #111827;
-  font-size: clamp(40px, 5.5vw, 72px);
+  font-size: clamp(26px, 3.5vw, 48px);
   margin: 0;
 }
 .italic {
@@ -60,7 +60,7 @@
   color: var(--accent);
 }
 .lead {
-  font-size: clamp(17px, 1.4vw, 21px);
+  font-size: clamp(14px, 1.1vw, 17px);
   line-height: 1.55;
   color: #374151;
   max-width: 56ch;
@@ -125,7 +125,7 @@
 
 /* Advantages */
 .advTitle {
-  font-size: clamp(28px, 3vw, 40px);
+  font-size: clamp(18px, 2.2vw, 28px);
   font-weight: 700;
   letter-spacing: -0.025em;
   line-height: 1.1;
@@ -133,7 +133,7 @@
   margin: 0 0 16px;
 }
 .advDesc {
-  font-size: 17px;
+  font-size: 15px;
   color: #4b5563;
   line-height: 1.6;
   margin: 0 0 32px;
@@ -183,7 +183,7 @@
 }
 .cardEyebrow { margin-bottom: 16px; }
 .price {
-  font-size: 52px;
+  font-size: 36px;
   font-weight: 700;
   letter-spacing: -0.04em;
   color: #111827;

--- a/app/catalogo/page.tsx
+++ b/app/catalogo/page.tsx
@@ -72,7 +72,7 @@ export default function CatalogPage() {
                 <p className="mb-2 text-sm font-semibold tracking-wide text-white/70">
                   {c.trainingLabel}
                 </p>
-                <h1 className="text-3xl font-bold leading-tight">
+                <h1 className="text-xl font-bold leading-tight">
                   {c.courseTitle}
                 </h1>
                 <p className="mt-3 max-w-md text-base leading-relaxed text-white/85">
@@ -80,7 +80,7 @@ export default function CatalogPage() {
                 </p>
               </div>
               <div className="shrink-0 text-right">
-                <p className="text-4xl font-bold">24,99€</p>
+                <p className="text-lg font-bold">24,99€</p>
                 <p className="text-sm text-white/70 line-through">64,99€</p>
                 <p className="mt-1 text-xs text-white/70">{c.lifetimeAccess}</p>
               </div>
@@ -89,19 +89,19 @@ export default function CatalogPage() {
             {/* Stats */}
             <div className="mt-8 grid grid-cols-4 gap-4 border-t border-white/20 pt-6">
               <div className="text-center">
-                <p className="text-2xl font-bold">10</p>
+                <p className="text-lg font-bold">10</p>
                 <p className="text-xs text-white/75 mt-0.5">{c.statsModules}</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold">+500</p>
+                <p className="text-lg font-bold">+500</p>
                 <p className="text-xs text-white/75 mt-0.5">{c.statsStudents}</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold">100%</p>
+                <p className="text-lg font-bold">100%</p>
                 <p className="text-xs text-white/75 mt-0.5">{c.statsOnline}</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold">PDF</p>
+                <p className="text-lg font-bold">PDF</p>
                 <p className="text-xs text-white/75 mt-0.5">{c.statsCertificate}</p>
               </div>
             </div>
@@ -197,7 +197,7 @@ export default function CatalogPage() {
                 <p className="text-xs text-[#666] mt-0.5">{c.footerUrl}</p>
               </div>
               <div className="text-right">
-                <p className="text-2xl font-bold text-[#22a094]">24,99€</p>
+                <p className="text-lg font-bold text-[#22a094]">24,99€</p>
                 <p className="text-xs text-[#666]">{c.footerAccessNote}</p>
               </div>
             </div>

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -19,7 +19,7 @@ export default function CheckoutPage() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center space-y-4">
-        <h1 className="text-3xl font-semibold home-title-highlight-text">Redirecionando para pagamento...</h1>
+        <h1 className="text-xl font-semibold home-title-highlight-text">Redirecionando para pagamento...</h1>
         <p className="text-sm sm:text-base leading-6 sm:leading-7">Se não for redirecionado automaticamente,</p>
         {paymentLink && (
           <a

--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -28,7 +28,7 @@ export default function ThreePointsCards() {
           className="flex min-h-[180px] flex-col items-center justify-center gap-3 rounded-[24px] p-6 text-center transition duration-300 hover:-translate-y-2 hover:shadow-lg sm:min-h-[240px] sm:gap-4 sm:p-10 md:min-h-[260px]"
           style={{ backgroundColor: "#22a094" }}
         >
-          <h3 className="text-xl font-bold text-white sm:text-2xl leading-tight">{benefit.title}</h3>
+          <h3 className="text-base font-bold text-white sm:text-lg leading-tight">{benefit.title}</h3>
           <p className="text-sm leading-6 text-white sm:text-base sm:leading-7">{benefit.description}</p>
         </div>
       ))}

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -11,7 +11,7 @@
 .page {
   background: var(--background);
   color: #111827;
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.65;
   font-family: "Google Sans", sans-serif;
 }
@@ -49,7 +49,7 @@
   letter-spacing: -0.035em;
   line-height: 0.98;
   color: #111827;
-  font-size: clamp(40px, 5.5vw, 72px);
+  font-size: clamp(26px, 3.5vw, 48px);
   margin: 0;
 }
 .italic {
@@ -59,7 +59,7 @@
   color: var(--accent);
 }
 .lead {
-  font-size: clamp(17px, 1.4vw, 21px);
+  font-size: clamp(14px, 1.1vw, 17px);
   line-height: 1.55;
   color: #374151;
   max-width: 56ch;

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -44,7 +44,7 @@
 .page {
   background: var(--background);
   color: var(--foreground);
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.65;
   font-family: "Google Sans", sans-serif;
   min-height: 100vh;
@@ -84,8 +84,8 @@
   color: #111827;
   margin: 0;
 }
-.displayXl { font-size: clamp(40px, 5.5vw, 72px); }
-.displayLg { font-size: clamp(32px, 4vw, 52px); }
+.displayXl { font-size: clamp(26px, 3.5vw, 48px); }
+.displayLg { font-size: clamp(20px, 2.8vw, 36px); }
 
 /* ============================================================
    BUTTONS
@@ -169,7 +169,7 @@
   letter-spacing: -0.025em;
 }
 .courseHeadSub {
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.55;
   color: #4b5563;
   margin: 0;
@@ -195,7 +195,7 @@
 }
 .progressCardCount {
   font-family: "Google Sans", sans-serif;
-  font-size: 44px;
+  font-size: 32px;
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1;
@@ -209,7 +209,7 @@
   margin: 0 2px;
 }
 .progressCardCount span {
-  font-size: 22px;
+  font-size: 16px;
   font-weight: 500;
   color: #4b5563;
   margin-left: 6px;
@@ -314,7 +314,7 @@
   font-family: "Basenji", Georgia, serif;
   font-style: italic;
   font-weight: 600;
-  font-size: 42px;
+  font-size: 28px;
   letter-spacing: -0.02em;
   line-height: 1;
   color: #9ca3af;
@@ -324,7 +324,7 @@
 .modCurrent .modNum { color: var(--accent); }
 .modBody { min-width: 0; }
 .modTitle {
-  font-size: clamp(18px, 1.7vw, 22px);
+  font-size: clamp(14px, 1.4vw, 17px);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: #111827;
@@ -411,7 +411,7 @@
 }
 .certBlockCopy { position: relative; max-width: 56ch; }
 .certBlockTitle {
-  font-size: clamp(24px, 2.2vw, 32px);
+  font-size: clamp(17px, 1.8vw, 24px);
   font-weight: 700;
   letter-spacing: -0.02em;
   margin: 0 0 8px;
@@ -576,7 +576,7 @@
   background: var(--accent);
 }
 .readerHeading {
-  font-size: clamp(32px, 4vw, 48px);
+  font-size: clamp(22px, 3vw, 34px);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.05;
@@ -585,7 +585,7 @@
   max-width: 22ch;
 }
 .readerH2 {
-  font-size: 28px;
+  font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
   margin: 32px 0 20px;
@@ -595,7 +595,7 @@
   font-family: "Basenji", Georgia, serif;
   font-style: italic;
   font-weight: 600;
-  font-size: 22px;
+  font-size: 17px;
   line-height: 1.4;
   letter-spacing: -0.01em;
   color: #111827;
@@ -606,7 +606,7 @@
   text-wrap: pretty;
 }
 .readerProse {
-  font-size: 18px;
+  font-size: 15px;
   line-height: 1.7;
   color: #374151;
   text-align: justify;
@@ -835,7 +835,7 @@
 }
 .quizHead { margin-bottom: 32px; }
 .quizTitle {
-  font-size: clamp(28px, 3.4vw, 40px);
+  font-size: clamp(18px, 2.4vw, 28px);
   font-weight: 700;
   letter-spacing: -0.025em;
   margin: 0 0 12px;
@@ -871,7 +871,7 @@
   margin: 0 0 8px;
 }
 .qText {
-  font-size: 19px;
+  font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.015em;
   line-height: 1.4;
@@ -972,7 +972,7 @@
   font-family: "Basenji", Georgia, serif;
   font-style: italic;
   font-weight: 600;
-  font-size: 120px;
+  font-size: 72px;
   line-height: 1;
   letter-spacing: -0.04em;
   color: var(--accent);
@@ -980,7 +980,7 @@
 }
 .resultScoreFail { color: #dc2626 !important; }
 .resultScore span {
-  font-size: 56px;
+  font-size: 36px;
   margin-left: -4px;
 }
 .resultLabel {
@@ -992,7 +992,7 @@
   margin: 16px 0 12px;
 }
 .resultTitle {
-  font-size: 28px;
+  font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.025em;
   margin: 0 0 8px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -638,7 +638,7 @@ h6 {
 
   /* Legacy classes for backward compatibility */
   .page-title {
-    font-size: 2.25rem;
+    font-size: 1.625rem;
     line-height: 1.2;
     font-weight: 700;
     color: #111827;
@@ -647,12 +647,12 @@ h6 {
 
   @media (min-width: 640px) {
     .page-title {
-      font-size: 3rem;
+      font-size: 2rem;
     }
   }
 
   .section-title {
-    font-size: 1.875rem;
+    font-size: 1.375rem;
     line-height: 1.2;
     font-weight: 700;
     color: #111827;
@@ -661,12 +661,12 @@ h6 {
 
   @media (min-width: 640px) {
     .section-title {
-      font-size: 2.25rem;
+      font-size: 1.75rem;
     }
   }
 
   .section-title-inverse {
-    font-size: 1.875rem;
+    font-size: 1.375rem;
     line-height: 1.2;
     font-weight: 700;
     color: white;
@@ -675,7 +675,7 @@ h6 {
 
   @media (min-width: 640px) {
     .section-title-inverse {
-      font-size: 2.25rem;
+      font-size: 1.75rem;
     }
   }
 

--- a/app/o-curso/page.module.css
+++ b/app/o-curso/page.module.css
@@ -11,7 +11,7 @@
 .page {
   background: var(--background);
   color: #111827;
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.65;
   font-family: "Google Sans", sans-serif;
 }
@@ -53,7 +53,7 @@
   letter-spacing: -0.035em;
   line-height: 0.98;
   color: #111827;
-  font-size: clamp(40px, 5.5vw, 72px);
+  font-size: clamp(26px, 3.5vw, 48px);
   margin: 0;
 }
 .displayMd {
@@ -62,7 +62,7 @@
   letter-spacing: -0.035em;
   line-height: 0.98;
   color: #111827;
-  font-size: clamp(32px, 4vw, 52px);
+  font-size: clamp(20px, 2.8vw, 36px);
   margin: 0;
 }
 .italic {
@@ -72,7 +72,7 @@
   color: var(--accent);
 }
 .lead {
-  font-size: clamp(17px, 1.4vw, 21px);
+  font-size: clamp(14px, 1.1vw, 17px);
   line-height: 1.55;
   color: #374151;
   max-width: 56ch;
@@ -152,7 +152,7 @@
 }
 .stat {}
 .statNum {
-  font-size: clamp(28px, 3vw, 40px);
+  font-size: clamp(18px, 2.2vw, 28px);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1;
@@ -191,7 +191,7 @@
 .cardPriceRow { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
 .cardOrig { font-size: 16px; color: #9ca3af; text-decoration: line-through; font-weight: 500; }
 .cardPrice {
-  font-size: 44px;
+  font-size: 30px;
   font-weight: 700;
   letter-spacing: -0.04em;
   color: var(--accent);
@@ -258,7 +258,7 @@
   .stripItem:last-child { border-right: none; }
 }
 .stripNum {
-  font-size: clamp(32px, 3.5vw, 48px);
+  font-size: clamp(22px, 2.8vw, 34px);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1;
@@ -285,7 +285,7 @@
 @media (min-width: 880px) {
   .head { grid-template-columns: 1.4fr 1fr; gap: 64px; }
 }
-.headSub { font-size: 17px; line-height: 1.6; color: #4b5563; max-width: 44ch; }
+.headSub { font-size: 15px; line-height: 1.6; color: #4b5563; max-width: 44ch; }
 
 .benefits {
   display: grid;
@@ -336,7 +336,7 @@
 .currEyebrow { color: rgba(255,255,255,.6); }
 .currEyebrow::before { background: var(--accent); }
 .currDisplay { color: #fff; }
-.currSub { color: rgba(255,255,255,.65); font-size: 17px; line-height: 1.6; max-width: 44ch; }
+.currSub { color: rgba(255,255,255,.65); font-size: 15px; line-height: 1.6; max-width: 44ch; }
 .currHead {
   display: grid;
   grid-template-columns: 1fr;
@@ -364,13 +364,13 @@
   font-family: "Basenji", Georgia, serif;
   font-style: italic;
   font-weight: 600;
-  font-size: 38px;
+  font-size: 26px;
   letter-spacing: -0.02em;
   line-height: 1;
   color: var(--accent);
 }
 .moduleTitle {
-  font-size: clamp(18px, 2vw, 24px);
+  font-size: clamp(14px, 1.5vw, 18px);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: #fff;
@@ -418,7 +418,7 @@
 .finalEyebrow { color: var(--accent); }
 .finalEyebrow::before { background: var(--accent); }
 .finalTitle {
-  font-size: clamp(32px, 4.5vw, 56px);
+  font-size: clamp(22px, 3vw, 40px);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1;
@@ -431,7 +431,7 @@
   color: var(--accent);
 }
 .finalSub {
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.55;
   color: rgba(255,255,255,.7);
   margin: 0 0 32px;

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -41,7 +41,7 @@
 .page {
   background: var(--background);
   color: var(--foreground);
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.65;
   font-family: "Google Sans", sans-serif;
 }
@@ -86,12 +86,12 @@
   color: #111827;
   margin: 0;
 }
-.displayXl { font-size: clamp(48px, 7.5vw, 104px); }
-.displayLg { font-size: clamp(40px, 5.5vw, 72px); }
-.displayMd { font-size: clamp(32px, 4vw, 52px); }
+.displayXl { font-size: clamp(32px, 4.5vw, 60px); }
+.displayLg { font-size: clamp(26px, 3.5vw, 48px); }
+.displayMd { font-size: clamp(20px, 2.8vw, 36px); }
 
 .lead {
-  font-size: clamp(17px, 1.4vw, 21px);
+  font-size: clamp(14px, 1.1vw, 17px);
   line-height: 1.55;
   color: #374151;
   max-width: 56ch;
@@ -416,7 +416,7 @@
   .stripItem:last-child { border-right: none; }
 }
 .stripNum {
-  font-size: clamp(36px, 4vw, 52px);
+  font-size: clamp(24px, 2.8vw, 38px);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1;
@@ -449,7 +449,7 @@
   .head { grid-template-columns: 1.4fr 1fr; gap: 56px; }
 }
 .headSub {
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.6;
   color: #4b5563;
   max-width: 48ch;
@@ -544,14 +544,14 @@
   font-family: "Basenji", Georgia, serif;
   font-style: italic;
   font-weight: 600;
-  font-size: 38px;
+  font-size: 26px;
   letter-spacing: -0.02em;
   line-height: 1;
   color: var(--accent);
   font-variant-numeric: lining-nums;
 }
 .moduleTitle {
-  font-size: clamp(20px, 2vw, 26px);
+  font-size: clamp(15px, 1.5vw, 18px);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: #fff;
@@ -612,7 +612,7 @@
   padding: 14px 26px;
 }
 .earnType {
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: #111827;
@@ -668,13 +668,13 @@
   font-family: "Basenji", Georgia, serif;
   font-style: italic;
   font-weight: 600;
-  font-size: 56px;
+  font-size: 40px;
   line-height: 0.9;
   color: var(--accent);
   letter-spacing: -0.02em;
 }
 .stepTitle {
-  font-size: clamp(22px, 2.2vw, 30px);
+  font-size: clamp(16px, 1.8vw, 22px);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: #111827;
@@ -707,7 +707,7 @@
   font-family: "Basenji", Georgia, serif;
   font-style: italic;
   font-weight: 600;
-  font-size: clamp(24px, 2.6vw, 36px);
+  font-size: clamp(18px, 2vw, 26px);
   line-height: 1.25;
   letter-spacing: -0.02em;
   color: #111827;
@@ -792,7 +792,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 32px;
-  font-size: clamp(17px, 1.6vw, 21px);
+  font-size: clamp(14px, 1.3vw, 17px);
   font-weight: 600;
   letter-spacing: -0.015em;
   color: #111827;
@@ -867,7 +867,7 @@
 .finalEyebrow { color: var(--accent); }
 .finalEyebrow::before { background: var(--accent); }
 .finalTitle {
-  font-size: clamp(36px, 5vw, 64px);
+  font-size: clamp(24px, 3.2vw, 44px);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1;
@@ -881,7 +881,7 @@
   font-weight: 600;
 }
 .finalSub {
-  font-size: 18px;
+  font-size: 15px;
   line-height: 1.55;
   color: rgba(255,255,255,.7);
   margin: 0 0 32px;
@@ -925,7 +925,7 @@
   font-size: 14px;
 }
 .finalPriceTag strong {
-  font-size: 28px;
+  font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
   color: #fff;

--- a/app/termos-e-condicoes/page.module.css
+++ b/app/termos-e-condicoes/page.module.css
@@ -11,7 +11,7 @@
 .page {
   background: var(--background);
   color: #111827;
-  font-size: 17px;
+  font-size: 15px;
   line-height: 1.65;
   font-family: "Google Sans", sans-serif;
 }
@@ -49,7 +49,7 @@
   letter-spacing: -0.035em;
   line-height: 0.98;
   color: #111827;
-  font-size: clamp(40px, 5.5vw, 72px);
+  font-size: clamp(26px, 3.5vw, 48px);
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
This PR implements a comprehensive font size reduction across the entire application to improve visual hierarchy and readability. All heading, body, and display text sizes have been scaled down proportionally while maintaining the responsive design through adjusted `clamp()` values.

## Key Changes
- **Base font sizes**: Reduced from 17px to 15px across all page modules
- **Display headings**: Scaled down all `displayXl`, `displayLg`, and `displayMd` classes with adjusted viewport-relative sizing
  - `displayXl`: 40-72px → 26-48px range
  - `displayLg`: 32-52px → 20-36px range
- **Section headings**: Reduced all heading sizes including course titles, module titles, and section headers
  - Course head subtitles: 17px → 15px
  - Module titles: clamp(18px, 1.7vw, 22px) → clamp(14px, 1.4vw, 17px)
  - Quiz titles: clamp(28px, 3.4vw, 40px) → clamp(18px, 2.4vw, 28px)
- **Body text**: Reduced prose and content text sizes
  - Reader prose: 18px → 15px
  - Question text: 19px → 15px
- **Large display numbers**: Scaled down prominent numeric displays
  - Progress card count: 44px → 32px
  - Result score: 120px → 72px
  - Module numbers: 42px → 28px
- **Catalog page**: Updated Tailwind classes for course cards and pricing displays
  - Course titles: text-3xl → text-xl
  - Price displays: text-4xl/text-2xl → text-lg
  - Stats numbers: text-2xl → text-lg
- **Global utility classes**: Updated legacy page-title and section-title classes with proportional reductions

## Implementation Details
- All `clamp()` functions were adjusted to maintain responsive scaling while reducing the overall size range
- Viewport-relative percentages (vw) were proportionally reduced to maintain responsive behavior
- Changes applied consistently across all page modules: curso, o-curso, about, contact, termos-e-condicoes, catalogo, and checkout
- Tailwind class updates in component files (ThreePointsCards.tsx, catalogo/page.tsx, checkout/page.tsx) to match new sizing strategy

https://claude.ai/code/session_013cmazTxWSWXXW4aoh9xdwP