### PR TITLE
Apply animated pill button style sitewide

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -228,3 +228,26 @@
   align-items: center;
   justify-content: center;
 }
+
+/* Formato Uiverse para botões desta página. */
+.btn {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: 500px;
+  padding: 0.9rem 2rem;
+  width: fit-content;
+  min-width: 0;
+  height: auto;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0.05rem;
+  line-height: 1.1;
+  background: var(--accent);
+  color: #fff;
+}
+.btn::before,
+.btn::after { content: ""; position: absolute; inset: 0; pointer-events: none; }
+.btn::after { background: var(--accent); z-index: -2; }
+.btn::before { background: var(--brand); width: 120%; left: -10%; transform: skew(30deg); transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1); z-index: -1; }
+.btn:hover::before { transform: translate3d(100%, 0, 0); }

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -248,3 +248,25 @@
   box-shadow: 0 12px 28px -10px rgba(255,107,74,.5);
 }
 .submit:disabled { opacity: .6; cursor: not-allowed; transform: none; }
+
+/* Formato Uiverse para o botão de envio, mantendo a paleta atual. */
+.submit {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: 500px;
+  padding: 0.9rem 2rem;
+  width: fit-content;
+  min-width: 0;
+  height: auto;
+  font-size: 17px;
+  letter-spacing: 0.05rem;
+  line-height: 1.1;
+  background: var(--accent);
+  color: #fff;
+}
+.submit::before,
+.submit::after { content: ""; position: absolute; inset: 0; pointer-events: none; }
+.submit::after { background: var(--accent); z-index: -2; }
+.submit::before { background: var(--brand); width: 120%; left: -10%; transform: skew(30deg); transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1); z-index: -1; }
+.submit:hover::before { transform: translate3d(100%, 0, 0); }

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -1011,3 +1011,52 @@
   justify-content: center;
   flex-wrap: wrap;
 }
