### PR TITLE
Refactor homepage to single-screen layout with process visualization

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -242,3 +242,203 @@
   align-items: center;
   justify-content: center;
 }
+
+/* ============================================================
+   SECÇÕES VINDAS DA ANTIGA PÁGINA INICIAL
+   ============================================================ */
+.sectionAlt {
+  padding: 96px 0;
+  background: var(--color-bg-light);
+  border-top: 1px solid var(--color-gray-light);
+}
+@media (max-width: 720px) { .sectionAlt { padding: 64px 0; } }
+
+.dot { color: var(--color-primary-red); }
+
+.head {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--sp-md);
+  margin-bottom: var(--sp-2xl);
+  align-items: end;
+}
+@media (min-width: 880px) {
+  .head { grid-template-columns: 1.25fr 1fr; gap: var(--sp-4xl); }
+}
+.headSub {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--muted);
+  max-width: 46ch;
+  margin: 0;
+  text-wrap: pretty;
+}
+.headKicker {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-primary-red);
+  margin: var(--sp-sm) 0 0;
+}
+
+/* Pilares */
+.pillars {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--sp-md);
+}
+@media (min-width: 860px) {
+  .pillars { grid-template-columns: repeat(3, 1fr); }
+}
+.pillar {
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-light);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-lg);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: all 300ms ease;
+}
+.pillar:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  border-color: rgba(239, 62, 77, 0.2);
+}
+.pillarAccent {
+  background: var(--color-primary-red);
+  border-color: var(--color-primary-red);
+  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+}
+.pillarAccent:hover {
+  border-color: var(--color-primary-red);
+  box-shadow: 0 8px 24px rgba(239, 62, 77, 0.3);
+}
+.pillarIcon {
+  display: block;
+  width: 32px;
+  height: 32px;
+  color: var(--color-primary-red);
+  margin-bottom: var(--sp-md);
+}
+.pillarIcon svg { width: 100%; height: 100%; }
+.pillarAccent .pillarIcon { color: var(--color-white); }
+.pillarTitle {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  color: var(--color-text-primary);
+  margin: 0 0 12px;
+}
+.pillarAccent .pillarTitle { color: var(--color-white); }
+.pillarRule {
+  width: 34px;
+  height: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary-red);
+  margin-bottom: var(--sp-sm);
+}
+.pillarAccent .pillarRule { background: var(--color-white); }
+.pillarDesc {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--muted);
+  margin: 0;
+  text-wrap: pretty;
+}
+.pillarAccent .pillarDesc { color: rgba(255, 255, 255, 0.92); }
+
+/* Setores */
+.cats {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--sp-md);
+}
+@media (min-width: 640px) {
+  .cats { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1000px) {
+  .cats { grid-template-columns: repeat(3, 1fr); }
+}
+.cat {
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-light);
+  border-top: 3px solid var(--color-primary-red);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-md);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+  transition: all 300ms ease;
+}
+.cat:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+}
+.catIcon {
+  width: 26px;
+  height: 26px;
+  color: var(--color-primary-red);
+  flex-shrink: 0;
+}
+.catBody { flex: 1; min-width: 0; }
+.catName {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--color-primary-blue);
+  margin: 0 0 4px;
+}
+.catPay {
+  font-size: 14px;
+  color: var(--muted);
+  margin: 0;
+}
+.catPay strong {
+  color: var(--color-success-green);
+  font-weight: 700;
+  font-size: 16px;
+}
+
+/* Faixa de números */
+.strip {
+  background: var(--color-bg-light);
+  border-top: 1px solid var(--color-gray-light);
+  border-bottom: 1px solid var(--color-gray-light);
+}
+.stripGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+@media (min-width: 860px) {
+  .stripGrid { grid-template-columns: repeat(4, 1fr); }
+}
+.stripItem {
+  padding: var(--sp-xl) var(--sp-md);
+  border-right: 1px solid var(--color-gray-light);
+  border-bottom: 1px solid var(--color-gray-light);
+}
+.stripItem:nth-child(2n) { border-right: none; }
+@media (min-width: 860px) {
+  .stripItem { border-bottom: none; }
+  .stripItem:nth-child(2n) { border-right: 1px solid var(--color-gray-light); }
+  .stripItem:last-child { border-right: none; }
+}
+.stripNum {
+  font-size: clamp(32px, 3.2vw, 44px);
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  line-height: 1;
+  color: var(--color-primary-blue);
+  margin-bottom: 12px;
+}
+.stripNum em {
+  font-style: normal;
+  color: var(--color-primary-red);
+}
+.stripLabel {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.6;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -16,6 +16,117 @@ const ArrowIcon = ({ size = 16 }: { size?: number }) => (
   </svg>
 );
 
+/* ---------- Conteúdo vindo da antiga página inicial ---------- */
+const pillars = [
+  {
+    title: "Vês o que ninguém vê",
+    desc: "Aprendes a ler uma loja em 30 segundos: tempos, guiões, linguagem corporal, higiene. Depois do curso, nunca mais entras num café da mesma maneira.",
+    accent: true,
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+    ),
+  },
+  {
+    title: "Método, não sorte",
+    desc: "Dez módulos com o processo completo: preparar a visita, executar sem levantar suspeitas, guardar provas e entregar um relatório que passa à primeira.",
+    accent: false,
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M9 11H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h5" />
+        <path d="M15 3h5a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1h-5" />
+        <path d="M9 3h6v18H9z" />
+      </svg>
+    ),
+  },
+  {
+    title: "Pago por missão",
+    desc: "Entre 5 € e 150 € por visita, além da refeição, das compras ou da estadia reembolsadas. Escolhes quando, onde e quantas. Sem chefe e sem horário.",
+    accent: false,
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M12 1v22" />
+        <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+      </svg>
+    ),
+  },
+];
+
+const categories = [
+  {
+    name: "Restauração",
+    pay: "20–60 €",
+    note: "refeição incluída",
+    icon: (
+      <>
+        <path d="M6 2v7a3 3 0 0 0 6 0V2" />
+        <path d="M9 12v10" />
+        <path d="M19 2c.6 3.5.6 7 0 10.5-1 .5-2 1-2 3.5v6" />
+      </>
+    ),
+  },
+  {
+    name: "Retalho e moda",
+    pay: "10–40 €",
+    note: "30 a 60 minutos",
+    icon: (
+      <>
+        <path d="M3 3h18l-2 4H5z" />
+        <path d="M5 7v14h14V7" />
+        <path d="M9 12h6" />
+      </>
+    ),
+  },
+  {
+    name: "Hotelaria",
+    pay: "80–150 €",
+    note: "estadia paga",
+    icon: (
+      <>
+        <path d="M3 21V8l9-5 9 5v13" />
+        <path d="M9 21v-8h6v8" />
+        <path d="M2 21h20" />
+      </>
+    ),
+  },
+  {
+    name: "Banca e seguros",
+    pay: "15–50 €",
+    note: "atendimento e conformidade",
+    icon: (
+      <>
+        <path d="M3 10 12 4l9 6" />
+        <path d="M5 10v9M19 10v9M9 10v9M15 10v9" />
+        <path d="M3 21h18" />
+      </>
+    ),
+  },
+  {
+    name: "Farmácias e saúde",
+    pay: "10–30 €",
+    note: "visitas rápidas",
+    icon: (
+      <>
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <path d="M12 8v8M8 12h8" />
+      </>
+    ),
+  },
+  {
+    name: "Telecom e automóvel",
+    pay: "15–40 €",
+    note: "presencial, telefone e online",
+    icon: (
+      <>
+        <rect x="6" y="2" width="12" height="20" rx="2" />
+        <path d="M11 18h2" />
+      </>
+    ),
+  },
+];
+
 function BuyButton({ children, className }: { children: React.ReactNode; className?: string }) {
   const router = useRouter();
   const paymentLink = process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK;
@@ -114,6 +225,105 @@ export default function AboutPage() {
                 {t.about.buyCourseButton}
                 <ArrowIcon />
               </BuyButton>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ============================================================
+          PILARES
+          ============================================================ */}
+      <section className={styles.sectionAlt}>
+        <div className={styles.wrap}>
+          <div className={styles.head}>
+            <div>
+              <div className={styles.eyebrow}>Porque é diferente</div>
+              <h2 className={styles.displayLg}>
+                O que levas contigo<span className={styles.dot}>.</span>
+              </h2>
+            </div>
+            <p className={styles.headSub}>
+              Não é uma lista de conselhos soltos: é o método que as agências usam, explicado passo
+              a passo e pronto a aplicar já na primeira visita.
+            </p>
+          </div>
+
+          <div className={styles.pillars}>
+            {pillars.map((p) => (
+              <article
+                key={p.title}
+                className={`${styles.pillar} ${p.accent ? styles.pillarAccent : ""}`}
+              >
+                <span className={styles.pillarIcon}>{p.icon}</span>
+                <h3 className={styles.pillarTitle}>{p.title}</h3>
+                <div className={styles.pillarRule} />
+                <p className={styles.pillarDesc}>{p.desc}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ============================================================
+          SETORES
+          ============================================================ */}
+      <section className={styles.section}>
+        <div className={styles.wrap}>
+          <div className={styles.head}>
+            <div>
+              <div className={styles.eyebrow}>Setores</div>
+              <h2 className={styles.displayLg}>
+                O que vais avaliar<span className={styles.dot}>.</span>
+              </h2>
+              <p className={styles.headKicker}>Trabalhas quando queres, onde queres</p>
+            </div>
+            <p className={styles.headSub}>
+              As plataformas de mystery shopping em Portugal cobrem dezenas de setores. Depois do
+              curso escolhes as missões que encaixam na tua zona, no teu horário e no teu perfil.
+            </p>
+          </div>
+
+          <div className={styles.cats}>
+            {categories.map((c) => (
+              <div className={styles.cat} key={c.name}>
+                <svg className={styles.catIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  {c.icon}
+                </svg>
+                <div className={styles.catBody}>
+                  <h3 className={styles.catName}>{c.name}</h3>
+                  <p className={styles.catPay}>
+                    <strong>{c.pay}</strong> · {c.note}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ============================================================
+          NÚMEROS
+          ============================================================ */}
+      <section className={styles.strip}>
+        <div className={styles.wrap}>
+          <div className={styles.stripGrid}>
+            <div className={styles.stripItem}>
+              <div className={styles.stripNum}>10</div>
+              <div className={styles.stripLabel}>Módulos práticos</div>
+            </div>
+            <div className={styles.stripItem}>
+              <div className={styles.stripNum}>
+                <em>5–150</em> €
+              </div>
+              <div className={styles.stripLabel}>Por missão concluída</div>
+            </div>
+            <div className={styles.stripItem}>
+              <div className={styles.stripNum}>100%</div>
+              <div className={styles.stripLabel}>Online e sem horários</div>
+            </div>
+            <div className={styles.stripItem}>
+              <div className={styles.stripNum}>+500</div>
+              <div className={styles.stripLabel}>Alunos em Portugal</div>
             </div>
           </div>
         </div>

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -5,6 +5,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { LanguageProvider } from "@/app/context/LanguageContext";
 import HeaderActions from "./HeaderActions";
 import LanguageSwitcher from "./LanguageSwitcher";
@@ -12,6 +13,11 @@ import TopNav from "./TopNav";
 import Footer from "./Footer";
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  // A página inicial ocupa exatamente um ecrã: sem rodapé não há nada para
+  // percorrer abaixo do processo. As restantes páginas mantêm o rodapé.
+  const isHome = pathname === "/";
+
   return (
     <LanguageProvider>
       <div className="mx-auto flex min-h-screen w-full flex-col bg-transparent">
@@ -51,9 +57,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           </div>
         </header>
 
-        <main className="flex-1 px-0 pb-0">{children}</main>
+        {/* Na página inicial o conteúdo estica-se para ocupar o ecrã inteiro. */}
+        <main className={`flex-1 px-0 pb-0 ${isHome ? "flex flex-col" : ""}`}>
+          {children}
+        </main>
 
-        <Footer />
+        {!isHome ? <Footer /> : null}
       </div>
     </LanguageProvider>
   );

--- a/app/lib/translations.ts
+++ b/app/lib/translations.ts
@@ -14,71 +14,14 @@ export const translations = {
       logout: "Terminar Sessão",
       dashboard: "Dashboard",
     },
-    // Home Page
+    // Home Page — ecrã único: proposta de valor + os três passos do processo.
     home: {
-      badge: "O ÚNICO CURSO EM PORTUGAL",
-      title: "Quer rendimento extra?",
-      titleHighlight: "Cliente Mistério",
-      description: "Avalia lojas, restaurantes e produtos ao teu ritmo, e recebe por isso. Certificado incluído.",
-      buyButton: "Comprar o curso",
-      viewProgram: "Ver o programa",
-      originalPrice: "64,99€",
-      discountPrice: "24,99€",
-
-      // Stats
-      stats: {
-        reviews: "Críticas",
-        students: "Alunos",
-        modules: "Módulos",
-        rating: "Avaliação",
-      },
-
-      // What's Included Section
-      whatIncluded: {
-        label: "O QUE INCLUI",
-        title: "Tudo o que precisas para começar",
-        description: "Do zero à primeira missão paga, com estrutura completa.",
-        card1Title: "Aprende ao teu ritmo",
-        card1Desc: "100% online, sem horários. Acesso vitalício aos conteúdos e atualizações futuras.",
-        card2Title: "Certificado incluído",
-        card2Desc: "Documento que comprova a conclusão do curso e as tuas competências como avaliador.",
-        card3Title: "Oportunidades reais",
-        card3Desc: "Testa produtos, lojas e restaurantes sem qualquer custo, e ainda recebes por cada visita.",
-      },
-
-      // How It Works Section
-      howWorks: {
-        label: "COMO FUNCIONA",
-        title: "Do curso à primeira missão",
-        description: "Quatro passos simples para começares a ganhar.",
-        step1Title: "Compra o curso",
-        step1Desc: "Pagamento único de 64,99€ → 24,99€. Acesso imediato a todos os módulos.",
-        step2Title: "Aprende",
-        step2Desc: "10 módulos práticos, do enquadramento ao plano de 30 dias.",
-        step3Title: "Regista-te",
-        step3Desc: "Acesso às plataformas de mystery shopping em Portugal.",
-        step4Title: "Ganhas",
-        step4Desc: "De 5 a 150€ por avaliação concluída.",
-      },
-
-      // Testimonials Section
-      testimonials: {
-        label: "TESTEMUNHOS",
-        title: "O que dizem os alunos",
-        description: "Mais de 500 pessoas já completaram o curso.",
-        testimonial1: "Comecei sem saber nada e no primeiro mês já tinha completado 4 missões. Muito prático e direto ao ponto.",
-        testimonial2: "Recomendo o valor do curso logo na primeira avaliação. Excelente investimento.",
-        testimonial3: "Curso bem estruturado. Ótimas informações e suporte ao longo de todo o processo. Já realizei mais de 10 missões.",
-      },
-
-      // CTA Section
-      cta: {
-        title: "Pronto para começar?",
-        description: "Junta-te a mais de 500 alunos que já avaliam e ganham em Portugal.",
-        immediateAccess: "Acesso imediato",
-        certificateIncluded: "Certificado incluído",
-        lifetimeSupport: "Suporte vitalício",
-      },
+      badge: "O único curso do género em Portugal",
+      titleLine1: "Avalia lojas.",
+      titleLine2: "Recebe por isso",
+      step1: "Inscreve-te no curso",
+      step2: "Realiza todos os módulos",
+      step3: "Acesso a todas as missões das várias empresas em Portugal",
     },
 
     // About Page
@@ -545,71 +488,14 @@ export const translations = {
       logout: "Sign Out",
       dashboard: "Dashboard",
     },
-    // Home Page
+    // Home Page — single screen: value proposition + the three process steps.
     home: {
-      badge: "THE ONLY COURSE IN PORTUGAL",
-      title: "Want extra income?",
-      titleHighlight: "Become a Mystery Shopper",
-      description: "Evaluate shops, restaurants and products at your own pace, and get paid for it. Certificate included.",
-      buyButton: "Buy the course",
-      viewProgram: "View the program",
-      originalPrice: "€64.99",
-      discountPrice: "€24.99",
-
-      // Stats
-      stats: {
-        reviews: "Reviews",
-        students: "Students",
-        modules: "Modules",
-        rating: "Rating",
-      },
-
-      // What's Included Section
-      whatIncluded: {
-        label: "WHAT'S INCLUDED",
-        title: "Everything you need to get started",
-        description: "From zero to your first paid mission, with complete structure.",
-        card1Title: "Learn at your own pace",
-        card1Desc: "100% online, no schedules. Lifetime access to content and future updates.",
-        card2Title: "Certificate included",
-        card2Desc: "Document that proves course completion and your skills as an evaluator.",
-        card3Title: "Real opportunities",
-        card3Desc: "Test products, shops and restaurants at no cost, and still get paid for each visit.",
-      },
-
-      // How It Works Section
-      howWorks: {
-        label: "HOW IT WORKS",
-        title: "From course to your first mission",
-        description: "Four simple steps to start earning.",
-        step1Title: "Buy the course",
-        step1Desc: "One-time payment of €64.99 → €24.99. Immediate access to all modules.",
-        step2Title: "Learn",
-        step2Desc: "10 practical modules, from the framework to the 30-day plan.",
-        step3Title: "Register",
-        step3Desc: "Access to mystery shopping platforms in Portugal.",
-        step4Title: "Earn",
-        step4Desc: "€5 to €150 per completed evaluation.",
-      },
-
-      // Testimonials Section
-      testimonials: {
-        label: "TESTIMONIALS",
-        title: "What students say",
-        description: "Over 500 people have already completed the course.",
-        testimonial1: "I started knowing nothing and completed 4 missions in the first month. Very practical and straightforward.",
-        testimonial2: "I recommend the course value from the first evaluation. Excellent investment.",
-        testimonial3: "Well-structured course. Great information and support throughout the process. I've already completed over 10 missions.",
-      },
-
-      // CTA Section
-      cta: {
-        title: "Ready to get started?",
-        description: "Join over 500 students who are already evaluating and earning in Portugal.",
-        immediateAccess: "Immediate access",
-        certificateIncluded: "Certificate included",
-        lifetimeSupport: "Lifetime support",
-      },
+      badge: "The only course of its kind in Portugal",
+      titleLine1: "Evaluate stores.",
+      titleLine2: "Get paid for it",
+      step1: "Sign up for the course",
+      step2: "Complete every module",
+      step3: "Access every mission from companies across Portugal",
     },
 
     // About Page

--- a/app/o-curso/page.module.css
+++ b/app/o-curso/page.module.css
@@ -568,3 +568,66 @@
   background: var(--color-bg-light);
   box-shadow: 0 6px 16px rgba(15, 76, 92, 0.28);
 }
+
+/* ============================================================
+   COMO FUNCIONA — secção vinda da antiga página inicial
+   ============================================================ */
+.sectionSteps {
+  padding: 96px 0;
+  background: var(--color-bg-light);
+  border-top: 1px solid var(--color-gray-light);
+  border-bottom: 1px solid var(--color-gray-light);
+}
+@media (max-width: 720px) { .sectionSteps { padding: 64px 0; } }
+
+.headKicker {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-primary-red);
+  margin: 16px 0 0;
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+@media (min-width: 760px) { .steps { grid-template-columns: repeat(2, 1fr); } }
+@media (min-width: 1060px) { .steps { grid-template-columns: repeat(4, 1fr); } }
+
+.step {
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-light);
+  border-radius: var(--radius-lg);
+  padding: 32px 28px;
+  transition: all 300ms ease;
+}
+.step:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  border-color: rgba(239, 62, 77, 0.2);
+}
+.stepNum {
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-primary-red);
+  margin-bottom: 16px;
+}
+.stepTitle {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  color: var(--color-text-primary);
+  margin: 0 0 12px;
+}
+.stepDesc {
+  font-size: 15px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0;
+  text-wrap: pretty;
+}

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -35,6 +35,14 @@ function BuyButton({ children, className }: { children: React.ReactNode; classNa
   );
 }
 
+/* Passos "Como funciona" — vindos da antiga página inicial. */
+const howItWorks = [
+  { n: "Passo 01", t: "Compras uma vez", d: "Pagamento único de 24,99 €. Acesso imediato e vitalício, em qualquer dispositivo, com atualizações incluídas." },
+  { n: "Passo 02", t: "Aprendes o método", d: "Dez módulos com casos reais, formulários-tipo e um quiz no fim de cada um para fixares o essencial." },
+  { n: "Passo 03", t: "Registas-te nas plataformas", d: "Damos-te a lista das empresas que operam em Portugal e o guião para criares um perfil que é escolhido." },
+  { n: "Passo 04", t: "Aceitas missões e recebes", d: "Escolhes onde, quando e quantas vezes. Cada missão é paga depois de o relatório ser aprovado." },
+];
+
 /* Benefit icons */
 const benefitIcons = [
   /* Beginners */ (
@@ -184,6 +192,39 @@ Dez módulos curtos, casos reais e um plano de 30 dias para saíres daqui com a 
                 </div>
                 <h3 className={styles.benefitTitle}>{b.title}</h3>
                 <p className={styles.benefitDesc}>{b.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ============================================================
+          COMO FUNCIONA
+          ============================================================ */}
+      <section className={styles.sectionSteps}>
+        <div className={styles.wrap}>
+          <div className={styles.head}>
+            <div>
+              <div className={styles.eyebrow}>Como funciona</div>
+              <h2 className={styles.displayLg}>
+                Do carrinho à primeira missão paga.
+              </h2>
+              <p className={styles.headKicker}>
+                Sem agências, sem comissões, sem mensalidades
+              </p>
+            </div>
+            <p className={styles.headSub}>
+              Compras uma vez, aprendes ao teu ritmo e candidatas-te diretamente às plataformas. O
+              dinheiro da missão é todo teu.
+            </p>
+          </div>
+
+          <div className={styles.steps}>
+            {howItWorks.map((s) => (
+              <div className={styles.step} key={s.n}>
+                <div className={styles.stepNum}>{s.n}</div>
+                <h3 className={styles.stepTitle}>{s.t}</h3>
+                <p className={styles.stepDesc}>{s.d}</p>
               </div>
             ))}
           </div>

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,53 +1,52 @@
 /*
- * Cliente Mistério — Homepage.
- * Sistema claro: fundo branco, texto #1A1A1A, azul #0F4C5C no hero e nos blocos
- * escuros, vermelho #EF3E4D como cor de energia e CTA.
+ * Cliente Mistério — Homepage de ecrã único.
+ * Fundo azul profundo (mesma superfície escura do resto do site), vermelho
+ * #EF3E4D como cor de energia e números fantasma como decoração.
  * CSS Module ao lado de app/page.tsx.
  */
 
-/* Reset das regras globais de <button>/<a> dentro desta página. */
-.page button {
-  background: transparent;
-  color: inherit;
-  border: 0;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  letter-spacing: normal;
-  text-transform: none;
-  border-radius: 0;
-  box-shadow: none;
-  width: auto;
-  min-width: 0;
-  overflow: visible;
-  text-align: inherit;
-  cursor: pointer;
-  box-sizing: border-box;
-  -webkit-appearance: none;
-  appearance: none;
-}
-.page button::before,
-.page button::after { content: none; }
-.page button:disabled { cursor: not-allowed; }
-.page a {
-  border-bottom: none !important;
-  color: inherit;
-  text-decoration: none;
-  transition: color .2s;
-}
-
 /* ============================================================
-   LAYOUT PRIMITIVES
+   PALCO — ocupa exatamente um ecrã, sem scroll
    ============================================================ */
+/* Na página inicial o `main` é uma coluna flex (ver AppShell): `flex: 1`
+   preenche exatamente o ecrã menos o cabeçalho, sem depender da altura da
+   barra em cada breakpoint e sem gerar scroll. */
 .page {
-  background: var(--color-white);
-  color: var(--color-text-primary);
-  font-size: 16px;
-  line-height: 1.7;
+  display: flex;
+  flex: 1;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-blue) 0%,
+    var(--color-blue-deep) 100%
+  );
+  color: var(--color-white);
   font-family: var(--font-body);
   overflow-x: hidden;
 }
+
+.stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: var(--sp-xl) 0;
+  position: relative;
+}
+
+/* Halo vermelho discreto, alinhado com o resto do site. */
+.stage::before {
+  content: "";
+  position: absolute;
+  top: -180px;
+  right: -140px;
+  width: 480px;
+  height: 480px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(239, 62, 77, 0.25) 0%, transparent 70%);
+  pointer-events: none;
+}
+
 .wrap {
+  position: relative;
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
@@ -56,15 +55,12 @@
 @media (min-width: 768px) {
   .wrap { padding: 0 var(--sp-xl); }
 }
-.section { padding: var(--sp-5xl) 0; }
-.sectionTight { padding: var(--sp-4xl) 0; }
-.sectionAlt { background: var(--color-bg-light); }
-@media (max-width: 720px) {
-  .section { padding: var(--sp-2xl) 0; }
-  .sectionTight { padding: var(--sp-xl) 0; }
-}
 
-/* Kicker: traço vermelho + texto em maiúsculas. */
+/* ============================================================
+   PROPOSTA DE VALOR
+   ============================================================ */
+.intro { max-width: 720px; }
+
 .eyebrow {
   display: flex;
   align-items: center;
@@ -73,8 +69,8 @@
   font-weight: 600;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  color: var(--color-primary-red);
-  margin-bottom: var(--sp-sm);
+  color: rgba(255, 255, 255, 0.85);
+  margin: 0 0 var(--sp-sm);
 }
 .eyebrow::before {
   content: "";
@@ -85,738 +81,154 @@
   flex-shrink: 0;
 }
 
-.display {
-  font-family: var(--font-body);
+.title {
+  font-size: clamp(36px, 5.4vw, 64px);
   font-weight: 700;
   letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-text-primary);
+  line-height: 1.12;
+  color: var(--color-white);
   margin: 0;
+  text-wrap: balance;
 }
-.displayXl { font-size: clamp(38px, 5.4vw, 64px); }
-.displayLg { font-size: clamp(30px, 3.6vw, 40px); }
 .dot { color: var(--color-primary-red); }
 
-.lead {
-  font-size: 16px;
-  line-height: 1.7;
-  color: var(--color-text-secondary);
-  max-width: 52ch;
-  margin: 0;
-  text-wrap: pretty;
-}
-
 /* ============================================================
-   BUTTONS
+   PROCESSO
    ============================================================ */
-.page .btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 16px 32px;
-  border-radius: var(--radius-md);
-  font-weight: 600;
-  font-size: 16px;
-  letter-spacing: 0;
-  text-transform: none;
-  border: none;
-  transition: all 200ms ease;
-  white-space: nowrap;
-  text-decoration: none;
-  cursor: pointer;
-  font-family: var(--font-body);
-  line-height: 1.2;
-}
-.page .btn:hover { transform: translateY(-2px); }
-.page .btn:active { transform: translateY(0); }
-
-/* Primário — vermelho preenchido. */
-.page .btnPrimary {
-  background: var(--color-primary-red);
-  color: var(--color-white);
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
-}
-.page .btnPrimary:hover {
-  background: var(--color-red-hover);
-  box-shadow: 0 6px 16px rgba(239, 62, 77, 0.35);
-}
-.page .btnPrimary:active {
-  background: var(--color-red-active);
-  box-shadow: 0 2px 8px rgba(239, 62, 77, 0.25);
-}
-
-/* Vazado sobre o hero azul — contorno branco. */
-.page .btnGhost {
-  background: transparent;
-  border: 2px solid rgba(255, 255, 255, 0.5);
-  color: var(--color-white);
-  padding: 14px 30px;
-}
-.page .btnGhost:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: var(--color-white);
-  color: var(--color-white);
-}
-
-.page .btnSmall { padding: 12px 24px; font-size: 14px; }
-
-.arrow { transition: transform .2s ease; }
-.page .btn:hover .arrow { transform: translateX(4px); }
-
-.priceStrike {
-  text-decoration: line-through;
-  opacity: .55;
-  font-weight: 600;
-}
-
-/* ============================================================
-   HERO — gradiente azul profundo
-   ============================================================ */
-.hero {
+.process {
   position: relative;
-  padding: var(--sp-5xl) 0 150px;
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-blue) 0%,
-    var(--color-blue-deep) 100%
-  );
-  overflow: hidden;
+  margin-top: clamp(var(--sp-2xl), 7vh, var(--sp-5xl));
 }
