### PR TITLE
Aplicar formato "skew wipe" (Uiverse) a todos os botões do site

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -70,30 +70,48 @@
 /* ============================================================
    BUTTONS
    ============================================================ */
-.btn {
+/* Formato "skew wipe": pílula que dimensiona ao texto. Em repouso mostra a
+   cor atual (via ::before); no hover o painel inclinado desliza e revela a
+   segunda cor da marca. Scoped em .page para vencer o reset .page button. */
+.page .btn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
-  height: 56px;
-  padding: 0 26px;
-  border-radius: 999px;
-  font-weight: 600;
+  padding: 0.9rem 2rem;
+  border-radius: 500px;
+  font-weight: 700;
   font-size: 16px;
-  letter-spacing: -0.005em;
+  letter-spacing: 0.02em;
   border: 1px solid transparent;
-  transition: transform .2s cubic-bezier(0.34,1.56,0.64,1), background .2s, color .2s, box-shadow .2s;
+  transition: color .4s, transform .2s cubic-bezier(0.34,1.56,0.64,1),
+    box-shadow .2s;
   white-space: nowrap;
   cursor: pointer;
   font-family: inherit;
-  width: 100%;
 }
-.btnDark {
-  background: var(--brand);
+.page .btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -10%;
+  width: 120%;
+  height: 100%;
+  z-index: -1;
+  transform: skew(30deg);
+  transition: transform .4s cubic-bezier(0.3, 1, 0.8, 1);
+}
+.page .btn:hover::before { transform: translate3d(100%, 0, 0); }
+
+.page .btnDark {
+  background: var(--accent);
   color: #fff;
 }
-.btnDark:hover {
-  background: var(--accent);
+.page .btnDark::before { background: var(--brand); }
+.page .btnDark:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 28px -10px rgba(255,107,74,.5);
 }