+
+/* Formato Uiverse para botões da página do curso, preservando as cores atuais. */
+.btn,
+.readerBack {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: 500px;
+  padding: 0.9rem 2rem;
+  width: fit-content;
+  min-width: 0;
+  height: auto;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0.05rem;
+  line-height: 1.1;
+  background: var(--button-hover-bg, var(--brand-700));
+  color: var(--button-fg, #fff);
+  transition: color 0.4s, transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+}
+.btn::before,
+.btn::after,
+.readerBack::before,
+.readerBack::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.btn::after,
+.readerBack::after { background: var(--button-hover-bg, var(--brand-700)); z-index: -2; }
+.btn::before,
+.readerBack::before {
+  background: var(--button-bg, var(--brand));
+  width: 120%;
+  left: -10%;
+  transform: skew(30deg);
+  transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  z-index: -1;
+}
+.btn:hover:not(:disabled)::before,
+.readerBack:hover:not(:disabled)::before { transform: translate3d(100%, 0, 0); }
+.btnPrimary { --button-bg: var(--brand); --button-hover-bg: var(--accent); --button-fg: #fff; }
+.btnAccent { --button-bg: var(--accent); --button-hover-bg: var(--accent-600); --button-fg: #fff; }
+.btnGhost,
+.readerBack { --button-bg: transparent; --button-hover-bg: var(--brand); --button-fg: var(--ink); }
+.btnGhost:hover:not(:disabled),
+.readerBack:hover:not(:disabled) { color: #fff; }
+.btnSmall { padding: 0.75rem 1.4rem; font-size: 14px; }

--- a/app/faq/page.module.css
+++ b/app/faq/page.module.css
@@ -194,3 +194,25 @@
 }
 .ctaBtn svg { transition: transform .2s; }
 .ctaBtn:hover svg { transform: translateX(3px); }
+
+/* Formato Uiverse para o CTA da FAQ. */
+.ctaBtn {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: 500px;
+  padding: 0.9rem 2rem;
+  width: fit-content;
+  min-width: 0;
+  height: auto;
+  font-size: 17px;
+  letter-spacing: 0.05rem;
+  line-height: 1.1;
+  background: #f5502e;
+  color: #fff;
+}
+.ctaBtn::before,
+.ctaBtn::after { content: ""; position: absolute; inset: 0; pointer-events: none; }
+.ctaBtn::after { background: #f5502e; z-index: -2; }
+.ctaBtn::before { background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%); width: 120%; left: -10%; transform: skew(30deg); transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1); z-index: -1; }
+.ctaBtn:hover::before { transform: translate3d(100%, 0, 0); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -171,34 +171,74 @@ h6 {
 
   /* Estilo global aplicado a <button> sem classe utilitária. */
   button {
+    --button-bg: var(--brand);
+    --button-hover-bg: var(--brand-700);
+    --button-fg: white;
+    --button-hover-fg: white;
+    --button-shadow: 0 14px 26px -12px rgba(79, 70, 229, 0.6);
     outline: none;
     cursor: pointer;
     border: none;
-    padding: 0.65em 1.4em;
+    padding: 0.9rem 2rem;
     margin: 0;
-    font-family: "Plus Jakarta Sans", sans-serif;
-    font-size: 14px;
+    font-family: inherit;
+    font-size: 17px;
     position: relative;
     display: inline-flex;
     align-items: center;
-    letter-spacing: 0.01em;
-    font-weight: 600;
-    border-radius: 14px;
+    justify-content: center;
+    gap: 0.65rem;
+    letter-spacing: 0.05rem;
+    font-weight: 700;
+    border-radius: 500px;
     overflow: hidden;
-    background: var(--brand);
-    color: white;
-    box-shadow: 0 12px 24px -12px rgba(79, 70, 229, 0.55);
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    width: auto;
-    min-width: auto;
+    background: var(--button-hover-bg);
+    color: var(--button-fg);
+    box-shadow: var(--button-shadow);
+    transition: color 0.4s, transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+    width: fit-content;
+    min-width: 0;
+    isolation: isolate;
+    white-space: nowrap;
+    line-height: 1.1;
   }
 
-  button:hover {
+  button::before,
+  button::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  button::after {
+    background: var(--button-hover-bg);
+    z-index: -2;
+  }
+
+  button::before {
+    background: var(--button-bg);
+    width: 120%;
+    left: -10%;
+    transform: skew(30deg);
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+    z-index: -1;
+  }
+
+  button:hover:not(:disabled) {
+    color: var(--button-hover-fg);
     transform: translateY(-2px);
-    box-shadow: 0 18px 30px -12px rgba(79, 70, 229, 0.6);
+    box-shadow: 0 20px 32px -12px rgba(79, 70, 229, 0.65);
   }
 
-  button:active {
+  button:hover:not(:disabled)::before {
+    transform: translate3d(100%, 0, 0);
+  }
+
+  button:active:not(:disabled) {
     transform: translateY(0);
     box-shadow: 0 8px 16px -10px rgba(79, 70, 229, 0.5);
   }
@@ -207,11 +247,13 @@ h6 {
     opacity: 0.6;
     cursor: not-allowed;
     transform: none;
+    box-shadow: none;
   }
 
   button span {
     position: relative;
     z-index: 10;
+    transition: color 0.4s;
   }
 
   /* === SISTEMA PADRONIZADO DE BOTÕES === */
@@ -1226,4 +1268,88 @@ main a:not(.site-pill-button):not(.button-size-login):not(.form-link):not(.site-
 main a:not(.site-pill-button):not(.button-size-login):not(.form-link):not(.site-pill-button-secondary):hover {
   border-bottom-color: var(--accent);
   color: var(--accent-600);
+}
+
+/* Formato Uiverse aplicado aos botões/CTAs do site, preservando a paleta atual por variante. */
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button) {
+  --button-bg: var(--brand);
+  --button-hover-bg: var(--brand-700);
+  --button-fg: #fff;
+  --button-hover-fg: #fff;
+  --button-shadow: 0 14px 26px -12px rgba(79, 70, 229, 0.6);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border: none;
+  border-radius: 500px;
+  padding: 0.9rem 2rem;
+  width: fit-content;
+  min-width: 0;
+  height: auto;
+  color: var(--button-fg) !important;
+  background: var(--button-hover-bg) !important;
+  font-family: inherit;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0.05rem;
+  line-height: 1.1;
+  white-space: nowrap;
+  box-shadow: var(--button-shadow);
+  transition: color 0.4s, transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+}
+
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button)::before,
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button)::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button)::after {
+  background: var(--button-hover-bg);
+  z-index: -2;
+}
+
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button)::before {
+  background: var(--button-bg);
+  width: 120%;
+  left: -10%;
+  transform: skew(30deg);
+  transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  z-index: -1;
+}
+
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button):hover:not(:disabled) {
+  color: var(--button-hover-fg) !important;
+  transform: translateY(-2px);
+  box-shadow: 0 20px 32px -12px rgba(79, 70, 229, 0.65);
+}
+
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button):hover:not(:disabled)::before {
+  transform: translate3d(100%, 0, 0);
+}
+
+:is(.btn-primary, .btn-secondary, .site-pill-button, .button-size-login, .site-pill-button-secondary, .submit, .cssbuttons-io-button):disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+:is(.btn-primary, .site-pill-button, .button-size-login, .submit, .cssbuttons-io-button) {
+  --button-bg: var(--brand);
+  --button-hover-bg: var(--brand-700);
+}
+
+:is(.btn-secondary, .site-pill-button.nav-login-btn, .site-pill-button-secondary) {
+  --button-bg: #fff;
+  --button-hover-bg: var(--brand-soft);
+  --button-fg: var(--brand-700);
+  --button-hover-fg: var(--brand-700);
+  --button-shadow: none;
+  border: 1.5px solid var(--brand-soft);
 }