-@media (max-width: 720px) {
-  .hero { padding: var(--sp-2xl) 0 120px; }
-}
-.heroGrid {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--sp-2xl);
-  align-items: center;
-}
-@media (min-width: 980px) {
-  .heroGrid { grid-template-columns: 1.05fr 0.95fr; gap: var(--sp-4xl); }
-}
-.heroCopy { max-width: 640px; }
 
-/* Kicker do hero: régua vermelha, texto branco para contraste sobre o azul. */
-.heroCopy .eyebrow { color: rgba(255, 255, 255, 0.85); }
-
-.heroTitle {
-  margin-bottom: var(--sp-md);
-  color: var(--color-white);
-}
-.heroSub {
-  margin-bottom: var(--sp-lg);
-  color: rgba(255, 255, 255, 0.9);
-}
-.heroCta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--sp-sm);
-  margin-bottom: var(--sp-lg);
-  align-items: center;
-}
-@media (max-width: 520px) {
-  .heroCta { flex-direction: column; align-items: stretch; }
-  .heroCta > * { width: 100%; }
-}
-.heroTrust {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  font-size: 14px;
-  color: rgba(255, 255, 255, 0.75);
-  padding-top: var(--sp-md);
-  border-top: 1px solid rgba(255, 255, 255, 0.15);
-}
-.heroTrust strong { color: var(--color-white); font-weight: 700; }
-.heroAvatars { display: inline-flex; }
-.heroAvatars span {
-  width: 32px; height: 32px;
-  border-radius: 50%;
-  border: 2px solid var(--color-primary-blue);
-  background: rgba(255, 255, 255, 0.18);
-  margin-left: -8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--color-white);
-  letter-spacing: 0.04em;
-}
-.heroAvatars span:first-child { margin-left: 0; background: var(--color-primary-red); }
-
-/* Visual do hero — cartão de missão (PARTE 6). */
-.heroVisual {
-  position: relative;
+/* Curva ascendente que liga os três nós. Estica-se com o contentor
+   (preserveAspectRatio="none"), por isso os centros dos nós estão nas
+   mesmas percentagens usadas no path: 16,7% / 50% / 83,3%. */
+.track {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
-  max-width: 460px;
-  margin: 0 auto;
-  justify-self: end;
-}
-.heroFrame {
-  position: absolute;
-  inset: 26px -22px -22px 26px;
-  border: 1px solid rgba(239, 62, 77, 0.5);
-  border-radius: var(--radius-xl);
+  height: 154px;
+  overflow: visible;
   pointer-events: none;
 }
-.heroPanel {
-  position: relative;
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(239, 62, 77, 0.4);
-  border-radius: var(--radius-lg);
-  padding: 28px;
-  backdrop-filter: blur(10px);
-}
-.heroPanelTop {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding-bottom: var(--sp-sm);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-  margin-bottom: var(--sp-sm);
-}
-.heroPanelLabel {
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  color: var(--color-primary-red);
-}
-.heroPanelBadge {
-  display: inline-flex;
-  align-items: center;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  color: var(--color-success-green);
-  background: rgba(42, 191, 132, 0.15);
-  border: 1px solid rgba(42, 191, 132, 0.4);
-  border-radius: var(--radius-sm);
-  padding: 5px 10px;
-}
-.heroRows { display: flex; flex-direction: column; }
-.heroRow {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 14px;
-  padding: 12px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  font-size: 15px;
-  color: rgba(255, 255, 255, 0.8);
-}
-.heroRow:last-child { border-bottom: none; }
-.heroRowVal {
-  font-weight: 600;
-  color: var(--color-white);
-  font-size: 15px;
-  white-space: nowrap;
-}
-.heroRowOk { color: var(--color-success-green); }
-.heroRowBad { color: var(--color-primary-red); }
-.heroPayout {
-  margin-top: var(--sp-sm);
-  border-radius: var(--radius-md);
-  background: var(--color-primary-red);
-  color: var(--color-white);
-  padding: 16px 20px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-.heroPayoutLabel {
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  opacity: 0.9;
-}
-.heroPayoutValue {
-  font-size: 30px;
-  font-weight: 700;
-  line-height: 1;
-}
 
-/* ============================================================
-   3 CARTÕES SOBREPOSTOS AO HERO
-   ============================================================ */
-.pillars {
-  position: relative;
-  z-index: 3;
-  margin-top: -90px;
-  padding-bottom: 20px;
-}
-@media (max-width: 720px) {
-  .pillars { margin-top: -76px; }
-}
-.pillarsGrid {
-  position: relative;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--sp-md);
-}
-@media (min-width: 860px) {
-  .pillarsGrid { grid-template-columns: repeat(3, 1fr); }
-}
-.pillarsFrame {
-  position: absolute;
-  right: -18px;
-  bottom: -18px;
-  width: 34%;
-  height: 62%;
-  border-right: 3px solid var(--color-primary-red);
-  border-bottom: 3px solid var(--color-primary-red);
-  border-bottom-right-radius: var(--radius-xl);
-  pointer-events: none;
-  display: none;
-}
-@media (min-width: 860px) {
-  .pillarsFrame { display: block; }
-}
-.pillar {
-  position: relative;
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
-  border-radius: var(--radius-lg);
-  padding: var(--sp-lg);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  transition: all 300ms ease;
-}
-.pillar:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-  border-color: rgba(239, 62, 77, 0.2);
-}
-.pillarAccent {
-  background: var(--color-primary-red);
-  border-color: var(--color-primary-red);
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
-}
-.pillarAccent:hover {
-  border-color: var(--color-primary-red);
-  box-shadow: 0 8px 24px rgba(239, 62, 77, 0.3);
-}
-.pillarIcon {
-  width: 32px;
-  height: 32px;
-  color: var(--color-primary-red);
-  margin-bottom: var(--sp-md);
-  display: block;
-}
-.pillarAccent .pillarIcon { color: var(--color-white); }
-.pillarTitle {
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
-  margin: 0 0 12px;
-}
-.pillarAccent .pillarTitle { color: var(--color-white); }
-.pillarRule {
-  width: 34px;
-  height: 3px;
-  border-radius: var(--radius-pill);
-  background: var(--color-primary-red);
-  margin-bottom: var(--sp-sm);
-}
-.pillarAccent .pillarRule { background: var(--color-white); }
-.pillarDesc {
-  font-size: 15px;
-  line-height: 1.6;
-  color: var(--color-gray-medium);
-  margin: 0;
-  text-wrap: pretty;
-}
-.pillarAccent .pillarDesc { color: rgba(255, 255, 255, 0.92); }
-
-/* ============================================================
-   CABEÇALHO DE SECÇÃO
-   ============================================================ */
-.head {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--sp-md);
-  margin-bottom: var(--sp-2xl);
-  align-items: end;
-}
-@media (min-width: 880px) {
-  .head { grid-template-columns: 1.25fr 1fr; gap: var(--sp-4xl); }
-}
-.headSub {
-  font-size: 16px;
-  line-height: 1.7;
-  color: var(--color-gray-medium);
-  max-width: 46ch;
-  margin: 0;
-  text-wrap: pretty;
-}
-.headKicker {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  color: var(--color-primary-red);
-  margin: var(--sp-sm) 0 0;
-}
-
-/* ============================================================
-   SETORES
-   ============================================================ */
-.cats {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--sp-md);
-}
-@media (min-width: 640px) {
-  .cats { grid-template-columns: repeat(2, 1fr); }
-}
-@media (min-width: 1000px) {
-  .cats { grid-template-columns: repeat(3, 1fr); }
-}
-.cat {
-  position: relative;
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
-  border-top: 3px solid var(--color-primary-red);
-  border-radius: var(--radius-lg);
-  padding: var(--sp-md);
-  display: flex;
-  align-items: center;
-  gap: var(--sp-sm);
-  transition: all 300ms ease;
-}
-.cat:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
-}
-.catIcon {
-  width: 26px;
-  height: 26px;
-  color: var(--color-primary-red);
-  flex-shrink: 0;
-}
-.catBody { flex: 1; min-width: 0; }
-.catName {
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--color-primary-blue);
-  margin: 0 0 4px;
-}
-.catPay {
-  font-size: 14px;
-  color: var(--color-gray-medium);
-  margin: 0;
-}
-.catPay strong {
-  color: var(--color-success-green);
-  font-weight: 700;
-  font-size: 16px;
-}
-.catArrow {
-  color: var(--color-gray-medium);
-  flex-shrink: 0;
-  transition: all 200ms ease;
-}
-.cat:hover .catArrow { color: var(--color-primary-red); transform: translateX(4px); }
-
-/* ============================================================
-   FAIXA DE NÚMEROS
-   ============================================================ */
-.strip {
-  background: var(--color-bg-light);
-  border-top: 1px solid var(--color-gray-light);
-  border-bottom: 1px solid var(--color-gray-light);
-}
-.stripGrid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-}
-@media (min-width: 860px) {
-  .stripGrid { grid-template-columns: repeat(4, 1fr); }
-}
-.stripItem {
-  padding: var(--sp-xl) var(--sp-md);
-  border-right: 1px solid var(--color-gray-light);
-  border-bottom: 1px solid var(--color-gray-light);
-}
-.stripItem:nth-child(2n) { border-right: none; }
-@media (min-width: 860px) {
-  .stripItem { border-bottom: none; }
-  .stripItem:nth-child(2n) { border-right: 1px solid var(--color-gray-light); }
-  .stripItem:last-child { border-right: none; }
-}
-.stripNum {
-  font-size: clamp(32px, 3.2vw, 44px);
-  font-weight: 700;
-  letter-spacing: -0.5px;
-  line-height: 1;
-  color: var(--color-primary-blue);
-  margin-bottom: 12px;
-}
-.stripNum em {
-  font-style: normal;
-  color: var(--color-primary-red);
-}
-.stripLabel {
-  font-size: 13px;
-  color: var(--color-gray-medium);
-  line-height: 1.6;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 600;
-}
-
-/* ============================================================
-   CURRÍCULO
-   ============================================================ */
-.modules { display: flex; flex-direction: column; }
-.module {
-  display: grid;
-  grid-template-columns: 62px 1fr auto;
-  gap: var(--sp-md);
-  padding: var(--sp-md) var(--sp-sm);
-  border-top: 1px solid var(--color-gray-light);
-  align-items: center;
-  transition: all 200ms ease;
-}
-.module:last-child { border-bottom: 1px solid var(--color-gray-light); }
-.module:hover { background: var(--color-white); padding-left: var(--sp-md); }
-.moduleNum {
-  font-weight: 700;
-  font-size: 24px;
-  letter-spacing: -0.3px;
-  line-height: 1;
-  color: var(--color-primary-red);
-}
-.moduleTitle {
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
-  margin: 0 0 6px;
-}
-.moduleDesc {
-  font-size: 15px;
-  color: var(--color-gray-medium);
-  line-height: 1.6;
-  margin: 0;
-  max-width: 62ch;
-  text-wrap: pretty;
-}
-.moduleTime {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-gray-medium);
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  white-space: nowrap;
-  border: 1px solid var(--color-gray-light);
-  background: var(--color-white);
-  border-radius: var(--radius-sm);
-  padding: 6px 10px;
-}
-@media (max-width: 620px) {
-  .module { grid-template-columns: 44px 1fr; }
-  .moduleTime { display: none; }
-}
-
-/* ============================================================
-   PASSOS
-   ============================================================ */
 .steps {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--sp-md);
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--sp-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
-@media (min-width: 760px) {
-  .steps { grid-template-columns: repeat(2, 1fr); }
-}
-@media (min-width: 1060px) {
-  .steps { grid-template-columns: repeat(4, 1fr); }
-}
+
 .step {
   position: relative;
-  background: var(--color-bg-light);
-  border: 1px solid var(--color-gray-light);
-  border-radius: var(--radius-lg);
-  padding: var(--sp-lg);
-  transition: all 300ms ease;
-}
-.step:hover {
-  background: var(--color-white);
-  transform: translateY(-4px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
-}
-.stepNum {
-  font-weight: 600;
-  font-size: 13px;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  color: var(--color-primary-red);
-  margin-bottom: var(--sp-sm);
-}
-.stepTitle {
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
-  margin: 0 0 12px;
-}
-.stepDesc {
-  font-size: 15px;
-  color: var(--color-gray-medium);
-  line-height: 1.6;
-  margin: 0;
-  text-wrap: pretty;
+  /* Cada passo sobe em relação ao anterior; o valor vem do page.tsx. */
+  padding-top: var(--node-y, 0px);
 }
 
-/* ============================================================
-   CTA FINAL
-   ============================================================ */
-.final {
-  position: relative;
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-blue) 0%,
-    var(--color-blue-deep) 100%
-  );
-  color: var(--color-white);
-  border-radius: var(--radius-xl);
-  padding: var(--sp-4xl) var(--sp-lg);
-  overflow: hidden;
-}
-@media (min-width: 880px) { .final { padding: var(--sp-5xl) var(--sp-4xl); } }
-.final::before {
-  content: "";
+/* Número fantasma, atrás do conteúdo. */
+.ghost {
   position: absolute;
-  width: 460px; height: 460px;
-  top: -220px; right: -160px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(239, 62, 77, 0.28) 0%, transparent 70%);
+  top: calc(var(--node-y, 0px) + 26px);
+  left: 40px;
+  font-size: clamp(90px, 9vw, 140px);
+  font-weight: 800;
+  line-height: 0.8;
+  letter-spacing: -4px;
+  color: rgba(255, 255, 255, 0.07);
   pointer-events: none;
+  user-select: none;
 }