--- a/app/catalogo/page.tsx
+++ b/app/catalogo/page.tsx
@@ -53,7 +53,7 @@ export default function CatalogPage() {
           <button
             type="button"
             onClick={() => window.print()}
-            className="flex items-center gap-2 rounded-lg bg-[#4f46e5] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#4338ca] transition-colors"
+            className="btn-primary gap-2"
           >
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />

--- a/app/components/CheckoutButton.tsx
+++ b/app/components/CheckoutButton.tsx
@@ -23,7 +23,7 @@ export default function CheckoutButton({
 
   if (!paymentLink) {
     return (
-      <button disabled className="opacity-50 cursor-not-allowed" title="Payment link não configurado">
+      <button disabled className="submit opacity-50 cursor-not-allowed" title="Payment link não configurado">
         {label}
       </button>
     );

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -121,7 +121,7 @@ export default function Footer() {
               />
               <button
                 type="submit"
-                className="w-full rounded-xl bg-gradient-to-r from-[#ff6b4a] to-[#f5502e] px-3 py-2.5 text-xs font-bold text-white shadow-[0_12px_24px_-12px_rgba(255,107,74,0.8)] transition-transform hover:-translate-y-0.5"
+                className="btn-accent btn-block !text-xs !py-2.5"
               >
                 {newsletterSubmitted ? "✓ " + t.footer.newsletterButton : t.footer.newsletterButton}
               </button>

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -222,29 +222,47 @@
 }
 .statusRef { font-size: 12px; color: var(--muted); margin-top: 6px; }
 
-/* Submit button */
-.submit {
+/* Submit — formato "skew wipe": índigo em repouso (via ::before), revela
+   coral no hover. Scoped em .page para vencer o reset .page button. */
+.page .submit {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 10px;
-  height: 56px;
-  padding: 0 28px;
-  border-radius: 999px;
-  font-weight: 600;
+  padding: 0.9rem 2rem;
+  border-radius: 500px;
+  font-weight: 700;
   font-size: 16px;
-  letter-spacing: -0.005em;
+  letter-spacing: 0.02em;
   border: none;
-  background: var(--brand);
+  background: var(--accent);
   color: #fff;
   cursor: pointer;
   font-family: inherit;
-  transition: transform .2s cubic-bezier(0.34,1.56,0.64,1), background .2s, box-shadow .2s;
-  width: 100%;
+  transition: color .4s, transform .2s cubic-bezier(0.34,1.56,0.64,1),
+    box-shadow .2s;
+  width: fit-content;
+  max-width: 100%;
+  justify-self: start;
 }
-.submit:hover {
-  background: var(--accent);
+.page .submit::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -10%;
+  width: 120%;
+  height: 100%;
+  z-index: -1;
+  background: var(--brand);
+  transform: skew(30deg);
+  transition: transform .4s cubic-bezier(0.3, 1, 0.8, 1);
+}
+.page .submit:hover::before { transform: translate3d(100%, 0, 0); }
+.page .submit:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 28px -10px rgba(255,107,74,.5);
 }
-.submit:disabled { opacity: .6; cursor: not-allowed; transform: none; }
+.page .submit:disabled { opacity: .6; cursor: not-allowed; transform: none; }

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -90,55 +90,75 @@
 /* ============================================================
    BUTTONS
    ============================================================ */
-.btn {
+/* Formato "skew wipe": pílula que dimensiona ao texto. Em repouso mostra a
+   cor atual (via ::before); no hover o painel inclinado desliza e revela a
+   segunda cor da marca. Scoped em .page para vencer o reset .page button. */
+.page .btn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
-  height: 52px;
-  padding: 0 24px;
-  border-radius: 999px;
-  font-weight: 600;
+  padding: 0.85rem 1.9rem;
+  border-radius: 500px;
+  font-weight: 700;
   font-size: 15px;
-  letter-spacing: -0.005em;
+  letter-spacing: 0.02em;
   border: 1px solid transparent;
-  transition: transform .2s cubic-bezier(0.34,1.56,0.64,1), background .2s, color .2s, box-shadow .2s, border-color .2s;
+  transition: color .4s, transform .2s cubic-bezier(0.34,1.56,0.64,1),
+    box-shadow .2s, border-color .2s;
   white-space: nowrap;
   cursor: pointer;
   font-family: inherit;
 }
-.btnPrimary { background: var(--brand); color: #fff; }
-.btnPrimary:hover:not(:disabled) {
-  background: var(--accent);
+.page .btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -10%;
+  width: 120%;
+  height: 100%;
+  z-index: -1;
+  transform: skew(30deg);
+  transition: transform .4s cubic-bezier(0.3, 1, 0.8, 1);
+}
+.page .btn:hover:not(:disabled)::before { transform: translate3d(100%, 0, 0); }
+
+.page .btnPrimary { background: var(--accent); color: #fff; }
+.page .btnPrimary::before { background: var(--brand); }
+.page .btnPrimary:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 12px 28px -10px rgba(255,107,74,.5);
 }
-.btnGhost {
-  background: transparent;
+.page .btnGhost {
+  background: var(--brand);
   color: var(--ink);
   border-color: var(--line);
 }
-.btnGhost:hover:not(:disabled) {
-  background: var(--brand);
+.page .btnGhost::before { background: var(--surface); }
+.page .btnGhost:hover:not(:disabled) {
   color: #fff;
   border-color: var(--brand);
 }
-.btnAccent { background: var(--accent); color: #fff; }
-.btnAccent:hover:not(:disabled) {
-  background: var(--accent-600);
+.page .btnAccent { background: var(--brand); color: #fff; }
+.page .btnAccent::before { background: var(--accent); }
+.page .btnAccent:hover:not(:disabled) {
   transform: translateY(-1px);
+  box-shadow: 0 12px 28px -10px rgba(79,70,229,.45);
 }
-.btnSmall { height: 40px; padding: 0 16px; font-size: 13px; }
-.btn:disabled {
+.page .btnSmall { padding: 0.55rem 1.3rem; font-size: 13px; }
+.page .btn:disabled {
   opacity: .4;
   cursor: not-allowed;
   transform: none !important;
   box-shadow: none !important;
 }
 .arrow { transition: transform .2s; }
-.btn:hover:not(:disabled) .arrow { transform: translateX(3px); }
-.btnBack .arrow { transform: rotate(180deg); }
-.btnBack:hover:not(:disabled) .arrow { transform: rotate(180deg) translateX(3px); }
+.page .btn:hover:not(:disabled) .arrow { transform: translateX(3px); }
+.page .btnBack .arrow { transform: rotate(180deg); }
+.page .btnBack:hover:not(:disabled) .arrow { transform: rotate(180deg) translateX(3px); }
 
 /* ============================================================
    COURSE HEAD

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -673,7 +673,7 @@ export default function DashboardPage() {
                   )}
 
                   <button
-                    className="submit mt-4 max-w-[240px] bg-red-600 hover:bg-red-700"
+                    className="submit is-danger mt-4 max-w-[240px]"
                     type="button"
                     onClick={handleDeleteAccount}
                   >

--- a/app/faq/page.module.css
+++ b/app/faq/page.module.css
@@ -171,26 +171,44 @@
   margin: 0;
   font-weight: 500;
 }
+/* Formato "skew wipe": coral em repouso (via ::before), revela índigo no
+   hover. !important em color/border para vencer a regra global main a. */
 .ctaBtn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  height: 54px;
-  padding: 0 28px;
-  border-radius: 16px;
+  padding: 0.85rem 2rem;
+  border-radius: 500px;
   font-weight: 700;
   font-size: 16px;
-  letter-spacing: -0.01em;
+  letter-spacing: 0.02em;
   white-space: nowrap;
   text-decoration: none;
-  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
-  color: #fff;
-  box-shadow: 0 16px 34px -12px rgba(255, 107, 74, 0.6);
-  transition: transform .2s, box-shadow .2s;
+  border-bottom: none !important;
+  background: var(--brand-500);
+  color: #fff !important;
+  box-shadow: 0 16px 34px -12px rgba(255, 107, 74, 0.55);
+  transition: color .4s, transform .3s, box-shadow .3s;
 }
+.ctaBtn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -10%;
+  width: 120%;
+  height: 100%;
+  z-index: -1;
+  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+  transform: skew(30deg);
+  transition: transform .4s cubic-bezier(0.3, 1, 0.8, 1);
+}
+.ctaBtn:hover::before { transform: translate3d(100%, 0, 0); }
 .ctaBtn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 42px -12px rgba(255, 107, 74, 0.7);
+  box-shadow: 0 22px 42px -12px rgba(79, 70, 229, 0.5);
 }
 .ctaBtn svg { transition: transform .2s; }
 .ctaBtn:hover svg { transform: translateX(3px); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,24 +131,57 @@ h6 {
      BOTÕES
      =================================================================== */
 
+  /* ===================================================================
+     FORMATO BASE DOS BOTÕES — "skew wipe" (inspirado em Uiverse.io por
+     BHARGAVPATEL1244). Pílula (border-radius 500px) que dimensiona ao
+     texto; ao passar o rato, um painel inclinado desliza revelando a
+     segunda cor da marca (sistema "Índigo & Coral"). As cores mantêm-se
+     as atuais: em repouso mostra-se a cor de origem (via ::before), no
+     hover revela-se a cor de destino (via background).
+     O painel usa z-index:-1 + isolation:isolate, ficando por baixo do
+     texto sem precisar de <span>, para funcionar em qualquer botão.
+     =================================================================== */
+
   /* Botão base decorativo (mantido por compatibilidade). */
   .cssbuttons-io-button {
-    display: flex;
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    display: inline-flex;
     align-items: center;
+    justify-content: center;
     font-family: "Plus Jakarta Sans", sans-serif;
     cursor: pointer;
-    font-weight: 600;
-    font-size: 14px;
-    padding: 0.7em 1.4em;
-    color: white;
-    background: var(--brand);
+    font-weight: 700;
+    font-size: 15px;
+    padding: 0.8rem 1.8rem;
+    color: #fff;
+    background: var(--accent);
     border: none;
-    box-shadow: 0 12px 24px -10px rgba(79, 70, 229, 0.55);
-    letter-spacing: 0.01em;
-    border-radius: 14px;
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    box-shadow: 0 12px 24px -12px rgba(79, 70, 229, 0.5);
+    letter-spacing: 0.03em;
+    border-radius: 500px;
+    transition: color 0.4s, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+      box-shadow 0.3s;
     width: auto;
     min-width: auto;
+  }
+
+  .cssbuttons-io-button::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -10%;
+    width: 120%;
+    height: 100%;
+    z-index: -1;
+    background: var(--brand);
+    transform: skew(30deg);
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  }
+
+  .cssbuttons-io-button:hover::before {
+    transform: translate3d(100%, 0, 0);
   }
 
   .cssbuttons-io-button svg {
@@ -157,7 +190,7 @@ h6 {
 
   .cssbuttons-io-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 18px 30px -12px rgba(79, 70, 229, 0.6);
+    box-shadow: 0 18px 30px -12px rgba(79, 70, 229, 0.55);
   }
 
   .cssbuttons-io-button:active {
@@ -167,9 +200,13 @@ h6 {
   .cssbuttons-io-button:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+    transform: none;
   }
 
-  /* Estilo global aplicado a <button> sem classe utilitária. */
+  /* Estilo global aplicado a <button> sem classe utilitária.
+     Mantém-se conservador (sem ::before) para não afetar botões
+     estruturais como toggles/acordeões/ícones; o formato "skew wipe"
+     é aplicado pelas classes de ação abaixo. */
   button {
     outline: none;
     cursor: pointer;
@@ -216,40 +253,60 @@ h6 {
 
   /* === SISTEMA PADRONIZADO DE BOTÕES === */
 
-  /* Primário (índigo) */
+  /* Primário — índigo em repouso, revela coral no hover. */
   .btn-primary {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     font-family: "Plus Jakarta Sans", sans-serif;
     cursor: pointer;
     font-weight: 700;
-    font-size: 0.8rem;
-    padding: 0.6rem 1.1rem;
-    color: white !important;
-    background: var(--brand);
+    font-size: 0.85rem;
+    padding: 0.7rem 1.6rem;
+    color: #fff !important;
+    background: var(--accent);
     border: none;
-    border-radius: 12px;
-    letter-spacing: 0.01em;
+    border-radius: 500px;
+    letter-spacing: 0.03em;
     text-transform: none;
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transition: color 0.4s, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+      box-shadow 0.3s;
     white-space: nowrap;
     touch-action: manipulation;
-    box-shadow: 0 12px 24px -12px rgba(79, 70, 229, 0.6);
+    box-shadow: 0 12px 24px -12px rgba(79, 70, 229, 0.5);
     line-height: 1;
+  }
+
+  .btn-primary::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -10%;
+    width: 120%;
+    height: 100%;
+    z-index: -1;
+    background: var(--brand);
+    transform: skew(30deg);
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  }
+
+  .btn-primary:hover::before {
+    transform: translate3d(100%, 0, 0);
   }
 
   @media (min-width: 640px) {
     .btn-primary {
-      font-size: 0.8rem;
-      padding: 0.7rem 2rem;
+      font-size: 0.85rem;
+      padding: 0.8rem 2rem;
     }
   }
 
   .btn-primary:hover {
-    background: var(--brand-700);
     transform: translateY(-2px);
-    box-shadow: 0 18px 30px -12px rgba(79, 70, 229, 0.65);
+    box-shadow: 0 18px 30px -12px rgba(79, 70, 229, 0.55);
   }
 
   .btn-primary:active {
@@ -262,37 +319,117 @@ h6 {
     transform: none;
   }
 
-  /* Secundário (contorno) */
-  .btn-secondary {
+  /* Acento — coral em repouso, revela índigo no hover. */
+  .btn-accent {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     font-family: "Plus Jakarta Sans", sans-serif;
     cursor: pointer;
     font-weight: 700;
-    font-size: 0.8rem;
-    padding: 0.6rem 1.1rem;
-    color: var(--brand-700);
-    background: white;
-    border: 1.5px solid var(--brand-soft);
-    border-radius: 12px;
-    letter-spacing: 0.01em;
+    font-size: 0.85rem;
+    padding: 0.7rem 1.6rem;
+    color: #fff !important;
+    background: var(--brand);
+    border: none;
+    border-radius: 500px;
+    letter-spacing: 0.03em;
     text-transform: none;
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transition: color 0.4s, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+      box-shadow 0.3s;
+    white-space: nowrap;
+    touch-action: manipulation;
+    box-shadow: 0 12px 24px -12px rgba(255, 107, 74, 0.5);
+    line-height: 1;
+  }
+
+  .btn-accent::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -10%;
+    width: 120%;
+    height: 100%;
+    z-index: -1;
+    background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+    transform: skew(30deg);
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  }
+
+  .btn-accent:hover::before {
+    transform: translate3d(100%, 0, 0);
+  }
+
+  .btn-accent:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 30px -12px rgba(255, 107, 74, 0.55);
+  }
+
+  .btn-accent:active {
+    transform: translateY(0);
+  }
+
+  .btn-accent:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  /* Secundário — contorno branco em repouso, preenche índigo no hover. */
+  .btn-secondary {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: "Plus Jakarta Sans", sans-serif;
+    cursor: pointer;
+    font-weight: 700;
+    font-size: 0.85rem;
+    padding: 0.7rem 1.6rem;
+    color: var(--brand-700);
+    background: var(--brand);
+    border: 1.5px solid var(--brand-soft);
+    border-radius: 500px;
+    letter-spacing: 0.03em;
+    text-transform: none;
+    transition: color 0.4s, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+      box-shadow 0.3s, border-color 0.3s;
     white-space: nowrap;
     touch-action: manipulation;
     line-height: 1;
   }
 
+  .btn-secondary::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -10%;
+    width: 120%;
+    height: 100%;
+    z-index: -1;
+    background: #fff;
+    transform: skew(30deg);
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  }
+
+  .btn-secondary:hover::before {
+    transform: translate3d(100%, 0, 0);
+  }
+
   @media (min-width: 640px) {
     .btn-secondary {
-      font-size: 0.8rem;
-      padding: 0.7rem 2rem;
+      font-size: 0.85rem;
+      padding: 0.8rem 2rem;
     }
   }
 
   .btn-secondary:hover {
-    background: var(--brand-soft);
+    color: #fff;
     border-color: var(--brand-500);
   }
 
@@ -306,12 +443,12 @@ h6 {
   }
 
   .btn-sm {
-    padding: 0.55rem 1rem;
+    padding: 0.55rem 1.3rem;
     font-size: 0.8rem;
   }
 
   .btn-lg {
-    padding: 1rem 2rem;
+    padding: 1rem 2.4rem;
     font-size: 1rem;
   }
 
@@ -319,42 +456,65 @@ h6 {
     width: 100%;
   }
 
-  /* Compat. legada — pílulas de navegação/ações. */
+  /* Compat. legada — pílulas de navegação/ações (índigo→coral). */
   .site-pill-button,
   .button-size-login {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     font-family: "Plus Jakarta Sans", sans-serif;
     cursor: pointer;
     font-weight: 700;
-    font-size: 0.7rem;
-    padding: 0.55rem 1.1rem;
-    color: white !important;
-    background: var(--brand);
+    font-size: 0.72rem;
+    padding: 0.55rem 1.4rem;
+    color: #fff !important;
+    background: var(--accent);
     border: none;
-    border-radius: 12px;
-    letter-spacing: 0.01em;
+    border-radius: 500px;
+    letter-spacing: 0.03em;
     text-transform: none;
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transition: color 0.4s, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+      box-shadow 0.3s, border-color 0.3s;
     white-space: nowrap;
     touch-action: manipulation;
-    box-shadow: 0 12px 22px -12px rgba(79, 70, 229, 0.6);
+    box-shadow: 0 12px 22px -12px rgba(79, 70, 229, 0.55);
     line-height: 1;
+  }
+
+  .site-pill-button::before,
+  .button-size-login::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -10%;
+    width: 120%;
+    height: 100%;
+    z-index: -1;
+    background: var(--brand);
+    transform: skew(30deg);
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  }
+
+  .site-pill-button:hover::before,
+  .button-size-login:hover::before {
+    transform: translate3d(100%, 0, 0);
   }
 
   @media (min-width: 640px) {
     .site-pill-button,
     .button-size-login {
       font-size: 0.78rem;
-      padding: 0.65rem 1.9rem;
+      padding: 0.6rem 1.9rem;
     }
   }
 
   .site-pill-button:hover,
   .button-size-login:hover {
     transform: translateY(-2px);
-    box-shadow: 0 18px 28px -12px rgba(79, 70, 229, 0.6);
+    box-shadow: 0 18px 28px -12px rgba(79, 70, 229, 0.55);
   }
 
   .site-pill-button:active,
@@ -369,49 +529,52 @@ h6 {
     transform: none;
   }
 
-  /* Login — contorno índigo sobre fundo claro. */
+  /* Login — contorno índigo em repouso, preenche índigo no hover. */
   .site-pill-button.nav-login-btn {
-    background: white;
+    background: var(--brand);
     color: var(--brand) !important;
     border: 1.5px solid var(--brand-soft);
     box-shadow: none;
   }
 
+  .site-pill-button.nav-login-btn::before {
+    background: #fff;
+  }
+
   .site-pill-button.nav-login-btn:hover {
-    background: var(--brand-soft);
+    color: #fff !important;
     border-color: var(--brand-500);
     transform: translateY(-1px);
   }
 
-  /* Dashboard — sólido índigo. */
+  /* Dashboard — índigo em repouso, revela coral no hover (herda a base). */
   .site-pill-button.nav-dashboard-btn {
-    background: var(--brand);
-    color: white !important;
+    color: #fff !important;
     border: none;
   }
 
-  .site-pill-button.nav-dashboard-btn:hover {
-    background: var(--brand-700);
-  }
-
-  /* Variante secundária clara. */
+  /* Variante secundária clara — branco em repouso, preenche índigo no hover. */
   .site-pill-button-secondary {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     font-family: "Plus Jakarta Sans", sans-serif;
     cursor: pointer;
     font-weight: 700;
-    font-size: 0.7rem;
-    padding: 0.55rem 1.1rem;
+    font-size: 0.72rem;
+    padding: 0.55rem 1.4rem;
     color: var(--body);
-    background: white;
+    background: var(--brand);
     border: 1.5px solid var(--line);
     box-shadow: none;
-    letter-spacing: 0.01em;
+    letter-spacing: 0.03em;
     text-transform: none;
-    border-radius: 12px;
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    border-radius: 500px;
+    transition: color 0.4s, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+      border-color 0.3s;
     white-space: nowrap;
     touch-action: manipulation;
     width: auto;
@@ -419,16 +582,33 @@ h6 {
     line-height: 1;
   }
 
+  .site-pill-button-secondary::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -10%;
+    width: 120%;
+    height: 100%;
+    z-index: -1;
+    background: #fff;
+    transform: skew(30deg);
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  }
+
+  .site-pill-button-secondary:hover::before {
+    transform: translate3d(100%, 0, 0);
+  }
+
   @media (min-width: 640px) {
     .site-pill-button-secondary {
       font-size: 0.78rem;
-      padding: 0.65rem 1.9rem;
+      padding: 0.6rem 1.9rem;
     }
   }
 
   .site-pill-button-secondary:hover {
-    background: var(--surface-muted);
-    border-color: var(--brand-soft);
+    color: #fff;
+    border-color: var(--brand);
     transform: translateY(-1px);
   }
 
@@ -925,18 +1105,23 @@ h6 {
 }
 
 .submit {
-  width: auto;
-  padding: 0.65rem 1.6rem;
-  color: white !important;
-  font-size: 0.78rem;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.7rem 1.9rem;
+  color: #fff !important;
+  font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.03em;
   cursor: pointer;
-  background: var(--brand);
+  background: var(--accent);
   border: none;
-  box-shadow: 0 14px 26px -12px rgba(79, 70, 229, 0.6);
-  border-radius: 12px;
-  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 14px 26px -12px rgba(79, 70, 229, 0.5);
+  border-radius: 500px;
+  transition: color 0.4s, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.3s;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -944,17 +1129,33 @@ h6 {
   line-height: 1;
 }
 
+.submit::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -10%;
+  width: 120%;
+  height: 100%;
+  z-index: -1;
+  background: var(--brand);
+  transform: skew(30deg);
+  transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+}
+
+.submit:hover::before {
+  transform: translate3d(100%, 0, 0);
+}
+
 @media (min-width: 640px) {
   .submit {
     font-size: 0.82rem;
-    padding: 0.75rem 2rem;
+    padding: 0.78rem 2.1rem;
   }
 }
 
 .submit:hover {
-  background: var(--brand-700);
   transform: translateY(-2px);
-  box-shadow: 0 20px 32px -12px rgba(79, 70, 229, 0.65);
+  box-shadow: 0 20px 32px -12px rgba(79, 70, 229, 0.55);
 }
 
 .submit:active {
@@ -965,6 +1166,15 @@ h6 {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;
+}
+
+/* Ação destrutiva (ex.: terminar sessão) — vermelho em repouso, escurece no hover. */
+.submit.is-danger {
+  background: #b91c1c;
+}
+
+.submit.is-danger::before {
+  background: #dc2626;
 }
 
 .form-link {

--- a/app/o-curso/page.module.css
+++ b/app/o-curso/page.module.css
@@ -91,44 +91,68 @@
 /* ============================================================
    BUTTONS
    ============================================================ */
-.btn {
+/* Formato "skew wipe": pílula que dimensiona ao texto. Em repouso mostra a
+   cor atual (via ::before); no hover o painel inclinado desliza e revela a
+   segunda cor da marca. Scoped em .page para vencer o reset .page button. */
+.page .btn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
-  height: 56px;
-  padding: 0 28px;
-  border-radius: 16px;
+  padding: 0.9rem 2rem;
+  border-radius: 500px;
   font-weight: 700;
   font-size: 16px;
-  letter-spacing: -0.005em;
+  letter-spacing: 0.02em;
   border: 1px solid transparent;
-  transition: all .3s cubic-bezier(0.23, 1, 0.320, 1);
+  transition: color .4s, transform .3s cubic-bezier(0.23, 1, 0.320, 1),
+    box-shadow .3s;
   white-space: nowrap;
   cursor: pointer;
   font-family: inherit;
 }
-.btnDark {
-  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
-  color: #fff;
-  box-shadow: 0 16px 30px -12px rgba(79, 70, 229, 0.55);
-  width: 100%;
+.page .btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -10%;
+  width: 120%;
+  height: 100%;
+  z-index: -1;
+  transform: skew(30deg);
+  transition: transform .4s cubic-bezier(0.3, 1, 0.8, 1);
 }
-.btnDark:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 22px 38px -12px rgba(79, 70, 229, 0.65);
-}
-.btnAccent {
+.page .btn:hover::before { transform: translate3d(100%, 0, 0); }
+
+.page .btnDark {
   background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
   color: #fff;
-  box-shadow: 0 16px 30px -12px rgba(255, 107, 74, 0.55);
+  box-shadow: 0 16px 30px -12px rgba(79, 70, 229, 0.5);
 }
-.btnAccent:hover {
+.page .btnDark::before {
+  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
+}
+.page .btnDark:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 38px -12px rgba(255, 107, 74, 0.65);
+  box-shadow: 0 22px 38px -12px rgba(255, 107, 74, 0.55);
+}
+.page .btnAccent {
+  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
+  color: #fff;
+  box-shadow: 0 16px 30px -12px rgba(255, 107, 74, 0.5);
+}
+.page .btnAccent::before {
+  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+}
+.page .btnAccent:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 38px -12px rgba(79, 70, 229, 0.55);
 }
 .arrow { transition: transform .2s; }
-.btn:hover .arrow { transform: translateX(3px); }
+.page .btn:hover .arrow { transform: translateX(3px); }
 
 /* ============================================================
    HERO
@@ -528,4 +552,4 @@
   font-weight: 500;
 }
 .finalCta { display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; }
-.btnBlock { width: 100%; max-width: 340px; }
+.page .btnBlock { width: 100%; max-width: 340px; }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -114,48 +114,71 @@
 /* ============================================================
    BUTTONS
    ============================================================ */
-.btn {
+/* Formato "skew wipe": pílula que dimensiona ao texto. Em repouso mostra
+   a cor atual (via ::before); no hover o painel inclinado desliza e revela
+   a segunda cor da marca. Scoped em .page para vencer o reset .page button. */
+.page .btn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
-  height: 56px;
-  padding: 0 28px;
-  border-radius: 16px;
+  padding: 0.9rem 2rem;
+  border-radius: 500px;
   font-weight: 700;
   font-size: 16px;
-  letter-spacing: -0.01em;
+  letter-spacing: 0.02em;
   border: none;
-  transition: all .3s cubic-bezier(0.23, 1, 0.320, 1);
+  transition: color .4s, transform .3s cubic-bezier(0.23, 1, 0.320, 1),
+    box-shadow .3s;
   white-space: nowrap;
   text-decoration: none;
   cursor: pointer;
   font-family: inherit;
 }
-.btnPrimary {
-  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+.page .btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -10%;
+  width: 120%;
+  height: 100%;
+  z-index: -1;
+  transform: skew(30deg);
+  transition: transform .4s cubic-bezier(0.3, 1, 0.8, 1);
+}
+.page .btn:hover::before { transform: translate3d(100%, 0, 0); }
+
+.page .btnPrimary {
+  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
   color: #fff;
-  box-shadow: 0 16px 30px -12px rgba(255, 107, 74, 0.6);
+  box-shadow: 0 16px 30px -12px rgba(255, 107, 74, 0.55);
 }
-.btnPrimary:hover {
+.page .btnPrimary::before {
+  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+}
+.page .btnPrimary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 38px -12px rgba(255, 107, 74, 0.65);
+  box-shadow: 0 22px 38px -12px rgba(79, 70, 229, 0.55);
 }
-.btnGhost {
-  background: #fff;
+.page .btnGhost {
+  background: var(--brand);
   color: var(--brand-700);
   border: 1.5px solid var(--brand-soft);
   box-shadow: 0 10px 24px -16px rgba(79, 70, 229, 0.5);
 }
-.btnGhost:hover {
-  background: var(--brand-soft);
+.page .btnGhost::before { background: #fff; }
+.page .btnGhost:hover {
+  color: #fff;
   border-color: var(--brand-500);
   transform: translateY(-2px);
 }
-.btnSmall { height: 44px; padding: 0 18px; font-size: 14px; }
+.page .btnSmall { padding: 0.6rem 1.3rem; font-size: 14px; }
 
 .arrow { transition: transform .2s; }
-.btn:hover .arrow { transform: translateX(3px); }
+.page .btn:hover .arrow { transform: translateX(3px); }
 
 .priceStrike {
   text-decoration: line-through;
@@ -163,7 +186,7 @@
   font-weight: 500;
   margin-right: 2px;
 }
-.btnPrimary strong { font-weight: 800; }
+.page .btnPrimary strong { font-weight: 800; }
 
 /* ============================================================
    HERO
@@ -692,14 +715,17 @@
   align-items: center;
   gap: 20px;
 }
-.finalBtn {
-  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+.page .finalBtn {
+  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
   color: #fff;
-  box-shadow: 0 16px 34px -12px rgba(255, 107, 74, 0.6);
+  box-shadow: 0 16px 34px -12px rgba(255, 107, 74, 0.55);
 }
-.finalBtn:hover {
+.page .finalBtn::before {
+  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+}
+.page .finalBtn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 42px -12px rgba(255, 107, 74, 0.7);
+  box-shadow: 0 22px 42px -12px rgba(79, 70, 229, 0.55);
 }
 .finalPriceTag {
   display: flex;
@@ -747,15 +773,17 @@
 }
 .buyBarPrice strong { font-size: 19px; color: var(--accent-600); font-weight: 800; margin-left: 6px; }
 .buyBarPrice s { color: var(--muted); margin-right: 4px; }
-.buyBarBtn {
-  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+.page .buyBarBtn {
+  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
   color: #fff;
-  height: 46px;
-  padding: 0 22px;
+  padding: 0.7rem 1.5rem;
   font-size: 14px;
-  box-shadow: 0 14px 26px -12px rgba(255, 107, 74, 0.6);
+  box-shadow: 0 14px 26px -12px rgba(255, 107, 74, 0.55);
 }
-.buyBarBtn:hover { transform: translateY(-2px); }
+.page .buyBarBtn::before {
+  background: linear-gradient(135deg, #ff6b4a 0%, #f5502e 100%);
+}
+.page .buyBarBtn:hover { transform: translateY(-2px); }
 @media (max-width: 520px) {
   .buyBar { padding: 8px 8px 8px 16px; gap: 10px; font-size: 13px; }
   .buyBarPrice { font-size: 13px; }


### PR DESCRIPTION
Todos os botões de ação passam a ter o mesmo formato: pílula
(border-radius: 500px), peso 700 e uma animação de "wipe" inclinado no
hover — um painel diagonal desliza revelando a segunda cor da marca
(sistema "Índigo & Coral").

- Cores mantidas: em repouso mostra-se a cor atual (via ::before) e no
  hover revela-se a cor de destino (índigo <-> coral). Sem introduzir
  cores novas do exemplo original (verde/preto/ghostwhite).
- Tamanho de acordo com o texto: removidas alturas/larguras fixas e
  width:100%; os botões passam a dimensionar-se ao conteúdo (exceto
  .btnBlock e o botão da newsletter, que acompanham a largura do campo).
- Técnica robusta: o painel usa z-index:-1 + isolation:isolate, ficando
  por baixo do texto sem necessitar de <span>, funcionando em qualquer
  botão (texto, ícones, preços).
- Cobertura de todas as páginas, incluindo a página do curso: regras de
  botões dos CSS Modules (home, o-curso, curso, sobre, faq, contacto)
  passam a estar scoped em .page para vencerem os resets .page button.
- Botões estruturais (menu hambúrguer, seletor de idioma, acordeão das
  FAQ, navegação do dashboard) mantêm-se inalterados.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CP7bBccMMTCpMGjSzCP4wG