--- a/app/o-curso/page.module.css
+++ b/app/o-curso/page.module.css
@@ -529,3 +529,28 @@
 }
 .finalCta { display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; }
 .btnBlock { width: 100%; max-width: 340px; }
+
+/* Formato Uiverse para CTAs da página do curso. */
+.btn {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: 500px;
+  padding: 0.9rem 2rem;
+  width: fit-content;
+  min-width: 0;
+  height: auto;
+  font-size: 17px;
+  letter-spacing: 0.05rem;
+  line-height: 1.1;
+  background: var(--button-hover-bg, var(--brand-700));
+  color: #fff;
+}
+.btn::before,
+.btn::after { content: ""; position: absolute; inset: 0; pointer-events: none; }
+.btn::after { background: var(--button-hover-bg, var(--brand-700)); z-index: -2; }
+.btn::before { background: var(--button-bg, var(--brand)); width: 120%; left: -10%; transform: skew(30deg); transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1); z-index: -1; }
+.btn:hover::before { transform: translate3d(100%, 0, 0); }
+.btnDark { --button-bg: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%); --button-hover-bg: #4338ca; }
+.btnAccent { --button-bg: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%); --button-hover-bg: #f5502e; }
+.btnBlock { width: fit-content; max-width: none; }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -771,3 +771,43 @@
   transition: opacity .8s ease, transform .8s cubic-bezier(.22,.61,.36,1);
 }
 .fadeUpIn { opacity: 1; transform: translateY(0); }
+
+/* Formato Uiverse para CTAs desta página, mantendo as cores das variantes atuais. */
+.btn {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: 500px;
+  padding: 0.9rem 2rem;
+  width: fit-content;
+  min-width: 0;
+  height: auto;
+  font-size: 17px;
+  letter-spacing: 0.05rem;
+  line-height: 1.1;
+  background: var(--button-hover-bg, var(--brand-700));
+  color: var(--button-fg, #fff);
+  transition: color 0.4s, transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+}
+.btn::before,
+.btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.btn::after { background: var(--button-hover-bg, var(--brand-700)); z-index: -2; }
+.btn::before {
+  background: var(--button-bg, var(--brand));
+  width: 120%;
+  left: -10%;
+  transform: skew(30deg);
+  transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  z-index: -1;
+}
+.btn:hover::before { transform: translate3d(100%, 0, 0); }
+.btnPrimary { --button-bg: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%); --button-hover-bg: #f5502e; --button-fg: #fff; }
+.btnGhost { --button-bg: #fff; --button-hover-bg: var(--brand-soft); --button-fg: var(--brand-700); }
+.finalBtn,
+.buyBarBtn { --button-bg: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%); --button-hover-bg: #f5502e; --button-fg: #fff; }
+.btnSmall { padding: 0.75rem 1.4rem; font-size: 14px; }


### PR DESCRIPTION
### Motivation
- Standardize all site buttons to the requested Uiverse-style pill shape and animated skewed hover wipe while keeping the current brand colour variants. 
- Ensure button width follows the text content and that visual variants (primary/ghost/submit/etc.) preserve their existing colours.

### Description
- Reworked global button rules in `app/globals.css` to a pill style (`border-radius: 500px`) with `width: fit-content`, larger base font/padding, CSS variables for per-variant colours, and pseudo-elements (`::before`/`::after`) implementing the skewed hover wipe and animations. 
- Added a sitewide convenience selector for existing CTA classes to adopt the same format (`:is(.btn-primary, .btn-secondary, .site-pill-button, .submit, .cssbuttons-io-button, ...)`) and mapped variant-specific variables so colours are preserved. 
- Applied the Uiverse format to page-scoped styles by adding compatible rules to `app/page.module.css`, `app/curso/page.module.css`, `app/o-curso/page.module.css`, `app/about/page.module.css`, `app/contact/page.module.css`, and `app/faq/page.module.css` so page-local `.btn`, `.submit`, `.ctaBtn`, `.readerBack` and similar selectors follow the new behavior. 
- Kept touch/disabled/active states and preserved existing box-shadow/hover behaviour while centralizing visual tokens via CSS variables for easy tuning.

### Testing
- Ran `npm run build` which completed successfully and produced the optimized production build. 
- Ran `npm run lint` which failed due to the environment/Next.js lint command resolving to an invalid project path (not a code error in the style changes). 
- Started the dev server with `npm run dev` successfully for local inspection; an automated screenshot attempt using Playwright failed because `playwright` is not installed in the repository (dependency missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62242a1694832daa19a486868ac20c)