-.finalInner { position: relative; max-width: 760px; }
-.finalEyebrow { color: rgba(255, 255, 255, 0.85); }
-.finalTitle {
-  font-size: clamp(30px, 3.8vw, 44px);
-  font-weight: 700;
-  letter-spacing: -0.5px;
-  line-height: 1.2;
-  color: var(--color-white);
-  margin: 0 0 var(--sp-sm);
-}
-.finalSub {
-  font-size: 16px;
-  line-height: 1.7;
-  color: rgba(255, 255, 255, 0.85);
-  margin: 0 0 var(--sp-lg);
-  max-width: 54ch;
-  text-wrap: pretty;
-}
-.finalList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px var(--sp-lg);
-  list-style: none;
-  padding: var(--sp-md) 0 0;
-  margin: 0 0 var(--sp-lg);
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  font-size: 15px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.9);
-}
-.finalList li { display: inline-flex; align-items: center; gap: 10px; }
-.finalList li svg { color: var(--color-success-green); flex-shrink: 0; }
-.finalCta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--sp-md);
-}
-.page .finalBtn {
-  background: var(--color-primary-red);
-  color: var(--color-white);
-  padding: 20px 48px;
-  font-size: 18px;
-  font-weight: 700;
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.35);
-}
-.page .finalBtn:hover {
-  background: var(--color-red-hover);
-  box-shadow: 0 6px 16px rgba(239, 62, 77, 0.45);
-}
-.finalPriceTag {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  color: rgba(255, 255, 255, 0.85);
-  font-size: 14px;
-}
-.finalPriceTag strong {
-  font-size: 28px;
-  font-weight: 700;
-  letter-spacing: -0.5px;
-  color: var(--color-white);
-}
-.finalPriceTag s { color: rgba(255, 255, 255, 0.5); }
 
-/* ============================================================
-   BARRA DE COMPRA FIXA
-   ============================================================ */
-.buyBar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  transform: translateY(130%);
-  background: rgba(255, 255, 255, 0.96);
-  backdrop-filter: blur(12px);
-  color: var(--color-text-primary);
-  border-top: 1px solid var(--color-gray-light);
-  box-shadow: 0 -4px 20px rgba(15, 76, 92, 0.1);
-  padding: 12px var(--sp-md);
-  display: flex;
+/* Nó: ícone dentro de um marcador redondo com halo. */
+.node {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--sp-md);
-  z-index: 40;
-  transition: transform .4s cubic-bezier(0.23, 1, 0.32, 1);
-}
-.buyBarVisible { transform: translateY(0); }
-.buyBarPrice {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--color-gray-medium);
-  white-space: nowrap;
-}
-.buyBarPrice strong {
-  font-size: 22px;
-  color: var(--color-text-primary);
-  font-weight: 700;
-  margin-left: 8px;
-}
-.buyBarPrice s { color: var(--color-gray-medium); }
-.page .buyBarBtn {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
   background: var(--color-primary-red);
   color: var(--color-white);
-  padding: 12px 24px;
-  font-size: 14px;
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+  box-shadow:
+    0 0 0 8px rgba(239, 62, 77, 0.14),
+    0 8px 20px rgba(0, 0, 0, 0.25);
 }
-.page .buyBarBtn:hover {
-  background: var(--color-red-hover);
-  box-shadow: 0 6px 16px rgba(239, 62, 77, 0.35);
+.node svg { width: 22px; height: 22px; }
+
+.stepIndex {
+  position: relative;
+  z-index: 1;
+  display: block;
+  margin-top: var(--sp-md);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-red-on-dark);
 }
-@media (max-width: 520px) {
-  .buyBar { padding: 10px 14px; gap: 12px; }
-  .buyBarPrice { font-size: 13px; }
-  .buyBarPrice strong { font-size: 18px; }
-  .page .buyBarBtn { padding: 12px 18px; }
+
+.stepTitle {
+  position: relative;
+  z-index: 1;
+  margin: 8px 0 0;
+  font-size: clamp(17px, 1.6vw, 22px);
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  line-height: 1.35;
+  color: var(--color-white);
+  max-width: 22ch;
+  text-wrap: pretty;
+}
+
+/* ============================================================
+   MOBILE — lista vertical, sem a curva
+   ============================================================ */
+@media (max-width: 860px) {
+  .track { display: none; }
+  .steps {
+    grid-template-columns: 1fr;
+    gap: var(--sp-md);
+  }
+  .step {
+    /* Anula o escalonamento em diagonal. */
+    padding-top: 0;
+    padding-left: 64px;
+    min-height: 48px;
+  }
+  .node {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 44px;
+    height: 44px;
+    box-shadow: 0 0 0 6px rgba(239, 62, 77, 0.14);
+  }
+  /* Fio vertical a ligar os nós. */
+  .step:not(:last-child)::before {
+    content: "";
+    position: absolute;
+    top: 48px;
+    left: 21px;
+    bottom: -24px;
+    width: 2px;
+    border-radius: var(--radius-pill);
+    background: linear-gradient(
+      180deg,
+      rgba(239, 62, 77, 0.7) 0%,
+      rgba(255, 255, 255, 0.15) 100%
+    );
+  }
+  .ghost {
+    top: -12px;
+    left: auto;
+    right: 0;
+    font-size: 84px;
+  }
+  .stepIndex { margin-top: 0; }
+  .stepTitle { max-width: none; }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,505 +1,107 @@
 /*
- * DESCRIÇÃO DO FICHEIRO: Landing page principal — design "Turkish Red & Railroad Black",
- * layout editorial de agência focado em conversão.
+ * DESCRIÇÃO DO FICHEIRO: Landing page principal — versão de ecrã único.
+ * Mostra apenas a proposta de valor e os três passos do processo; todo o
+ * restante conteúdo vive nas páginas /about, /o-curso, /faq e /catalogo.
  */
 
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useLanguage } from "@/app/context/LanguageContext";
 import styles from "./page.module.css";
 
-/* ---------- Ícones reutilizáveis ---------- */
-const ArrowIcon = ({ size = 15 }: { size?: number }) => (
-  <svg className={styles.arrow} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-    <path d="M5 12h14" />
-    <path d="m12 5 7 7-7 7" />
-  </svg>
-);
-
-const CheckIcon = ({ size = 12 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-    <polyline points="20 6 9 17 4 12" />
-  </svg>
-);
-
-/* ---------- Botão de compra ligado ao Stripe (replica CheckoutButton) ---------- */
-function BuyButton({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  const router = useRouter();
-  const paymentLink = process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK;
-
-  const handleCheckout = () => {
-    if (!paymentLink) return;
-    const session =
-      typeof window !== "undefined" ? localStorage.getItem("vp_session") : null;
-    if (session) {
-      window.location.href = paymentLink;
-    } else {
-      router.push("/login?checkout=1");
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={handleCheckout}
-      disabled={!paymentLink}
-      className={className}
-      title={!paymentLink ? "Payment link não configurado" : undefined}
-    >
-      {children}
-    </button>
-  );
-}
-
-/* ---------- Dados ---------- */
-const pillars = [
-  {
-    title: "Vês o que ninguém vê",
-    desc: "Aprendes a ler uma loja em 30 segundos: tempos, guiões, linguagem corporal, higiene. Depois do curso, nunca mais entras num café da mesma maneira.",
-    accent: true,
-    icon: (
-      <svg className={styles.pillarIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-        <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
-        <circle cx="12" cy="12" r="3" />
-      </svg>
-    ),
-  },
-  {
-    title: "Método, não sorte",
-    desc: "Dez módulos com o processo completo: preparar a visita, executar sem levantar suspeitas, guardar provas e entregar um relatório que passa à primeira.",
-    accent: false,
-    icon: (
-      <svg className={styles.pillarIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-        <path d="M9 11H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h5" />
-        <path d="M15 3h5a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1h-5" />
-        <path d="M9 3h6v18H9z" />
-      </svg>
-    ),
-  },
-  {
-    title: "Pago por missão",
-    desc: "Entre 5 € e 150 € por visita, além da refeição, das compras ou da estadia reembolsadas. Escolhes quando, onde e quantas. Sem chefe e sem horário.",
-    accent: false,
-    icon: (
-      <svg className={styles.pillarIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-        <path d="M12 1v22" />
-        <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-      </svg>
-    ),
-  },
-];
-
-const categories = [
-  {
-    name: "Restauração",
-    pay: "20–60 €",
-    note: "refeição incluída",
-    icon: (
-      <>
-        <path d="M6 2v7a3 3 0 0 0 6 0V2" />
-        <path d="M9 12v10" />
-        <path d="M19 2c.6 3.5.6 7 0 10.5-1 .5-2 1-2 3.5v6" />
-      </>
-    ),
-  },
-  {
-    name: "Retalho e moda",
-    pay: "10–40 €",
-    note: "30 a 60 minutos",
-    icon: (
-      <>
-        <path d="M3 3h18l-2 4H5z" />
-        <path d="M5 7v14h14V7" />
-        <path d="M9 12h6" />
-      </>
-    ),
-  },
-  {
-    name: "Hotelaria",
-    pay: "80–150 €",
-    note: "estadia paga",
-    icon: (
-      <>
-        <path d="M3 21V8l9-5 9 5v13" />
-        <path d="M9 21v-8h6v8" />
-        <path d="M2 21h20" />
-      </>
-    ),
-  },
-  {
-    name: "Banca e seguros",
-    pay: "15–50 €",
-    note: "atendimento e conformidade",
-    icon: (
-      <>
-        <path d="M3 10 12 4l9 6" />
-        <path d="M5 10v9M19 10v9M9 10v9M15 10v9" />
-        <path d="M3 21h18" />
-      </>
-    ),
-  },
-  {
-    name: "Farmácias e saúde",
-    pay: "10–30 €",
-    note: "visitas rápidas",
-    icon: (
-      <>
-        <rect x="3" y="3" width="18" height="18" rx="2" />
-        <path d="M12 8v8M8 12h8" />
-      </>
-    ),
-  },
-  {
-    name: "Telecom e automóvel",
-    pay: "15–40 €",
-    note: "presencial, telefone e online",
-    icon: (
-      <>
-        <rect x="6" y="2" width="12" height="20" rx="2" />
-        <path d="M11 18h2" />
-      </>
-    ),
-  },
-];
-
-const modules = [
-  { n: "01", t: "O lado invisível do serviço", d: "O que é mesmo um cliente mistério, quem paga a fatura e porque é que a tua opinião vale dinheiro.", time: "14 min" },
-  { n: "02", t: "O mercado e onde estão as missões", d: "Quem opera em Portugal, que setores pagam melhor e como escolher missões que compensam.", time: "16 min" },
-  { n: "03", t: "Perfil, conduta e ética", d: "Discrição, imparcialidade e confidencialidade — as três regras que te mantêm no jogo.", time: "18 min" },
-  { n: "04", t: "Avaliar sem opinar", d: "Transformar o que viste em dados objetivos: factos, tempos e critérios em vez de \"gostei\".", time: "22 min" },
-  { n: "05", t: "Preparar a missão", d: "Ler o briefing como um profissional, montar o cenário e memorizar o essencial sem apontamentos.", time: "20 min" },
-  { n: "06", t: "Execução no terreno", d: "Entrar, observar, cronometrar e sair sem ser apanhado. Restauração, retalho, banca e hotelaria.", time: "24 min" },
-  { n: "07", t: "Provas à prova de dúvida", d: "Talões, fotos, gravações e nomes: o que recolher, como guardar e o que a lei permite.", time: "19 min" },
-  { n: "08", t: "O relatório aprovado à primeira", d: "Estrutura, tom e nível de detalhe. Os erros que fazem chumbar relatórios — e como evitá-los.", time: "22 min" },
-  { n: "09", t: "Quanto ganhas e quanto sobra", d: "Honorários, reembolsos, custos e impostos. Contas reais para saberes o que rende cada missão.", time: "18 min" },
-  { n: "10", t: "Plano de ação de 30 dias", d: "Inscrições nas plataformas, primeiro perfil, primeiras missões e como subir de nível.", time: "20 min" },
-];
-
-const steps = [
-  { n: "Passo 01", t: "Compras uma vez", d: "Pagamento único de 24,99 €. Acesso imediato e vitalício, em qualquer dispositivo, com atualizações incluídas." },
-  { n: "Passo 02", t: "Aprendes o método", d: "Dez módulos com casos reais, formulários-tipo e um quiz no fim de cada um para fixares o essencial." },
-  { n: "Passo 03", t: "Registas-te nas plataformas", d: "Damos-te a lista das empresas que operam em Portugal e o guião para criares um perfil que é escolhido." },
-  { n: "Passo 04", t: "Aceitas missões e recebes", d: "Escolhes onde, quando e quantas vezes. Cada missão é paga depois de o relatório ser aprovado." },
+/* ---------- Ícones dos nós do processo ---------- */
+const StepIcons = [
+  /* 01 — inscrição */ (
+    <svg key="signup" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V4s-1 1-4 1-5-2-8-2-4 1-4 1Z" />
+      <path d="M4 22v-7" />
+    </svg>
+  ),
+  /* 02 — módulos */ (
+    <svg key="modules" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+      <path d="M6.5 3H20v18H6.5A2.5 2.5 0 0 1 4 18.5v-13A2.5 2.5 0 0 1 6.5 3Z" />
+      <path d="M9 7h7M9 11h5" />
+    </svg>
+  ),
+  /* 03 — missões */ (
+    <svg key="missions" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M21 10c0 6-9 12-9 12s-9-6-9-12a9 9 0 0 1 18 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  ),
 ];
 
 export default function HomePage() {
-  const [showBuyBar, setShowBuyBar] = useState(false);
-  const finalRef = useRef<HTMLElement>(null);
+  const { t } = useLanguage();
 
-  useEffect(() => {
-    const onScroll = () => {
-      const el = finalRef.current;
-      let finalVisible = false;
-      if (el) {
-        const r = el.getBoundingClientRect();
-        finalVisible = r.top < window.innerHeight && r.bottom > 0;
-      }
-      setShowBuyBar(window.scrollY > 600 && !finalVisible);
-    };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    onScroll();
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
+  const steps = [t.home.step1, t.home.step2, t.home.step3];
 
   return (
     <div className={styles.page}>
-      {/* ============================================================
-          HERO
-          ============================================================ */}
-      <header className={styles.hero} id="home">
-        <div className={`${styles.wrap} ${styles.heroGrid}`}>
-          <div className={styles.heroCopy}>
-            <div className={styles.eyebrow}>O único curso do género em Portugal</div>
-            <h1 className={`${styles.display} ${styles.displayXl} ${styles.heroTitle}`}>
-              Avalia lojas.
+      <section className={styles.stage}>
+        <div className={styles.wrap}>
+          {/* ----------------------------------------------------------
+              PROPOSTA DE VALOR
+              ---------------------------------------------------------- */}
+          <div className={styles.intro}>
+            <p className={styles.eyebrow}>{t.home.badge}</p>
+            <h1 className={styles.title}>
+              {t.home.titleLine1}
               <br />
-              Recebe por isso<span className={styles.dot}>.</span>
+              {t.home.titleLine2}
+              <span className={styles.dot}>.</span>
             </h1>
-            <p className={`${styles.lead} ${styles.heroSub}`}>
-              Entras como cliente comum, sais com um relatório que vale dinheiro. Ensinamos-te o
-              método completo — observar, documentar e reportar como um profissional — em dez
-              módulos diretos ao assunto, com certificado no fim.
-            </p>
-
-            <div className={styles.heroCta}>
-              <BuyButton className={`${styles.btn} ${styles.btnPrimary}`}>
-                Começar agora
-                <ArrowIcon />
-              </BuyButton>
-              <a href="/o-curso" className={`${styles.btn} ${styles.btnGhost}`}>
-                Ver o programa
-              </a>
-            </div>
-
-            <div className={styles.heroTrust}>
-              <div className={styles.heroAvatars}>
-                <span>AP</span>
-                <span>RC</span>
-                <span>MF</span>
-                <span>JS</span>
-              </div>
-              <span>
-                <strong>+500 alunos</strong> já avaliam em Portugal &nbsp;·&nbsp;{" "}
-                <strong>4,9/5</strong> de satisfação
-              </span>
-            </div>
           </div>
 
-          {/* Visual do hero — relatório de missão estilizado */}
-          <div className={styles.heroVisual}>
-            <span className={styles.heroFrame} aria-hidden />
-            <div className={styles.heroPanel}>
-              <div className={styles.heroPanelTop}>
-                <span className={styles.heroPanelLabel}>Missão #4172 · Cafetaria</span>
-                <span className={styles.heroPanelBadge}>Aprovado</span>
-              </div>
+          {/* ----------------------------------------------------------
+              PROCESSO — três nós ligados por uma curva ascendente
+              ---------------------------------------------------------- */}
+          <div className={styles.process}>
+            <svg
+              className={styles.track}
+              viewBox="0 0 100 100"
+              preserveAspectRatio="none"
+              aria-hidden
+            >
+              <defs>
+                <linearGradient id="cmTrack" x1="0" y1="1" x2="1" y2="0">
+                  <stop offset="0%" stopColor="#ef3e4d" stopOpacity="0.25" />
+                  <stop offset="45%" stopColor="#ef3e4d" stopOpacity="0.9" />
+                  <stop offset="100%" stopColor="#ffffff" stopOpacity="0.55" />
+                </linearGradient>
+              </defs>
+              <path
+                d="M 0,95 C 8,86 11,84.4 16.7,84.4 C 31,84.4 36,46.8 50,46.8 C 64,46.8 69,15.6 83.3,15.6 C 90,15.6 95,11 100,6"
+                fill="none"
+                stroke="url(#cmTrack)"
+                strokeWidth="2"
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            </svg>
 
-              <div className={styles.heroRows}>
-                <div className={styles.heroRow}>
-                  <span>Tempo até ser abordado</span>
-                  <span className={styles.heroRowVal}>1 min 42 s</span>
-                </div>
-                <div className={styles.heroRow}>
-                  <span>Cumprimento inicial</span>
-                  <span className={`${styles.heroRowVal} ${styles.heroRowOk}`}>Cumprido</span>
-                </div>
-                <div className={styles.heroRow}>
-                  <span>Sugestão de complemento</span>
-                  <span className={`${styles.heroRowVal} ${styles.heroRowBad}`}>Não cumprido</span>
-                </div>
-                <div className={styles.heroRow}>
-                  <span>Higiene do balcão</span>
-                  <span className={`${styles.heroRowVal} ${styles.heroRowOk}`}>9 / 10</span>
-                </div>
-                <div className={styles.heroRow}>
-                  <span>Evidências anexadas</span>
-                  <span className={styles.heroRowVal}>Talão + 3 fotos</span>
-                </div>
-              </div>
-
-              <div className={styles.heroPayout}>
-                <span className={styles.heroPayoutLabel}>Pagamento da missão</span>
-                <span className={styles.heroPayoutValue}>35,00 €</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      {/* ============================================================
-          PILARES (sobrepostos ao hero)
-          ============================================================ */}
-      <section className={styles.pillars}>
-        <div className={styles.wrap}>
-          <div className={styles.pillarsGrid}>
-            <span className={styles.pillarsFrame} aria-hidden />
-            {pillars.map((p) => (
-              <article
-                key={p.title}
-                className={`${styles.pillar} ${p.accent ? styles.pillarAccent : ""}`}
-              >
-                {p.icon}
-                <h3 className={styles.pillarTitle}>{p.title}</h3>
-                <div className={styles.pillarRule} />
-                <p className={styles.pillarDesc}>{p.desc}</p>
-              </article>
-            ))}
+            <ol className={styles.steps}>
+              {steps.map((label, i) => (
+                <li
+                  className={styles.step}
+                  key={label}
+                  style={{ "--node-y": `${[106, 48, 0][i]}px` } as React.CSSProperties}
+                >
+                  <span className={styles.ghost} aria-hidden>
+                    {i + 1}
+                  </span>
+                  <span className={styles.node} aria-hidden>
+                    {StepIcons[i]}
+                  </span>
+                  <span className={styles.stepIndex}>{`0${i + 1}`}</span>
+                  <h2 className={styles.stepTitle}>{label}</h2>
+                </li>
+              ))}
+            </ol>
           </div>
         </div>
       </section>
-
-      {/* ============================================================
-          SETORES
-          ============================================================ */}
-      <section className={styles.section} id="categorias">
-        <div className={styles.wrap}>
-          <div className={styles.head}>
-            <div>
-              <h2 className={`${styles.display} ${styles.displayLg}`}>
-                O que vais avaliar<span className={styles.dot}>.</span>
-              </h2>
-              <p className={styles.headKicker}>Trabalhas quando queres, onde queres</p>
-            </div>
-            <p className={styles.headSub}>
-              As plataformas de mystery shopping em Portugal cobrem dezenas de setores. Depois do
-              curso escolhes as missões que encaixam na tua zona, no teu horário e no teu perfil.
-            </p>
-          </div>
-
-          <div className={styles.cats}>
-            {categories.map((c) => (
-              <div className={styles.cat} key={c.name}>
-                <svg className={styles.catIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                  {c.icon}
-                </svg>
-                <div className={styles.catBody}>
-                  <h3 className={styles.catName}>{c.name}</h3>
-                  <p className={styles.catPay}>
-                    <strong>{c.pay}</strong> · {c.note}
-                  </p>
-                </div>
-                <svg className={styles.catArrow} width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                  <path d="M5 12h14" />
-                  <path d="m12 5 7 7-7 7" />
-                </svg>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ============================================================
-          NÚMEROS
-          ============================================================ */}
-      <section className={styles.strip}>
-        <div className={styles.wrap}>
-          <div className={styles.stripGrid}>
-            <div className={styles.stripItem}>
-              <div className={styles.stripNum}>10</div>
-              <div className={styles.stripLabel}>Módulos práticos</div>
-            </div>
-            <div className={styles.stripItem}>
-              <div className={styles.stripNum}>
-                <em>5–150</em> €
-              </div>
-              <div className={styles.stripLabel}>Por missão concluída</div>
-            </div>
-            <div className={styles.stripItem}>
-              <div className={styles.stripNum}>100%</div>
-              <div className={styles.stripLabel}>Online e sem horários</div>
-            </div>
-            <div className={styles.stripItem}>
-              <div className={styles.stripNum}>+500</div>
-              <div className={styles.stripLabel}>Alunos em Portugal</div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ============================================================
-          CURRÍCULO
-          ============================================================ */}
-      <section className={`${styles.section} ${styles.sectionAlt}`} id="curso">
-        <div className={styles.wrap}>
-          <div className={styles.head}>
-            <div>
-              <div className={styles.eyebrow}>O programa</div>
-              <h2 className={`${styles.display} ${styles.displayLg}`}>
-                Do zero à primeira missão paga<span className={styles.dot}>.</span>
-              </h2>
-            </div>
-            <p className={styles.headSub}>
-              Cada módulo é curto, prático e termina com um quiz. Sem enchimento, sem teoria a mais
-              — só o que precisas para entrar numa loja e sair com um relatório aprovado.
-            </p>
-          </div>
-
-          <div className={styles.modules}>
-            {modules.map((m) => (
-              <div className={styles.module} key={m.n}>
-                <div className={styles.moduleNum}>{m.n}</div>
-                <div>
-                  <h3 className={styles.moduleTitle}>{m.t}</h3>
-                  <p className={styles.moduleDesc}>{m.d}</p>
-                </div>
-                <span className={styles.moduleTime}>{m.time}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ============================================================
-          COMO FUNCIONA
-          ============================================================ */}
-      <section className={styles.section}>
-        <div className={styles.wrap}>
-          <div className={styles.head}>
-            <div>
-              <h2 className={`${styles.display} ${styles.displayLg}`}>
-                Como funciona<span className={styles.dot}>.</span>
-              </h2>
-              <p className={styles.headKicker}>Sem agências, sem comissões, sem mensalidades</p>
-            </div>
-            <p className={styles.headSub}>
-              Compras uma vez, aprendes ao teu ritmo e candidatas-te diretamente às plataformas. O
-              dinheiro da missão é todo teu.
-            </p>
-          </div>
-
-          <div className={styles.steps}>
-            {steps.map((s) => (
-              <div className={styles.step} key={s.n}>
-                <div className={styles.stepNum}>{s.n}</div>
-                <h3 className={styles.stepTitle}>{s.t}</h3>
-                <p className={styles.stepDesc}>{s.d}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ============================================================
-          CTA FINAL
-          ============================================================ */}
-      <section className={styles.sectionTight} id="comprar" ref={finalRef}>
-        <div className={styles.wrap}>
-          <div className={styles.final}>
-            <div className={styles.finalInner}>
-              <div className={`${styles.eyebrow} ${styles.finalEyebrow}`}>Pronto para começar</div>
-              <h2 className={styles.finalTitle}>
-                A próxima missão paga pode ser tua.
-              </h2>
-              <p className={styles.finalSub}>
-                Acesso imediato e vitalício. Atualizações futuras incluídas. Sem mensalidades, sem
-                agências e sem letra pequena.
-              </p>
-
-              <ul className={styles.finalList}>
-                <li><CheckIcon size={14} /> 10 módulos</li>
-                <li><CheckIcon size={14} /> Certificado</li>
-                <li><CheckIcon size={14} /> Acesso vitalício</li>
-                <li><CheckIcon size={14} /> 14 dias de reembolso</li>
-              </ul>
-
-              <div className={styles.finalCta}>
-                <BuyButton className={`${styles.btn} ${styles.finalBtn}`}>
-                  Comprar agora
-                  <ArrowIcon />
-                </BuyButton>
-                <div className={styles.finalPriceTag}>
-                  <s>64,99 €</s>
-                  <strong>24,99 €</strong> · pagamento único
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ============================================================
-          BARRA DE COMPRA FIXA
-          ============================================================ */}
-      <div
-        className={`${styles.buyBar} ${showBuyBar ? styles.buyBarVisible : ""}`}
-        aria-hidden={!showBuyBar}
-      >
-        <span className={styles.buyBarPrice}>
-          <s>64,99 €</s>
-          <strong>24,99 €</strong>
-        </span>
-        <BuyButton className={`${styles.btn} ${styles.buyBarBtn}`}>
-          Comprar curso
-          <ArrowIcon size={13} />
-        </BuyButton>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Restructured the homepage from a multi-section editorial layout to a focused single-screen experience. The new design emphasizes the value proposition with a three-step process visualization, while moving detailed content (pillars, categories, modules, stats) to dedicated pages.

## Key Changes

### Homepage Redesign (`app/page.tsx` & `app/page.module.css`)
- **Simplified layout**: Replaced complex hero with grid sections, multiple CTAs, and trust indicators with a clean single-screen stage
- **New visual hierarchy**: 
  - Eyebrow badge + title + value proposition only
  - Three-step process with animated SVG curve connecting nodes
  - Ghost numbers (1, 2, 3) as decorative background elements
  - Red halo accent (radial gradient) for visual interest
- **Process visualization**: 
  - Curved SVG track connecting three process nodes
  - Each step has an icon, title, and index
  - Nodes positioned with CSS custom properties (`--node-y`) for dynamic vertical alignment
  - Ghost numbers scale responsively (clamp 90px–140px)

### Content Redistribution
- **Moved to `/about` page**: Three pillars ("Vês o que ninguém vê", "Método, não sorte", "Pago por missão") with full styling
- **Moved to `/o-curso` page**: "Como funciona" four-step section (purchase → learn → register → earn)
- **Removed from homepage**: Categories grid, stats strip, modules list, testimonials, final CTA section

### CSS Refactoring (`app/page.module.css`)
- **Removed**: 
  - Button reset rules (now handled globally)
  - Hero-specific styles (`.hero`, `.heroGrid`, `.heroCopy`, etc.)
  - Pillar cards, category cards, stats strip, modules list, final CTA section
  - Multiple section padding variants (`.section`, `.sectionTight`, `.sectionAlt`)
- **Added**:
  - `.stage`: Full-height flex container with gradient background (blue to deep blue)
  - `.track`: SVG curve positioning (absolute, 154px height)
  - `.steps`: 3-column grid layout
  - `.step`: Individual step with ghost number and node positioning
  - `.node`: Red circular marker with icon and halo shadow
  - `.ghost`: Large semi-transparent number decoration
  - `.intro`: Max-width container for value proposition

### About Page (`app/about/page.tsx` & `app/about/page.module.css`)
- Added pillar cards section with full styling (3-column grid, hover effects, accent variant)
- Added category cards section (6 sectors with icons and pay ranges)
- Added stats strip section (4-column grid with numbers and labels)
- Imported all necessary CSS classes from old homepage

### Course Page (`app/o-curso/page.tsx` & `app/o-curso/page.module.css`)
- Added "How It Works" section with four-step process cards
- Styled with consistent hover effects and responsive grid layout

### Translations (`app/lib/translations.ts`)
- Simplified `home` object to only include:
  - Badge, title lines, and dot accent
  - Three step labels (signup, modules, missions)
- Removed: stats, what's included, testimonials, CTA sections

### AppShell (`app/components/AppShell.tsx`)
- Added `usePathname` hook for potential route-specific styling
- Main element now uses `flex: 1` to fill available space (enables single-screen layout on homepage)

## Implementation Details

- **Responsive design**: Uses `clamp()` for fluid typography and spacing
- **Performance**: Removed scroll-dependent buy bar logic; simplified component structure
- **Accessibility**: Maintained semantic HTML, SVG icons with `aria-hidden`
- **Visual consistency**: Preserved red accent color (#EF3E4D) and blue gradient from original design
- **Gradient background**: 135deg linear gradient from primary blue to deep blue on homepage stage
- **Decorative elements**: Ghost numbers use `rgba(255, 255, 255, 0.07)` for subtle watermark effect

https://claude.ai/code/session_0195fZ33ChDVcpKjwxdsLAas