### PR TITLE
Rebrand to red/white system with Creato Display typography

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -1,5 +1,8 @@
 /*
- * Página "Sobre" — design "Turkish Red & Railroad Black", alinhado com a homepage.
+ * Página "Sobre" — sistema vermelho/branco.
+ * A página inteira assenta no vermelho da marca; os blocos de foco (cartão de
+ * preço) invertem-se para painel branco. As secções alternam entre o vermelho
+ * base e o vermelho profundo para dar ritmo sem sair da paleta.
  */
 
 /* Reset global button/link styles inside this page */
@@ -10,8 +13,8 @@
    LAYOUT PRIMITIVES
    ============================================================ */
 .page {
-  background: var(--color-white);
-  color: var(--color-text-primary);
+  background: var(--surface-brand);
+  color: var(--color-white);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -30,40 +33,44 @@
 .eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.22em;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: rgba(255, 255, 255, 0.78);
   margin-bottom: 20px;
 }
 .eyebrow::before {
   content: "";
-  width: 30px; height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  width: 34px; height: 2px;
+  background: currentColor;
   flex-shrink: 0;
 }
 
 .displayLg {
-  font-family: var(--font-body);
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-text-primary);
-  font-size: clamp(26px, 3.5vw, 48px);
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  color: var(--color-white);
+  font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
+/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
 .italic {
   font-style: normal;
-  font-weight: 800;
-  color: var(--brand);
+  font-weight: 700;
+  color: var(--color-red);
+  background: var(--color-white);
+  padding: 0 0.14em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 .lead {
-  font-size: clamp(14px, 1.1vw, 17px);
-  line-height: 1.75;
-  color: var(--body);
+  font-size: clamp(15px, 1.1vw, 18px);
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.82);
   max-width: 56ch;
   margin: 0;
 }
@@ -71,7 +78,7 @@
 /* ============================================================
    BUTTONS
    ============================================================ */
-/* CTA vazado com contorno Turkish Red; preenche no hover. */
+/* CTA vazado a branco; enche no hover. */
 .page .btn {
   display: inline-flex;
   align-items: center;
@@ -79,35 +86,37 @@
   gap: 8px;
   padding: 14px 30px;
   border-radius: var(--radius-md);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 16px;
   line-height: 1.2;
-  border: 2px solid var(--color-primary-blue);
+  border: 1.5px solid rgba(255, 255, 255, 0.5);
   background: transparent;
-  color: var(--color-primary-blue);
+  color: var(--color-white);
   transition: all 200ms ease;
   white-space: nowrap;
   cursor: pointer;
   font-family: var(--font-body);
 }
 .page .btn:hover {
-  background: rgba(15, 76, 92, 0.05);
+  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--color-white);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(15, 76, 92, 0.15);
 }
 .page .btn:active { transform: translateY(0); }
 
-/* Variante sólida vermelha — CTA principal. */
+/* Variante sólida — CTA principal. Dentro do cartão branco fica vermelho
+   sobre branco; sobre o vermelho da página fica branco sobre vermelho. */
 .page .btnDark {
-  background: var(--color-primary-red);
-  border-color: var(--color-primary-red);
+  background: var(--color-red);
+  border-color: var(--color-red);
   color: var(--color-white);
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+  box-shadow: 0 4px 14px rgba(227, 6, 19, 0.28);
 }
 .page .btnDark:hover {
-  background: var(--color-red-hover);
-  border-color: var(--color-red-hover);
-  box-shadow: 0 6px 16px rgba(239, 62, 77, 0.35);
+  background: var(--color-red-2);
+  border-color: var(--color-red-2);
+  color: var(--color-white);
+  box-shadow: 0 8px 22px rgba(227, 6, 19, 0.34);
 }
 
 /* ============================================================
@@ -115,10 +124,10 @@
    ============================================================ */
 .hero {
   padding: 96px 0;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--hairline);
 }
 @media (max-width: 720px) { .hero { padding: 64px 0; } }
-.heroInner { max-width: 720px; }
+.heroInner { max-width: 860px; }
 .heroTitle { margin-bottom: 28px; }
 .heroSub { margin-top: 24px; }
 
@@ -137,40 +146,43 @@
 
 /* Advantages */
 .advTitle {
-  font-size: clamp(18px, 2.2vw, 28px);
+  font-size: clamp(19px, 2.2vw, 30px);
   font-weight: 700;
-  letter-spacing: -0.3px;
-  line-height: 1.2;
-  color: var(--color-text-primary);
+  letter-spacing: -0.03em;
+  line-height: 1.14;
+  color: var(--color-white);
   margin: 0 0 16px;
 }
 .advDesc {
   font-size: 15px;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.7);
   line-height: 1.6;
   margin: 0 0 32px;
 }
-.advList { display: flex; flex-direction: column; gap: 12px; }
+.advList { display: flex; flex-direction: column; gap: 10px; }
 .adv {
   display: flex;
   align-items: flex-start;
   gap: 16px;
   padding: 20px 24px;
-  background: var(--color-bg-light);
-  border: 1px solid var(--color-gray-light);
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid var(--hairline);
   border-radius: var(--radius-lg);
   font-size: 15px;
-  color: var(--body);
+  color: rgba(255, 255, 255, 0.88);
   line-height: 1.5;
-  transition: border-color .2s;
+  transition: border-color .2s, background .2s;
 }
-.adv:hover { border-color: var(--brand); }
+.adv:hover {
+  border-color: var(--color-white);
+  background: rgba(255, 255, 255, 0.12);
+}
 .advNum {
   flex-shrink: 0;
   width: 28px; height: 28px;
   border-radius: var(--radius-sm);
-  background: var(--brand);
-  color: var(--moonlight-white);
+  background: var(--color-white);
+  color: var(--color-red);
   font-weight: 700;
   font-size: 13px;
   display: inline-flex;
@@ -179,41 +191,61 @@
 }
 .bodyText {
   font-size: 16px;
-  color: var(--muted);
-  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.7;
   margin: 24px 0 0;
 }
 
-/* Pricing card */
+/* ============================================================
+   PRICING CARD — painel branco invertido
+   ============================================================ */
 .card {
+  /* Vira os tokens herdados para a escala escura: tudo o que está dentro
+     do cartão passa a ler-se sobre branco sem declarações extra. */
+  --line: var(--hairline-invert);
+  --muted: var(--on-invert-3);
+  --body: var(--on-invert-2);
+
   background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
-  border-top: 3px solid var(--color-primary-red);
-  border-radius: var(--radius-lg);
+  color: var(--on-invert);
+  border: none;
+  border-radius: var(--radius-xl);
   padding: 40px;
-  box-shadow: 0 8px 24px rgba(15, 76, 92, 0.1);
+  box-shadow: var(--shadow-lg);
   position: sticky;
   top: 100px;
+  overflow: hidden;
 }
-.cardEyebrow { margin-bottom: 16px; }
+/* Régua vermelha no topo, assinatura dos painéis brancos. */
+.card::before {
+  content: "";
+  position: absolute;
+  top: 0; left: var(--radius-xl);
+  width: 72px; height: 4px;
+  background: var(--color-red);
+}
+.cardEyebrow {
+  margin-bottom: 16px;
+  color: var(--color-red);
+}
 .price {
-  font-size: 36px;
+  font-size: 44px;
   font-weight: 700;
-  letter-spacing: -0.5px;
-  color: var(--color-success-green);
+  letter-spacing: -0.04em;
+  color: var(--on-invert);
   line-height: 1;
   margin: 0 0 4px;
 }
 .priceOriginal {
   font-size: 18px;
-  color: var(--muted);
+  color: var(--on-invert-3);
   text-decoration: line-through;
   margin-right: 8px;
   font-weight: 500;
 }
 .priceNote {
-  font-size: 14px;
-  color: var(--muted);
+  font-size: 13px;
+  color: var(--on-invert-3);
   margin: 0 0 28px;
 }
 .featureList {
@@ -221,8 +253,8 @@
   flex-direction: column;
   gap: 14px;
   padding: 24px 0;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
+  border-top: 1px solid var(--hairline-invert);
+  border-bottom: 1px solid var(--hairline-invert);
   margin-bottom: 28px;
 }
 .featureItem {
@@ -230,14 +262,14 @@
   align-items: center;
   gap: 12px;
   font-size: 15px;
-  color: var(--body);
+  color: var(--on-invert-2);
 }
 .check {
   flex-shrink: 0;
   width: 20px; height: 20px;
   border-radius: var(--radius-sm);
-  background: var(--brand);
-  color: var(--moonlight-white);
+  background: var(--color-red);
+  color: var(--color-white);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -248,12 +280,12 @@
    ============================================================ */
 .sectionAlt {
   padding: 96px 0;
-  background: var(--color-bg-light);
-  border-top: 1px solid var(--color-gray-light);
+  background: var(--surface-brand-alt);
+  border-top: 1px solid var(--hairline-soft);
 }
 @media (max-width: 720px) { .sectionAlt { padding: 64px 0; } }
 
-.dot { color: var(--color-primary-red); }
+.dot { color: rgba(255, 255, 255, 0.5); }
 
 .head {
   display: grid;
@@ -268,17 +300,17 @@
 .headSub {
   font-size: 16px;
   line-height: 1.7;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.7);
   max-width: 46ch;
   margin: 0;
   text-wrap: pretty;
 }
 .headKicker {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--color-primary-red);
+  color: rgba(255, 255, 255, 0.6);
   margin: var(--sp-sm) 0 0;
 }
 
@@ -292,60 +324,59 @@
   .pillars { grid-template-columns: repeat(3, 1fr); }
 }
 .pillar {
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
+  background: transparent;
+  border: 1px solid var(--hairline);
   border-radius: var(--radius-lg);
   padding: var(--sp-lg);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   transition: all 300ms ease;
 }
 .pillar:hover {
   transform: translateY(-4px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-  border-color: rgba(239, 62, 77, 0.2);
+  border-color: var(--color-white);
+  background: rgba(255, 255, 255, 0.07);
 }
+/* O pilar em destaque inverte-se: branco sobre o vermelho da secção. */
 .pillarAccent {
-  background: var(--color-primary-red);
-  border-color: var(--color-primary-red);
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+  background: var(--color-white);
+  border-color: var(--color-white);
+  box-shadow: var(--shadow-md);
 }
 .pillarAccent:hover {
-  border-color: var(--color-primary-red);
-  box-shadow: 0 8px 24px rgba(239, 62, 77, 0.3);
+  background: var(--color-white);
+  border-color: var(--color-white);
 }
 .pillarIcon {
   display: block;
   width: 32px;
   height: 32px;
-  color: var(--color-primary-red);
+  color: var(--color-white);
   margin-bottom: var(--sp-md);
 }
 .pillarIcon svg { width: 100%; height: 100%; }
-.pillarAccent .pillarIcon { color: var(--color-white); }
+.pillarAccent .pillarIcon { color: var(--color-red); }
 .pillarTitle {
-  font-size: 22px;
+  font-size: 23px;
   font-weight: 700;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
+  letter-spacing: -0.025em;
+  color: var(--color-white);
   margin: 0 0 12px;
 }
-.pillarAccent .pillarTitle { color: var(--color-white); }
+.pillarAccent .pillarTitle { color: var(--on-invert); }
 .pillarRule {
   width: 34px;
   height: 3px;
-  border-radius: var(--radius-pill);
-  background: var(--color-primary-red);
+  background: var(--color-white);
   margin-bottom: var(--sp-sm);
 }
-.pillarAccent .pillarRule { background: var(--color-white); }
+.pillarAccent .pillarRule { background: var(--color-red); }
 .pillarDesc {
   font-size: 15px;
-  line-height: 1.6;
-  color: var(--muted);
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.74);
   margin: 0;
   text-wrap: pretty;
 }
-.pillarAccent .pillarDesc { color: rgba(255, 255, 255, 0.92); }
+.pillarAccent .pillarDesc { color: var(--on-invert-2); }
 
 /* Setores */
 .cats {
@@ -360,9 +391,9 @@
   .cats { grid-template-columns: repeat(3, 1fr); }
 }
 .cat {
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
-  border-top: 3px solid var(--color-primary-red);
+  background: transparent;
+  border: 1px solid var(--hairline);
+  border-top: 3px solid var(--color-white);
   border-radius: var(--radius-lg);
   padding: var(--sp-md);
   display: flex;
@@ -372,37 +403,40 @@
 }
 .cat:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.07);
+  border-color: var(--hairline-strong);
+  border-top-color: var(--color-white);
 }
 .catIcon {
   width: 26px;
   height: 26px;
-  color: var(--color-primary-red);
+  color: var(--color-white);
   flex-shrink: 0;
 }
 .catBody { flex: 1; min-width: 0; }
 .catName {
   font-size: 20px;
   font-weight: 700;
-  color: var(--color-primary-blue);
+  letter-spacing: -0.025em;
+  color: var(--color-white);
   margin: 0 0 4px;
 }
 .catPay {
   font-size: 14px;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.7);
   margin: 0;
 }
 .catPay strong {
-  color: var(--color-success-green);
+  color: var(--color-white);
   font-weight: 700;
   font-size: 16px;
 }
 
-/* Faixa de números */
+/* Faixa de números — preto, para ancorar o fim da página. */
 .strip {
-  background: var(--color-bg-light);
-  border-top: 1px solid var(--color-gray-light);
-  border-bottom: 1px solid var(--color-gray-light);
+  background: var(--color-black);
+  border-top: none;
+  border-bottom: none;
 }
 .stripGrid {
   display: grid;
@@ -413,32 +447,32 @@
 }
 .stripItem {
   padding: var(--sp-xl) var(--sp-md);
-  border-right: 1px solid var(--color-gray-light);
-  border-bottom: 1px solid var(--color-gray-light);
+  border-right: 1px solid rgba(255, 255, 255, 0.14);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
 }
 .stripItem:nth-child(2n) { border-right: none; }
 @media (min-width: 860px) {
   .stripItem { border-bottom: none; }
-  .stripItem:nth-child(2n) { border-right: 1px solid var(--color-gray-light); }
+  .stripItem:nth-child(2n) { border-right: 1px solid rgba(255, 255, 255, 0.14); }
   .stripItem:last-child { border-right: none; }
 }
 .stripNum {
-  font-size: clamp(32px, 3.2vw, 44px);
+  font-size: clamp(34px, 3.4vw, 50px);
   font-weight: 700;
-  letter-spacing: -0.5px;
+  letter-spacing: -0.04em;
   line-height: 1;
-  color: var(--color-primary-blue);
+  color: var(--color-white);
   margin-bottom: 12px;
 }
 .stripNum em {
   font-style: normal;
-  color: var(--color-primary-red);
+  color: var(--color-red-bright);
 }
 .stripLabel {
-  font-size: 13px;
-  color: var(--muted);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
   line-height: 1.6;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 600;
+  letter-spacing: 0.18em;
+  font-weight: 700;
 }

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -26,8 +26,8 @@ export default function ApiDocsPage() {
     <main className="min-h-screen bg-[color:var(--background)] px-4 py-6 sm:px-6 md:px-8">
       {/* Título e contexto rápido para orientar quem vai testar endpoints no browser. */}
       <header className="mx-auto mb-4 max-w-6xl">
-        <h1 className="text-2xl font-bold text-[color:var(--ink)]">Swagger API Explorer</h1>
-        <p className="mt-2 text-sm text-[color:var(--body)]">
+        <h1 className="text-2xl font-bold tracking-[-0.03em] text-white">Swagger API Explorer</h1>
+        <p className="mt-2 text-sm text-white/80">
           Use esta página para testar todos os endpoints disponíveis da aplicação.
         </p>
       </header>
@@ -36,7 +36,9 @@ export default function ApiDocsPage() {
       <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
 
       {/* Container onde o Swagger UI será montado no cliente. */}
-      <section className="mx-auto max-w-6xl overflow-hidden rounded-xl border border-[color:var(--line)] bg-[#f5f8fa] p-2 shadow-sm">
+      {/* O Swagger UI traz o seu próprio tema claro: fica num painel branco,
+          como os restantes blocos de foco do sistema. */}
+      <section className="on-light mx-auto max-w-6xl overflow-hidden rounded-xl bg-white p-2 shadow-[0_18px_48px_rgba(0,0,0,0.24)]">
         <div id="swagger-ui" />
       </section>
 

--- a/app/catalogo/page.tsx
+++ b/app/catalogo/page.tsx
@@ -42,7 +42,7 @@ export default function CatalogPage() {
       <style>{`
         @media print {
           header, footer, .no-print { display: none !important; }
-          body { background: #f5f8fa !important; }
+          body { background: #ffffff !important; }
           .print-page { box-shadow: none !important; }
         }
       `}</style>
@@ -66,7 +66,10 @@ export default function CatalogPage() {
         <div className="print-page mx-auto max-w-[820px] bg-white shadow-lg print:shadow-none">
 
           {/* Header */}
-          <div className="bg-gradient-to-br from-[#ef3e4d] to-[#c62a35] px-10 py-10 text-white">
+          {/* Capa do documento a preto: sobre o vermelho da página, é o que
+              torna visível o limite da "folha". O vermelho da marca continua
+              presente nos acentos ao longo do documento. */}
+          <div className="bg-[#141416] px-10 py-10 text-white">
             <div className="flex items-start justify-between gap-6">
               <div>
                 <p className="mb-2 text-sm font-semibold tracking-wide text-white/70">
@@ -112,23 +115,23 @@ export default function CatalogPage() {
 
             {/* For whom */}
             <section>
-              <h2 className="mb-4 text-lg font-bold !text-[#1a1a1a] border-b border-[#e8eef1] pb-2">
+              <h2 className="mb-4 text-lg font-bold !text-[#141416] border-b border-[#e7e7ea] pb-2">
                 {c.forWhomTitle}
               </h2>
-              <p className="text-sm leading-7 text-[#1a1a1a]/80 text-justify">
+              <p className="text-sm leading-7 text-[#141416]/80 text-justify">
                 {c.forWhomDesc}
               </p>
             </section>
 
             {/* What's included */}
             <section>
-              <h2 className="mb-4 text-lg font-bold !text-[#1a1a1a] border-b border-[#e8eef1] pb-2">
+              <h2 className="mb-4 text-lg font-bold !text-[#141416] border-b border-[#e7e7ea] pb-2">
                 {c.whatsIncludedTitle}
               </h2>
               <div className="grid grid-cols-2 gap-3">
                 {includedItems.map((item) => (
-                  <div key={item} className="flex items-start gap-2 text-sm text-[#1a1a1a]/80">
-                    <span className="mt-0.5 shrink-0 text-[#ef3e4d]">✓</span>
+                  <div key={item} className="flex items-start gap-2 text-sm text-[#141416]/80">
+                    <span className="mt-0.5 shrink-0 text-[#e30613]">✓</span>
                     <span className="leading-6">{item}</span>
                   </div>
                 ))}
@@ -137,32 +140,32 @@ export default function CatalogPage() {
 
             {/* Programme */}
             <section>
-              <h2 className="mb-4 text-lg font-bold !text-[#1a1a1a] border-b border-[#e8eef1] pb-2">
+              <h2 className="mb-4 text-lg font-bold !text-[#141416] border-b border-[#e7e7ea] pb-2">
                 {c.programTitle}
               </h2>
               <div className="space-y-2">
                 {modules.map((mod) => (
                   <div
                     key={mod.id}
-                    className="flex items-start gap-4 rounded-lg border border-[#e8eef1] bg-[#e8eef1]/25 px-4 py-3"
+                    className="flex items-start gap-4 rounded-lg border border-[#e7e7ea] bg-[#e7e7ea]/25 px-4 py-3"
                   >
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#ef3e4d]/15 text-xs font-bold text-[#ef3e4d]">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#e30613]/15 text-xs font-bold text-[#e30613]">
                       {mod.id}
                     </div>
                     <div>
-                      <p className="text-sm font-semibold text-[#1a1a1a]">{mod.title}</p>
-                      <p className="text-xs text-[#1a1a1a]/65 mt-0.5">{mod.description}</p>
+                      <p className="text-sm font-semibold text-[#141416]">{mod.title}</p>
+                      <p className="text-xs text-[#141416]/65 mt-0.5">{mod.description}</p>
                     </div>
                   </div>
                 ))}
                 {/* Certificate */}
-                <div className="flex items-start gap-4 rounded-lg border border-[#ef3e4d]/30 bg-[#ef3e4d]/10 px-4 py-3">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#ef3e4d] text-xs font-bold text-white">
+                <div className="flex items-start gap-4 rounded-lg border border-[#e30613]/30 bg-[#e30613]/10 px-4 py-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#e30613] text-xs font-bold text-white">
                     ★
                   </div>
                   <div>
-                    <p className="text-sm font-semibold text-[#1a1a1a]">{c.certificateModuleTitle}</p>
-                    <p className="text-xs text-[#1a1a1a]/65 mt-0.5">
+                    <p className="text-sm font-semibold text-[#141416]">{c.certificateModuleTitle}</p>
+                    <p className="text-xs text-[#141416]/65 mt-0.5">
                       {c.certificateModuleDesc}
                     </p>
                   </div>
@@ -172,17 +175,17 @@ export default function CatalogPage() {
 
             {/* How it works */}
             <section>
-              <h2 className="mb-4 text-lg font-bold !text-[#1a1a1a] border-b border-[#e8eef1] pb-2">
+              <h2 className="mb-4 text-lg font-bold !text-[#141416] border-b border-[#e7e7ea] pb-2">
                 {c.howWorksTitle}
               </h2>
               <div className="grid grid-cols-4 gap-4 text-center">
                 {howWorksSteps.map((item) => (
                   <div key={item.step} className="space-y-2">
-                    <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-[#ef3e4d] text-sm font-bold text-white">
+                    <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-[#e30613] text-sm font-bold text-white">
                       {item.step}
                     </div>
-                    <p className="text-sm font-semibold text-[#1a1a1a]">{item.label}</p>
-                    <p className="text-xs text-[#1a1a1a]/65 leading-5">{item.desc}</p>
+                    <p className="text-sm font-semibold text-[#141416]">{item.label}</p>
+                    <p className="text-xs text-[#141416]/65 leading-5">{item.desc}</p>
                   </div>
                 ))}
               </div>
@@ -190,15 +193,15 @@ export default function CatalogPage() {
           </div>
 
           {/* Document footer */}
-          <div className="border-t border-[#e8eef1] bg-[#e8eef1]/30 px-10 py-6">
+          <div className="border-t border-[#e7e7ea] bg-[#e7e7ea]/30 px-10 py-6">
             <div className="flex items-center justify-between gap-6">
               <div>
-                <p className="text-sm font-bold text-[#1a1a1a]">{c.footerBrand}</p>
-                <p className="text-xs text-[#1a1a1a]/65 mt-0.5">{c.footerUrl}</p>
+                <p className="text-sm font-bold text-[#141416]">{c.footerBrand}</p>
+                <p className="text-xs text-[#141416]/65 mt-0.5">{c.footerUrl}</p>
               </div>
               <div className="text-right">
-                <p className="text-lg font-bold text-[#ef3e4d]">24,99€</p>
-                <p className="text-xs text-[#1a1a1a]/65">{c.footerAccessNote}</p>
+                <p className="text-lg font-bold text-[#e30613]">24,99€</p>
+                <p className="text-xs text-[#141416]/65">{c.footerAccessNote}</p>
               </div>
             </div>
           </div>

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -21,7 +21,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <LanguageProvider>
       <div className="mx-auto flex min-h-screen w-full flex-col bg-transparent">
-        {/* Cabeçalho azul: marca à esquerda, navegação e ações à direita. */}
+        {/* Cabeçalho vermelho: marca à esquerda, navegação e ações à direita. */}
         <header className="site-header sticky top-0 z-50">
           <div className="site-header-inner mx-auto w-full max-w-[1400px]">
             <Link
@@ -29,14 +29,15 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               href="/"
               aria-label="Cliente Mistério — início"
             >
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-[color:var(--color-primary-red)] text-[13px] font-bold tracking-tight text-white">
+              {/* Marca invertida: quadrado branco sobre o vermelho do cabeçalho. */}
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-white text-[13px] font-bold tracking-[-0.02em] text-[color:var(--color-red)]">
                 CM
               </span>
               <span className="hidden flex-col whitespace-nowrap leading-none sm:flex">
-                <span className="text-[16px] font-bold tracking-tight text-white">
-                  Cliente Mistério<span className="text-[color:var(--color-primary-red)]">.</span>
+                <span className="text-[16px] font-bold tracking-[-0.03em] text-white">
+                  Cliente Mistério<span className="text-white/55">.</span>
                 </span>
-                <span className="mt-1 text-[10px] font-semibold uppercase tracking-[0.5px] text-white/60">
+                <span className="mt-1.5 text-[9px] font-bold uppercase tracking-[0.22em] text-white/55">
                   Formação Pro
                 </span>
               </span>
@@ -52,7 +53,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           </div>
 
           {/* Em ecrãs pequenos o seletor de idioma fica numa linha própria. */}
-          <div className="flex w-full justify-center border-t border-white/15 px-3 py-1.5 md:hidden">
+          <div className="flex w-full justify-center border-t border-white/20 px-3 py-1.5 md:hidden">
             <LanguageSwitcher />
           </div>
         </header>

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -50,13 +50,10 @@ export default function Footer() {
 
   return (
     <footer className="relative overflow-hidden">
-      {/* Halo vermelho discreto no canto superior direito. */}
+      {/* Régua vermelha a todo o comprimento: liga o rodapé preto ao corpo
+          vermelho da página em vez de o cortar a seco. */}
       <div
-        className="pointer-events-none absolute -right-24 -top-24 h-72 w-72 rounded-full opacity-25"
-        style={{
-          background:
-            "radial-gradient(circle, var(--color-primary-red) 0%, transparent 70%)",
-        }}
+        className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-[color:var(--color-red)]"
         aria-hidden
       />
       <div className="relative mx-auto w-full max-w-[1200px]">
@@ -65,22 +62,22 @@ export default function Footer() {
           {/* Brand Column */}
           <div className="footer-column lg:col-span-1">
             <div className="mb-5 flex items-center gap-2.5">
-              <span className="flex h-10 w-10 items-center justify-center rounded-[var(--radius-md)] bg-[color:var(--color-primary-red)] text-[13px] font-bold text-white">
+              <span className="flex h-10 w-10 items-center justify-center rounded-[var(--radius-sm)] bg-[color:var(--color-red)] text-[13px] font-bold text-white">
                 CM
               </span>
               <span className="flex flex-col leading-none">
-                <span className="text-[16px] font-bold tracking-tight text-white">
-                  Cliente Mistério<span className="text-[color:var(--color-primary-red)]">.</span>
+                <span className="text-[16px] font-bold tracking-[-0.03em] text-white">
+                  Cliente Mistério<span className="text-[color:var(--color-red)]">.</span>
                 </span>
-                <span className="mt-1 text-[10px] font-semibold uppercase tracking-[0.5px] text-white/60">
+                <span className="mt-1.5 text-[9px] font-bold uppercase tracking-[0.22em] text-white/50">
                   Formação Pro
                 </span>
               </span>
             </div>
-            <p className="mb-4 text-[13px] font-semibold uppercase tracking-[0.5px] text-[color:var(--color-red-on-dark)]">
+            <p className="mb-4 text-[11px] font-bold uppercase tracking-[0.2em] text-[color:var(--color-red-bright)]">
               {t.footer.madeWith}
             </p>
-            <p className="text-[15px] leading-relaxed text-white/70">
+            <p className="text-[15px] leading-relaxed text-white/65">
               {t.footer.tagline}
             </p>
           </div>

--- a/app/components/HeaderActions.tsx
+++ b/app/components/HeaderActions.tsx
@@ -90,14 +90,14 @@ export default function HeaderActions() {
           {/* User Avatar & Name */}
           <div className="user-menu hidden sm:flex">
             <div className="flex items-center gap-2">
-              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--color-primary-red)] text-xs font-bold text-white">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-xs font-bold text-[color:var(--color-red)]">
                 {sessionUser.fullName.charAt(0).toUpperCase()}
               </div>
               <div className="flex flex-col">
                 <span className="user-name leading-tight">
                   {sessionUser.fullName.split(" ")[0]}
                 </span>
-                <span className="text-[10px] uppercase tracking-[0.5px] leading-tight text-white/60">
+                <span className="text-[9px] font-bold uppercase tracking-[0.18em] leading-tight text-white/55">
                   {t.nav.account}
                 </span>
               </div>

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -46,10 +46,10 @@ export default function LanguageSwitcher() {
   const { language, setLanguage } = useLanguage();
 
   const buttonClass = (isActive: boolean) =>
-    `lang-selector flex items-center justify-center gap-1.5 font-semibold ${
+    `lang-selector flex items-center justify-center gap-1.5 ${
       isActive
-        ? "border-[color:var(--color-primary-red)] bg-[color:var(--color-red-soft)] text-white"
-        : "border-white/30 text-white/70 hover:text-white"
+        ? "!border-white !bg-white !text-[color:var(--color-red)]"
+        : "border-white/35 text-white/70 hover:text-white"
     }`;
 
   return (

--- a/app/components/ThreePointsCards.tsx
+++ b/app/components/ThreePointsCards.tsx
@@ -5,24 +5,29 @@ import { useLanguage } from "@/app/context/LanguageContext";
 export default function ThreePointsCards() {
   const { t } = useLanguage();
 
+  // Alterna vermelho profundo / branco / preto: o trio percorre a paleta
+  // inteira sem introduzir cores fora do sistema.
   const benefits = [
     {
       title: t.threePoints.learn,
       description: t.threePoints.learnDesc,
-      background:
-        "linear-gradient(155deg, var(--color-primary-red) 0%, var(--color-red-hover) 100%)",
+      surface: "bg-[color:var(--color-red-2)] text-white",
+      titleClass: "text-white",
+      bodyClass: "text-white/80",
     },
     {
       title: t.threePoints.certificate,
       description: t.threePoints.certificateDesc,
-      background:
-        "linear-gradient(155deg, var(--color-red-hover) 0%, var(--color-red-active) 100%)",
+      surface: "bg-white",
+      titleClass: "text-[color:var(--on-invert)]",
+      bodyClass: "text-[color:var(--on-invert-2)]",
     },
     {
       title: t.threePoints.opportunities,
       description: t.threePoints.opportunitiesDesc,
-      background:
-        "linear-gradient(155deg, var(--color-primary-blue) 0%, var(--color-blue-deep) 100%)",
+      surface: "bg-[color:var(--color-black)] text-white",
+      titleClass: "text-white",
+      bodyClass: "text-white/70",
     },
   ];
 
@@ -31,11 +36,14 @@ export default function ThreePointsCards() {
       {benefits.map((benefit) => (
         <div
           key={benefit.title}
-          className="on-brand flex min-h-[180px] flex-col items-center justify-center gap-3 rounded-[var(--radius-xl)] p-6 text-center shadow-[0_20px_44px_-24px_rgba(5,20,29,0.6)] transition duration-300 hover:-translate-y-2 hover:shadow-[0_28px_50px_-22px_rgba(5,20,29,0.65)] sm:min-h-[240px] sm:gap-4 sm:p-10 md:min-h-[260px]"
-          style={{ background: benefit.background }}
+          className={`flex min-h-[180px] flex-col items-center justify-center gap-3 rounded-[var(--radius-xl)] p-6 text-center shadow-[0_20px_44px_-24px_rgba(0,0,0,0.5)] transition duration-300 hover:-translate-y-2 sm:min-h-[240px] sm:gap-4 sm:p-10 md:min-h-[260px] ${benefit.surface}`}
         >
-          <h3 className="text-base font-bold text-white sm:text-lg leading-tight">{benefit.title}</h3>
-          <p className="text-sm leading-6 text-white sm:text-base sm:leading-7">{benefit.description}</p>
+          <h3 className={`text-base font-bold leading-tight tracking-[-0.02em] sm:text-lg ${benefit.titleClass}`}>
+            {benefit.title}
+          </h3>
+          <p className={`text-sm leading-6 sm:text-base sm:leading-7 ${benefit.bodyClass}`}>
+            {benefit.description}
+          </p>
         </div>
       ))}
     </div>

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -1,5 +1,7 @@
 /*
- * Contact page — editorial design matching the homepage.
+ * Página de contacto — sistema vermelho/branco.
+ * Informação de contacto em texto branco sobre o vermelho; o formulário vive
+ * num painel branco invertido, porque é onde o utilizador tem de escrever.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -9,8 +11,8 @@
    LAYOUT PRIMITIVES
    ============================================================ */
 .page {
-  background: var(--color-white);
-  color: var(--color-text-primary);
+  background: var(--surface-brand);
+  color: var(--color-white);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -29,40 +31,44 @@
 .eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
+  gap: 14px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand-700);
+  color: rgba(255, 255, 255, 0.78);
   margin-bottom: 20px;
 }
 .eyebrow::before {
   content: "";
-  width: 30px; height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  width: 34px; height: 2px;
+  background: currentColor;
   flex-shrink: 0;
 }
 
 .displayLg {
-  font-family: var(--font-body);
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-text-primary);
-  font-size: clamp(26px, 3.5vw, 48px);
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  color: var(--color-white);
+  font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
+/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
 .italic {
   font-style: normal;
-  font-weight: 800;
-  color: var(--brand);
+  font-weight: 700;
+  color: var(--color-red);
+  background: var(--color-white);
+  padding: 0 0.14em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 .lead {
-  font-size: clamp(14px, 1.1vw, 17px);
-  line-height: 1.75;
-  color: var(--body);
+  font-size: clamp(15px, 1.1vw, 18px);
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.82);
   max-width: 56ch;
   margin: 0;
 }
@@ -72,7 +78,7 @@
    ============================================================ */
 .hero {
   padding: 96px 0;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--hairline);
 }
 @media (max-width: 720px) { .hero { padding: 64px 0; } }
 .heroTitle { margin-bottom: 24px; }
@@ -95,10 +101,10 @@
    CONTACT INFO
    ============================================================ */
 .infoTitle {
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 700;
-  letter-spacing: -0.3px;
-  color: var(--color-text-primary);
+  letter-spacing: -0.03em;
+  color: var(--color-white);
   margin: 0 0 28px;
 }
 .infoItems { display: flex; flex-direction: column; gap: 20px; }
@@ -107,52 +113,73 @@
   flex-shrink: 0;
   width: 40px; height: 40px;
   border-radius: var(--radius-md);
-  background: var(--brand);
-  color: var(--moonlight-white);
+  background: var(--color-white);
+  color: var(--color-red);
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.infoLabel { font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); margin-bottom: 4px; }
-.infoValue { font-size: 16px; color: var(--body); line-height: 1.4; }
-.infoValue a { color: var(--brand-500) !important; }
+.infoLabel {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 4px;
+}
+.infoValue { font-size: 16px; color: var(--color-white); line-height: 1.4; }
+.infoValue a { color: var(--color-white) !important; border-bottom: 1px solid rgba(255, 255, 255, 0.5); }
 .infoValue a:hover { opacity: .8; }
 
 .badge {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  padding: 14px 18px;
-  background: var(--brand-soft);
-  border: 1px solid rgba(239, 62, 77,.3);
+  padding: 13px 18px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.45);
   border-radius: var(--radius-pill);
-  font-size: 14px;
-  color: var(--color-red-ink);
-  font-weight: 600;
+  font-size: 13px;
+  color: var(--color-white);
+  font-weight: 700;
+  letter-spacing: 0.02em;
   margin-top: 32px;
 }
 .badgeDot {
   width: 8px; height: 8px;
   border-radius: 50%;
-  background: var(--brand);
-  box-shadow: 0 0 0 4px rgba(239, 62, 77,.24);
+  background: var(--color-white);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.22);
 }
 
 /* ============================================================
-   FORM CARD
+   FORM CARD — painel branco invertido
    ============================================================ */
 .card {
+  --muted: var(--on-invert-3);
+  --body: var(--on-invert-2);
+
   background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
-  border-radius: var(--radius-lg);
+  color: var(--on-invert);
+  border: none;
+  border-radius: var(--radius-xl);
   padding: 40px;
-  box-shadow: 0 8px 24px rgba(15, 76, 92, 0.1);
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+.card::before {
+  content: "";
+  position: absolute;
+  top: 0; left: var(--radius-xl);
+  width: 72px; height: 4px;
+  background: var(--color-red);
 }
 .cardTitle {
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 700;
-  letter-spacing: -0.3px;
-  color: var(--color-text-primary);
+  letter-spacing: -0.03em;
+  color: var(--on-invert);
   margin: 0 0 28px;
 }
 
@@ -167,40 +194,41 @@
 
 .field { display: flex; flex-direction: column; gap: 6px; }
 .label {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--on-invert-3);
 }
 .input {
   height: 48px;
   padding: 0 16px;
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
+  background: #f7f7f9;
+  border: 1px solid var(--hairline-invert);
   border-radius: var(--radius-md);
   font-size: 16px;
   font-family: inherit;
-  color: var(--color-text-primary);
-  transition: border-color .2s, box-shadow .2s;
+  color: var(--on-invert);
+  transition: border-color .2s, box-shadow .2s, background .2s;
   outline: none;
   width: 100%;
   box-sizing: border-box;
 }
 .input:focus {
-  border-color: var(--brand);
-  box-shadow: 0 0 0 3px rgba(239, 62, 77,.18);
+  background: var(--color-white);
+  border-color: var(--color-red);
+  box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.14);
 }
 .textarea {
   min-height: 140px;
   padding: 14px 16px;
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
+  background: #f7f7f9;
+  border: 1px solid var(--hairline-invert);
   border-radius: var(--radius-md);
   font-size: 16px;
   font-family: inherit;
-  color: var(--color-text-primary);
-  transition: border-color .2s, box-shadow .2s;
+  color: var(--on-invert);
+  transition: border-color .2s, box-shadow .2s, background .2s;
   outline: none;
   resize: vertical;
   width: 100%;
@@ -208,23 +236,25 @@
   line-height: 1.55;
 }
 .textarea:focus {
-  border-color: var(--brand);
-  box-shadow: 0 0 0 3px rgba(239, 62, 77,.18);
+  background: var(--color-white);
+  border-color: var(--color-red);
+  box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.14);
 }
 
 /* Status message */
 .status {
   padding: 16px 20px;
-  background: var(--brand-soft);
-  border: 1px solid rgba(239, 62, 77,.3);
-  border-radius: var(--radius-md);
+  background: rgba(227, 6, 19, 0.07);
+  border: none;
+  border-left: 3px solid var(--color-red);
+  border-radius: var(--radius-sm);
   font-size: 14px;
-  color: var(--color-red-ink);
+  color: var(--color-danger);
   line-height: 1.5;
 }
-.statusRef { font-size: 12px; color: var(--muted); margin-top: 6px; }
+.statusRef { font-size: 12px; color: var(--on-invert-3); margin-top: 6px; }
 
-/* Submit — vazado Turkish Red que preenche no hover. */
+/* Submit — sólido vermelho sobre o painel branco. */
 .page .submit {
   display: inline-flex;
   align-items: center;
@@ -232,13 +262,13 @@
   gap: 8px;
   padding: 16px 32px;
   border-radius: var(--radius-md);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 16px;
   line-height: 1.2;
   border: none;
-  background: var(--color-primary-red);
+  background: var(--color-red);
   color: var(--color-white);
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+  box-shadow: 0 4px 14px rgba(227, 6, 19, 0.28);
   cursor: pointer;
   font-family: var(--font-body);
   transition: all 200ms ease;
@@ -247,12 +277,12 @@
   justify-self: start;
 }
 .page .submit:hover:not(:disabled) {
-  background: var(--color-red-hover);
+  background: var(--color-red-2);
   transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(239, 62, 77, 0.35);
+  box-shadow: 0 8px 22px rgba(227, 6, 19, 0.34);
 }
 .page .submit:active:not(:disabled) {
-  background: var(--color-red-active);
+  background: var(--color-red-3);
   transform: translateY(0);
 }
-.page .submit:disabled { opacity: .6; cursor: not-allowed; transform: none; }
+.page .submit:disabled { opacity: .55; cursor: not-allowed; transform: none; }

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -1,6 +1,11 @@
 /*
- * DESCRIÇÃO DO FICHEIRO: Estilos scoped da página /curso (design "Turkish Red & Railroad Black").
+ * DESCRIÇÃO DO FICHEIRO: Estilos scoped da página /curso, sistema vermelho/branco.
  * Convenção: classes camelCase para acesso direto via styles.xxx
+ *
+ * A capa do curso (cabeçalho + lista de módulos) vive sobre o vermelho da
+ * marca. O leitor é um overlay com chrome vermelho e corpo branco: são
+ * milhares de palavras por módulo, e o branco é a superfície onde o texto
+ * longo se lê sem cansar. O quiz e o resultado vivem dentro desse corpo.
  */
 
 /* Reset das regras globais que entram nesta página.
@@ -43,8 +48,8 @@
    PRIMITIVAS DE LAYOUT
    ============================================================ */
 .page {
-  background: var(--background);
-  color: var(--body);
+  background: var(--surface-brand);
+  color: rgba(255, 255, 255, 0.82);
   font-size: 15px;
   line-height: 1.7;
   font-family: var(--font-body);
@@ -61,37 +66,36 @@
 .eyebrow {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.22em;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: rgba(255, 255, 255, 0.78);
   margin-bottom: 18px;
 }
 .eyebrow::before {
   content: "";
-  width: 30px; height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  width: 34px; height: 2px;
+  background: currentColor;
   flex-shrink: 0;
 }
-.eyebrowAccent { color: var(--brand); }
+.eyebrowAccent { color: var(--color-white); }
 
 .display {
-  font-family: var(--font-body);
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-text-primary);
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  color: var(--color-white);
   margin: 0;
 }
-.displayXl { font-size: clamp(28px, 3.6vw, 50px); }
-.displayLg { font-size: clamp(21px, 2.8vw, 36px); }
+.displayXl { font-size: clamp(30px, 4.2vw, 58px); }
+.displayLg { font-size: clamp(22px, 3vw, 40px); }
 .lead {
-  font-size: 15px;
-  line-height: 1.75;
-  color: var(--body);
+  font-size: 16px;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.82);
   max-width: 56ch;
   margin: 0;
 }
@@ -106,7 +110,7 @@
   gap: 8px;
   padding: 16px 32px;
   border-radius: var(--radius-md);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 16px;
   border: none;
   transition: all 200ms ease;
@@ -118,38 +122,40 @@
 .page .btn:hover:not(:disabled) { transform: translateY(-2px); }
 .page .btn:active:not(:disabled) { transform: translateY(0); }
 
+/* Principal sobre vermelho: branco cheio. */
 .page .btnPrimary {
-  background: var(--color-primary-red);
-  color: var(--color-white);
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+  background: var(--color-white);
+  color: var(--color-red);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.16);
 }
 .page .btnPrimary:hover:not(:disabled) {
-  background: var(--color-red-hover);
-  box-shadow: 0 6px 16px rgba(239, 62, 77, 0.35);
+  background: var(--color-white);
+  color: var(--color-red-3);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.22);
 }
 .page .btnGhost {
   background: transparent;
-  color: var(--color-primary-blue);
-  border: 2px solid var(--color-gray-light);
-  padding: 14px 30px;
+  color: var(--color-white);
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  padding: 14.5px 30.5px;
 }
 .page .btnGhost:hover:not(:disabled) {
-  border-color: var(--color-primary-blue);
-  background: rgba(15, 76, 92, 0.05);
+  border-color: var(--color-white);
+  background: rgba(255, 255, 255, 0.12);
 }
 .page .btnAccent {
   background: transparent;
-  border: 2px solid var(--color-primary-blue);
-  color: var(--color-primary-blue);
-  padding: 14px 30px;
+  border: 1.5px solid rgba(255, 255, 255, 0.5);
+  color: var(--color-white);
+  padding: 14.5px 30.5px;
 }
 .page .btnAccent:hover:not(:disabled) {
-  background: rgba(15, 76, 92, 0.05);
-  box-shadow: 0 4px 12px rgba(15, 76, 92, 0.15);
+  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--color-white);
 }
 .page .btnSmall { padding: 12px 24px; font-size: 14px; }
 .page .btn:disabled {
-  opacity: .6;
+  opacity: .5;
   cursor: not-allowed;
   transform: none !important;
   box-shadow: none;
@@ -180,34 +186,43 @@
 .courseHeadTitle {
   margin: 0 0 20px;
 }
+/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
 .courseHeadTitle em {
   font-style: normal;
-  color: var(--brand);
+  color: var(--color-red);
+  background: var(--color-white);
+  padding: 0 0.14em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 .courseHeadSub {
-  font-size: 14.5px;
+  font-size: 15px;
   line-height: 1.75;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.7);
   margin: 0;
   max-width: 48ch;
   text-wrap: pretty;
 }
 
+/* Cartão de progresso — painel branco invertido. */
 .progressCard {
+  --muted: var(--on-invert-3);
+
   background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
-  border-radius: var(--radius-lg);
+  color: var(--on-invert);
+  border: none;
+  border-radius: var(--radius-xl);
   padding: 28px;
-  box-shadow: 0 8px 24px rgba(15, 76, 92, 0.1);
+  box-shadow: var(--shadow-lg);
   position: relative;
+  overflow: hidden;
 }
 .progressCard::before {
   content: "";
   position: absolute;
-  top: -1px; left: var(--radius-xl);
-  width: 56px; height: 3px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  top: 0; left: var(--radius-xl);
+  width: 56px; height: 4px;
+  background: var(--color-red);
 }
 .progressCardRow {
   display: flex;
@@ -217,49 +232,49 @@
   gap: 12px;
 }
 .progressCardCount {
-  font-size: 34px;
-  font-weight: 800;
-  letter-spacing: -0.5px;
+  font-size: 40px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
   line-height: 1;
-  color: var(--color-text-primary);
+  color: var(--on-invert);
 }
 .progressCardCount em {
   font-style: normal;
-  color: var(--brand);
+  color: var(--color-red);
 }
 .progressCardCount span {
   font-size: 16px;
   font-weight: 600;
-  color: var(--muted);
+  color: var(--on-invert-3);
   margin-left: 6px;
 }
 .progressCardPct {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: var(--color-red);
   text-align: right;
 }
 .progressBar {
   height: 5px;
-  background: var(--line);
+  background: #ededf1;
   border-radius: var(--radius-pill);
   overflow: hidden;
   position: relative;
 }
 .progressBarFill {
   height: 100%;
-  background: var(--brand);
+  background: var(--color-red);
   transition: width .6s cubic-bezier(0.23, 1, 0.32, 1);
 }
 .progressCardLabel {
   margin-top: 16px;
   font-size: 12.5px;
-  color: var(--muted);
+  color: var(--on-invert-3);
   line-height: 1.6;
 }
-.progressCardLabel strong { color: var(--color-text-primary); font-weight: 700; }
+.progressCardLabel strong { color: var(--on-invert); font-weight: 700; }
 
 /* ============================================================
    LISTA DE MÓDULOS
@@ -273,26 +288,26 @@
   align-items: center;
   justify-content: space-between;
   padding: 28px 0 14px;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--hairline);
   margin-top: 28px;
   flex-wrap: wrap;
   gap: 16px;
 }
 .modListTitle {
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0.18em;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.6);
   margin: 0;
 }
 .modListLegend {
   display: flex;
   gap: 18px;
-  font-size: 11px;
-  color: var(--muted);
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.6);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.18em;
   font-weight: 700;
 }
 .modListLegend span {
@@ -303,10 +318,10 @@
 .modListLegend span::before {
   content: "";
   width: 7px; height: 7px;
-  background: var(--line);
+  background: rgba(255, 255, 255, 0.35);
 }
-.modListLegend .legDone::before { background: var(--mint); }
-.modListLegend .legNow::before { background: var(--brand); }
+.modListLegend .legDone::before { background: var(--color-white); }
+.modListLegend .legNow::before { background: var(--color-black); }
 
 .mod {
   display: grid;
@@ -314,43 +329,44 @@
   gap: 24px;
   padding: 26px 0;
   align-items: start;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--hairline);
   transition: background .25s, padding .25s;
   cursor: pointer;
   position: relative;
   width: 100%;
   text-align: left;
 }
-.mod:last-of-type { border-bottom: 1px solid var(--line); }
-.mod:not(:disabled):hover { background: var(--color-bg-light); padding-left: 16px; }
+.mod:last-of-type { border-bottom: 1px solid var(--hairline); }
+.mod:not(:disabled):hover { background: rgba(255, 255, 255, 0.08); padding-left: 16px; }
 .mod:disabled,
 .modLocked {
-  opacity: .38;
+  opacity: .4;
   cursor: not-allowed;
 }
 .mod:disabled:hover,
 .modLocked:hover { background: transparent; padding-left: 0; }
 
 .modNum {
-  font-weight: 800;
-  font-size: 22px;
-  letter-spacing: -0.02em;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: -0.04em;
   line-height: 1.15;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.5);
 }
-.modDone .modNum { color: var(--mint); }
-.modCurrent .modNum { color: var(--brand); }
+.modDone .modNum { color: var(--color-white); }
+.modCurrent .modNum { color: var(--color-white); }
 .modBody { min-width: 0; }
 .modTitle {
-  font-size: clamp(14px, 1.4vw, 17px);
-  font-weight: 800;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
+  font-size: clamp(15px, 1.4vw, 18px);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--color-white);
   margin: 0 0 5px;
 }
 .modDesc {
   font-size: 13.5px;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.7);
   line-height: 1.7;
   margin: 0;
   max-width: 68ch;
@@ -367,44 +383,53 @@
   align-items: center;
   gap: 6px;
   font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.12em;
+  font-weight: 700;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   padding: 6px 11px;
   border-radius: var(--radius-pill);
-  background: var(--surface-raised);
-  color: var(--body);
-  border: 1px solid var(--line);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--hairline-strong);
   white-space: nowrap;
 }
-.modBadgeCurrent { background: var(--color-primary-red); color: var(--color-white); border-color: var(--color-primary-red); }
+.modBadgeCurrent {
+  background: var(--color-white);
+  color: var(--color-red);
+  border-color: var(--color-white);
+}
 .modBadgeLocked {
   background: transparent;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.55);
+  border-color: var(--hairline);
 }
-.modBadgeDone { background: rgba(42, 191, 132, 0.15); color: #1b6f4a; border-color: rgba(42, 191, 132, 0.35); }
+.modBadgeDone {
+  background: var(--color-black);
+  color: var(--color-white);
+  border-color: var(--color-black);
+}
 .modArrow {
   width: 28px; height: 28px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--hairline-strong);
   border-radius: var(--radius-sm);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-primary-blue);
+  color: var(--color-white);
   transition: background .2s, color .2s, border-color .2s;
 }
 .mod:not(:disabled):hover .modArrow {
-  background: var(--color-primary-red);
-  color: var(--color-white);
-  border-color: var(--color-primary-red);
+  background: var(--color-white);
+  color: var(--color-red);
+  border-color: var(--color-white);
 }
 
 /* ============================================================
-   BLOCO DO CERTIFICADO
+   BLOCO DO CERTIFICADO — preto, para marcar a chegada
    ============================================================ */
 .certBlock {
   margin: 36px 0 0;
-  background: var(--color-primary-red);
+  background: var(--color-black);
   color: var(--color-white);
   border-radius: var(--radius-xl);
   padding: 40px 44px;
@@ -418,43 +443,43 @@
 .certBlock::before {
   content: "";
   position: absolute;
-  width: 360px; height: 360px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(15, 76, 92, 0.3) 0%, transparent 70%);
-  top: -170px; right: -140px;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: var(--color-red);
   pointer-events: none;
 }
 .certBlockCopy { position: relative; max-width: 56ch; }
 .certBlockTitle {
-  font-size: clamp(18px, 1.9vw, 26px);
-  font-weight: 800;
-  letter-spacing: -0.3px;
+  font-size: clamp(20px, 2.1vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.035em;
   margin: 0 0 10px;
   color: var(--color-white);
 }
 .certBlockTitle em {
   font-style: normal;
-  color: var(--color-blue-deep);
+  color: var(--color-red-bright);
 }
 .certBlockSub {
   font-size: 14px;
-  color: rgba(255, 255, 255, .82);
+  color: rgba(255, 255, 255, .62);
   margin: 0;
   max-width: 56ch;
   line-height: 1.7;
   text-wrap: pretty;
 }
 .certBlockCta { position: relative; display: flex; gap: 12px; flex-wrap: wrap; }
-/* Sobre o painel vermelho, o CTA passa a branco para máximo contraste. */
+/* Sobre o painel preto, o CTA passa a vermelho sólido. */
 .certBlock .btnAccent {
-  background: var(--color-white);
-  border-color: var(--color-white);
-  color: var(--color-primary-red);
-  box-shadow: 0 4px 12px rgba(15, 76, 92, 0.2);
+  background: var(--color-red);
+  border-color: var(--color-red);
+  color: var(--color-white);
+  box-shadow: 0 4px 14px rgba(227, 6, 19, 0.3);
 }
 .certBlock .btnAccent:hover:not(:disabled) {
-  background: var(--color-bg-light);
-  box-shadow: 0 6px 16px rgba(15, 76, 92, 0.28);
+  background: var(--color-red-bright);
+  border-color: var(--color-red-bright);
+  box-shadow: 0 8px 22px rgba(227, 6, 19, 0.36);
 }
 @media (max-width: 720px) {
   .certBlock { grid-template-columns: 1fr; padding: 30px 26px; }
@@ -462,11 +487,12 @@
 
 /* ============================================================
    LEITOR (overlay)
+   Chrome vermelho, corpo branco: modo de leitura.
    ============================================================ */
 .reader {
   position: fixed;
   inset: 0;
-  background: var(--background);
+  background: var(--color-white);
   z-index: 100;
   display: flex;
   flex-direction: column;
@@ -480,10 +506,8 @@
   justify-content: space-between;
   gap: 24px;
   padding: 18px 32px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(15, 76, 92, .96);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.22);
+  background: var(--color-red);
   flex-shrink: 0;
 }
 @media (max-width: 720px) {
@@ -493,11 +517,11 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.75);
   transition: color .2s;
   background: transparent;
   border: 0;
@@ -509,7 +533,7 @@
 
 .readerTitle {
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--color-white);
   text-align: center;
   display: flex;
@@ -521,8 +545,8 @@
 }
 .readerTitle em {
   font-style: normal;
-  font-weight: 800;
-  color: var(--color-red-on-dark);
+  font-weight: 700;
+  color: var(--color-white);
   font-size: 16px;
 }
 .readerTitleName {
@@ -552,24 +576,27 @@
 .readerProgressDots span {
   width: 20px; height: 3px;
   border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.3);
   transition: background .2s, width .2s;
 }
-.dotDone { background: var(--mint) !important; }
-.dotCurrent { background: var(--brand) !important; width: 34px !important; }
+.dotDone { background: rgba(255, 255, 255, 0.75) !important; }
+.dotCurrent { background: var(--color-white) !important; width: 34px !important; }
 .readerProgressLabel {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.7);
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.75);
   white-space: nowrap;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   font-weight: 700;
 }
 
-/* Corpo do leitor */
+/* Corpo do leitor — superfície branca de leitura. */
 .readerBody {
   flex: 1;
   overflow-y: auto;
   padding: 52px 32px 72px;
+  background: var(--color-white);
+  color: var(--on-invert-2);
 }
 @media (max-width: 720px) {
   .readerBody { padding: 32px 20px 48px; }
@@ -587,61 +614,61 @@
 
 .readerChap {
   font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.22em;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: var(--color-red);
   margin: 0 0 16px;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 .readerChap::before {
   content: "";
-  width: 30px; height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  width: 34px; height: 2px;
+  background: currentColor;
   flex-shrink: 0;
 }
 .readerHeading {
-  font-size: clamp(24px, 3vw, 36px);
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-text-primary);
+  font-family: var(--font-display);
+  font-size: clamp(28px, 3.4vw, 44px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.03;
+  color: var(--on-invert);
   margin: 0 0 26px;
   max-width: 22ch;
 }
 .readerH2 {
-  font-size: 24px;
-  font-weight: 600;
-  letter-spacing: -0.3px;
+  font-size: 25px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
   margin: 40px 0 20px;
-  color: var(--color-text-primary);
+  color: var(--on-invert);
 }
 .readerLede {
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 600;
   line-height: 1.6;
-  letter-spacing: -0.1px;
-  color: var(--color-text-primary);
+  letter-spacing: -0.015em;
+  color: var(--on-invert);
   margin: 0 0 34px;
   padding-left: 20px;
-  border-left: 2px solid var(--brand);
+  border-left: 3px solid var(--color-red);
   max-width: 54ch;
   text-wrap: pretty;
 }
 .readerProse {
-  font-size: 15px;
-  line-height: 1.85;
-  color: var(--body);
+  font-size: 16px;
+  line-height: 1.8;
+  color: var(--on-invert-2);
   text-wrap: pretty;
 }
 .readerProse p {
   margin: 0 0 20px;
   max-width: 66ch;
 }
-.readerProse strong { color: var(--color-text-primary); font-weight: 700; }
+.readerProse strong { color: var(--on-invert); font-weight: 700; }
 .readerProse ul {
   margin: 0 0 22px;
   padding-left: 0;
@@ -650,19 +677,18 @@
 }
 .readerProse li {
   padding: 11px 0 11px 32px;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--hairline-invert);
   position: relative;
 }
-.readerProse li:last-child { border-bottom: 1px solid var(--line); }
+.readerProse li:last-child { border-bottom: 1px solid var(--hairline-invert); }
 .readerProse li::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 21px;
+  top: 22px;
   width: 14px;
   height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  background: var(--color-red);
 }
 
 .readerBreak {
@@ -670,17 +696,17 @@
   align-items: center;
   gap: 14px;
   margin: 52px 0 34px;
-  color: var(--brand);
+  color: var(--color-red);
 }
 .readerBreak::before, .readerBreak::after {
   content: "";
   flex: 1;
   height: 1px;
-  background: var(--line);
+  background: var(--hairline-invert);
 }
 .readerBreakIcon {
   font-size: 20px;
-  font-weight: 800;
+  font-weight: 700;
 }
 
 /* Conteúdo premium */
@@ -694,32 +720,33 @@
 .prem {
   border-radius: var(--radius-lg);
   padding: 26px;
-  border: 1px solid var(--color-gray-light);
-  background: var(--color-bg-light);
+  border: 1px solid var(--hairline-invert);
+  background: #f7f7f9;
 }
-.premGood { border-color: rgba(42, 191, 132, .35); }
-.premBad { border-color: rgba(239, 62, 77, .3); }
-.premStrat { border-color: var(--line); }
-.premCheck { background: var(--color-primary-red); border-color: var(--color-primary-red); color: var(--color-white); }
+.premGood { border-color: rgba(18, 160, 109, .3); }
+.premBad { border-color: rgba(227, 6, 19, .28); }
+.premStrat { border-color: var(--hairline-invert); }
+/* O checklist inverte-se dentro do corpo branco: vermelho da marca. */
+.premCheck { background: var(--color-red); border-color: var(--color-red); color: var(--color-white); }
 .premCheck .premTitle { color: var(--color-white); }
-.premCheck .premList li { color: rgba(255, 255, 255, .88); border-color: rgba(255, 255, 255, .16); }
+.premCheck .premList li { color: rgba(255, 255, 255, .9); border-color: rgba(255, 255, 255, .2); }
 .premCheck .premList li::before { background: var(--color-white); opacity: 1; }
 .premTitle {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.16em;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--color-text-primary);
+  color: var(--on-invert);
   margin: 0 0 16px;
 }
-.premGood .premTitle { color: #1b6f4a; }
-.premBad .premTitle { color: var(--brand-500); }
+.premGood .premTitle { color: var(--color-success); }
+.premBad .premTitle { color: var(--color-danger); }
 .premList { margin: 0; padding: 0; list-style: none; }
 .premList li {
   font-size: 14px;
-  color: var(--color-dark-blue);
+  color: var(--on-invert-2);
   padding: 11px 0 11px 26px;
-  border-top: 1px solid var(--color-gray-light);
+  border-top: 1px solid var(--hairline-invert);
   position: relative;
   line-height: 1.65;
 }
@@ -732,35 +759,34 @@
   top: 20px;
   width: 14px;
   height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--muted);
+  background: var(--on-invert-3);
 }
-.premGood .premList li::before { background: var(--mint); }
-.premBad .premList li::before { background: var(--brand-500); }
+.premGood .premList li::before { background: var(--color-success); }
+.premBad .premList li::before { background: var(--color-danger); }
 
 /* Exemplo de avaliação */
 .example {
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-gray-light);
-  border-left: 3px solid var(--color-primary-red);
-  background: var(--color-bg-light);
+  border: 1px solid var(--hairline-invert);
+  border-left: 3px solid var(--color-red);
+  background: #f7f7f9;
   padding: 26px;
 }
-.example p { margin: 0 0 10px; font-size: 14px; color: var(--body); line-height: 1.7; }
+.example p { margin: 0 0 10px; font-size: 14px; color: var(--on-invert-2); line-height: 1.7; }
 .example p:last-child { margin-bottom: 0; }
 .exampleTitle {
-  font-size: 16px;
-  font-weight: 800;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--on-invert);
   margin: 0 0 14px;
 }
 .exampleLabel {
   font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
+  font-weight: 700;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: var(--color-red);
   margin-right: 6px;
 }
 
@@ -774,27 +800,27 @@
   gap: 16px;
 }
 .asideCard {
-  background: var(--color-bg-light);
-  border: 1px solid var(--color-gray-light);
+  background: #f7f7f9;
+  border: 1px solid var(--hairline-invert);
   border-radius: var(--radius-lg);
   padding: 22px;
 }
 .asideLabel {
   font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.18em;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--on-invert-3);
   margin: 0 0 14px;
   display: flex;
   align-items: center;
   gap: 8px;
 }
-.asideLabel svg { color: var(--brand); }
+.asideLabel svg { color: var(--color-red); }
 .asideText {
   font-size: 14px;
   line-height: 1.75;
-  color: var(--body);
+  color: var(--on-invert-2);
   margin: 0;
   text-wrap: pretty;
 }
@@ -808,20 +834,18 @@
   font-weight: 600;
   padding: 6px 10px;
   background: var(--color-white);
-  color: var(--body);
-  border: 1px solid var(--line);
+  color: var(--on-invert-2);
+  border: 1px solid var(--hairline-invert);
   border-radius: var(--radius-pill);
 }
-.asideCardWarn { border-color: rgba(239, 62, 77, .35); background: rgba(239, 62, 77, .06); }
-.asideCardWarn .asideLabel { color: var(--brand-500); }
-.asideCardWarn .asideLabel svg { color: var(--brand-500); }
+.asideCardWarn { border-color: rgba(227, 6, 19, .3); background: rgba(227, 6, 19, .05); }
+.asideCardWarn .asideLabel { color: var(--color-red); }
+.asideCardWarn .asideLabel svg { color: var(--color-red); }
 
 /* Rodapé do leitor */
 .readerBottom {
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(15, 76, 92, .96);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid rgba(255, 255, 255, 0.22);
+  background: var(--color-red);
   padding: 16px 32px;
   flex-shrink: 0;
 }
@@ -837,19 +861,32 @@
   gap: 16px;
 }
 .readerPageInfo {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.7);
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.75);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.18em;
   font-weight: 700;
 }
 .readerPageInfo strong { color: var(--color-white); font-weight: 700; }
 @media (max-width: 600px) {
   .readerPageInfo { display: none; }
 }
+/* No chrome vermelho do leitor, os botões voltam a ser brancos/vazados. */
+.readerBottom .btnPrimary,
+.readerTop .btnPrimary {
+  background: var(--color-white);
+  color: var(--color-red);
+}
+.readerBottom .btnGhost,
+.readerBottom .btnAccent,
+.readerTop .btnGhost,
+.readerTop .btnAccent {
+  color: var(--color-white);
+  border-color: rgba(255, 255, 255, 0.5);
+}
 
 /* ============================================================
-   QUIZ
+   QUIZ — dentro do corpo branco do leitor
    ============================================================ */
 .quiz {
   max-width: 760px;
@@ -857,15 +894,17 @@
 }
 .quizHead { margin-bottom: 34px; }
 .quizTitle {
-  font-size: clamp(20px, 2.4vw, 30px);
-  font-weight: 800;
-  letter-spacing: -0.3px;
+  font-family: var(--font-display);
+  font-size: clamp(24px, 2.8vw, 36px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
   margin: 0 0 12px;
-  color: var(--color-text-primary);
+  color: var(--on-invert);
 }
 .quizSub {
   font-size: 15px;
-  color: var(--muted);
+  color: var(--on-invert-3);
   margin: 0;
   max-width: 60ch;
   line-height: 1.75;
@@ -874,29 +913,29 @@
 
 .q {
   background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
+  border: 1px solid var(--hairline-invert);
   border-radius: var(--radius-lg);
   padding: 28px;
   margin-bottom: 12px;
-  box-shadow: 0 2px 8px rgba(15, 76, 92, 0.06);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 }
 @media (max-width: 600px) {
   .q { padding: 22px; }
 }
 .qNum {
-  font-weight: 800;
-  font-size: 11px;
-  letter-spacing: 0.18em;
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: var(--color-red);
   margin: 0 0 12px;
 }
 .qText {
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.45;
-  color: var(--color-text-primary);
+  letter-spacing: -0.025em;
+  line-height: 1.4;
+  color: var(--on-invert);
   margin: 0 0 22px;
   max-width: 52ch;
   text-wrap: pretty;
@@ -908,60 +947,60 @@
   justify-content: flex-start;
   gap: 16px;
   padding: 15px 18px;
-  background: var(--color-bg-light);
-  border: 1px solid var(--color-gray-light);
+  background: #f7f7f9;
+  border: 1px solid var(--hairline-invert);
   border-radius: var(--radius-md);
   text-align: left;
   width: 100%;
   font-size: 14.5px;
-  color: var(--body);
+  color: var(--on-invert-2);
   transition: border-color .15s, background .15s, color .15s;
   cursor: pointer;
   font-family: inherit;
 }
-.qOpt:hover:not(:disabled) { border-color: var(--color-primary-blue); color: var(--color-text-primary); }
+.qOpt:hover:not(:disabled) { border-color: var(--on-invert-3); color: var(--on-invert); }
 .qOptSelected {
-  border-color: var(--color-primary-red) !important;
-  background: rgba(239, 62, 77, 0.1) !important;
-  color: var(--color-red-ink) !important;
+  border-color: var(--color-red) !important;
+  background: rgba(227, 6, 19, 0.07) !important;
+  color: var(--color-danger) !important;
 }
 .qOptLetter {
   flex-shrink: 0;
   width: 26px; height: 26px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--line);
+  border: 1px solid var(--hairline-invert);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 12px;
-  font-weight: 800;
-  color: var(--muted);
-  background: transparent;
+  font-weight: 700;
+  color: var(--on-invert-3);
+  background: var(--color-white);
   transition: all .15s;
 }
 .qOptSelected .qOptLetter {
-  background: var(--color-primary-red);
-  border-color: var(--color-primary-red);
+  background: var(--color-red);
+  border-color: var(--color-red);
   color: var(--color-white);
 }
 .qOptCorrect {
-  border-color: rgba(42, 191, 132, .5) !important;
-  background: rgba(42, 191, 132, .12) !important;
-  color: #1b6f4a !important;
+  border-color: rgba(18, 160, 109, .5) !important;
+  background: rgba(18, 160, 109, .09) !important;
+  color: var(--color-success) !important;
 }
 .qOptCorrect .qOptLetter {
-  background: var(--color-success-green);
-  border-color: var(--color-success-green);
+  background: var(--color-success);
+  border-color: var(--color-success);
   color: var(--color-white);
 }
 .qOptWrong {
-  border-color: rgba(239, 62, 77, .5) !important;
-  background: rgba(239, 62, 77, .1) !important;
-  color: var(--color-red-ink) !important;
+  border-color: rgba(227, 6, 19, .5) !important;
+  background: rgba(227, 6, 19, .08) !important;
+  color: var(--color-danger) !important;
 }
 .qOptWrong .qOptLetter {
-  background: var(--color-primary-red);
-  border-color: var(--color-primary-red);
+  background: var(--color-red);
+  border-color: var(--color-red);
   color: var(--color-white);
 }
 .qOptDim { opacity: .45; }
@@ -977,16 +1016,37 @@
 .quizHint {
   flex: 1;
   font-size: 12.5px;
-  color: var(--muted);
+  color: var(--on-invert-3);
   min-width: 200px;
+}
+/* Dentro do corpo branco, os botões do quiz invertem-se. */
+.quiz .btnPrimary {
+  background: var(--color-red);
+  color: var(--color-white);
+  box-shadow: 0 4px 14px rgba(227, 6, 19, 0.28);
+}
+.quiz .btnPrimary:hover:not(:disabled) {
+  background: var(--color-red-2);
+  color: var(--color-white);
+  box-shadow: 0 8px 22px rgba(227, 6, 19, 0.34);
+}
+.quiz .btnGhost,
+.quiz .btnAccent {
+  color: var(--on-invert);
+  border-color: var(--hairline-invert);
+}
+.quiz .btnGhost:hover:not(:disabled),
+.quiz .btnAccent:hover:not(:disabled) {
+  background: #f2f2f5;
+  border-color: var(--on-invert-3);
 }
 
 /* Resultado */
 .result {
   background: var(--color-white);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-gray-light);
-  box-shadow: 0 8px 24px rgba(15, 76, 92, 0.1);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--hairline-invert);
+  box-shadow: var(--shadow-md);
   padding: 52px;
   text-align: center;
   margin-bottom: 24px;
@@ -998,44 +1058,44 @@
   position: absolute;
   top: 0; left: 50%;
   transform: translateX(-50%);
-  width: 72px; height: 3px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  width: 72px; height: 4px;
+  background: var(--color-red);
 }
 @media (max-width: 600px) {
   .result { padding: 34px 24px; }
 }
 .resultScore {
-  font-weight: 800;
-  font-size: 76px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 86px;
   line-height: 1;
-  letter-spacing: -0.5px;
-  color: var(--color-success-green);
+  letter-spacing: -0.05em;
+  color: var(--color-success);
   margin: 0;
 }
-.resultScoreFail { color: var(--color-primary-red) !important; }
+.resultScoreFail { color: var(--color-danger) !important; }
 .resultScore span {
   font-size: 34px;
   margin-left: 2px;
 }
 .resultLabel {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.18em;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--on-invert-3);
   margin: 18px 0 12px;
 }
 .resultTitle {
-  font-size: 22px;
-  font-weight: 800;
-  letter-spacing: -0.3px;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.035em;
   margin: 0 0 10px;
-  color: var(--color-text-primary);
+  color: var(--on-invert);
 }
 .resultSub {
   font-size: 15px;
-  color: var(--muted);
+  color: var(--on-invert-3);
   line-height: 1.7;
   margin: 0 auto 30px;
   max-width: 50ch;

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,7 +1,7 @@
 export default function DashboardLoading() {
   return (
     <div className="flex min-h-[40vh] items-center justify-center">
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-[color:var(--color-red-soft)] border-t-[color:var(--color-primary-red)]" />
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/25 border-t-white" />
     </div>
   );
 }

--- a/app/faq/page.module.css
+++ b/app/faq/page.module.css
@@ -1,5 +1,7 @@
 /*
- * Cliente Mistério — Página FAQ (design "Turkish Red & Railroad Black").
+ * Cliente Mistério — Página FAQ, sistema vermelho/branco.
+ * Acordeão tipográfico sobre o vermelho da marca: as respostas são separadas
+ * por filetes brancos finos, sem cartões, para manter a leitura calma.
  */
 
 /* Reset das regras globais de <button> dentro desta página. */
@@ -27,11 +29,8 @@
 .page button::after { content: none; }
 
 .page {
-  background:
-    radial-gradient(60% 40% at 85% -5%, rgba(239, 62, 77, 0.08) 0%, transparent 60%),
-    radial-gradient(55% 45% at 0% 0%, rgba(239, 62, 77, 0.09) 0%, transparent 55%),
-    var(--background);
-  color: var(--body);
+  background: var(--surface-brand);
+  color: rgba(255, 255, 255, 0.82);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -58,54 +57,53 @@
 .eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.22em;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: rgba(255, 255, 255, 0.78);
   margin-bottom: 22px;
 }
 .eyebrow::before {
   content: "";
-  width: 30px; height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  width: 34px; height: 2px;
+  background: currentColor;
   flex-shrink: 0;
 }
 .title {
-  font-family: var(--font-body);
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-text-primary);
-  font-size: clamp(29px, 3.9vw, 52px);
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  color: var(--color-white);
+  font-size: clamp(32px, 4.6vw, 60px);
   margin: 0 0 18px;
 }
 .sub {
   font-size: clamp(15px, 1.15vw, 18px);
   line-height: 1.65;
-  color: var(--body);
+  color: rgba(255, 255, 255, 0.78);
   max-width: 52ch;
   margin: 0 auto;
   text-wrap: pretty;
-  font-weight: 500;
+  font-weight: 400;
 }
 .subLink {
-  color: var(--brand);
+  color: var(--color-white);
   font-weight: 700;
   text-decoration: none;
-  border-bottom: 1px solid rgba(239, 62, 77, 0.4);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
   transition: border-color .2s;
 }
-.subLink:hover { border-color: var(--brand); }
+.subLink:hover { border-color: var(--color-white); }
 
 /* ---------- Accordion ---------- */
 .faq {
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--hairline);
   margin-top: 12px;
 }
-.faqItem { border-bottom: 1px solid var(--line); }
+.faqItem { border-bottom: 1px solid var(--hairline); }
 .page .faqQ {
   display: flex;
   width: 100%;
@@ -114,40 +112,40 @@
   align-items: center;
   justify-content: space-between;
   gap: 32px;
-  font-size: clamp(15px, 1.4vw, 18px);
+  font-size: clamp(16px, 1.4vw, 19px);
   font-weight: 700;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
+  letter-spacing: -0.025em;
+  color: var(--color-white);
   background: transparent;
   border: 0;
   cursor: pointer;
-  transition: color .2s;
+  transition: opacity .2s;
   font-family: inherit;
 }
-.page .faqQ:hover { color: var(--brand); }
+.page .faqQ:hover { opacity: 0.8; }
 .faqIcon {
   flex-shrink: 0;
   width: 34px; height: 34px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 50%;
   position: relative;
   transition: all .3s cubic-bezier(0.23, 1, 0.320, 1);
 }
 .faqIcon::before, .faqIcon::after {
   content: "";
   position: absolute;
-  background: var(--brand);
+  background: var(--color-white);
   top: 50%; left: 50%;
   transition: all .3s cubic-bezier(0.23, 1, 0.320, 1);
 }
 .faqIcon::before { width: 12px; height: 2px; transform: translate(-50%,-50%); }
 .faqIcon::after { width: 2px; height: 12px; transform: translate(-50%,-50%); }
 .faqItemOpen .faqIcon {
-  background: var(--brand);
-  border-color: transparent;
+  background: var(--color-white);
+  border-color: var(--color-white);
 }
 .faqItemOpen .faqIcon::before,
-.faqItemOpen .faqIcon::after { background: var(--moonlight-white); }
+.faqItemOpen .faqIcon::after { background: var(--color-red); }
 .faqItemOpen .faqIcon::after { transform: translate(-50%,-50%) rotate(90deg); }
 
 .faqA {
@@ -158,18 +156,18 @@
 .faqAInner {
   padding: 0 0 24px;
   max-width: 68ch;
-  color: var(--body);
+  color: rgba(255, 255, 255, 0.78);
   font-size: 16px;
-  line-height: 1.7;
+  line-height: 1.75;
   text-wrap: pretty;
-  font-weight: 500;
+  font-weight: 400;
 }
 .faqItemOpen .faqA { max-height: 400px; }
 
-/* ---------- CTA ---------- */
+/* ---------- CTA — painel branco a fechar a página ---------- */
 .cta {
   margin-top: 56px;
-  background: var(--brand);
+  background: var(--color-white);
   border-radius: var(--radius-xl);
   padding: 36px 32px;
   display: flex;
@@ -177,22 +175,32 @@
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  color: var(--moonlight-white);
+  color: var(--on-invert);
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+.cta::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: var(--color-red);
 }
 .ctaTitle {
-  font-size: clamp(20px, 2.4vw, 28px);
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  color: var(--moonlight-white);
+  font-size: clamp(21px, 2.4vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  color: var(--on-invert);
   margin: 0 0 6px;
 }
 .ctaSub {
   font-size: 15px;
-  color: rgba(255, 255, 255, 0.74);
+  color: var(--on-invert-3);
   margin: 0;
-  font-weight: 500;
+  font-weight: 400;
 }
-/* CTA branco sobre o painel vermelho — máximo contraste sobre a cor de marca. */
+/* CTA sólido vermelho sobre o painel branco. */
 .ctaBtn {
   display: inline-flex;
   align-items: center;
@@ -200,21 +208,21 @@
   gap: 8px;
   padding: 16px 32px;
   border-radius: var(--radius-md);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 16px;
   line-height: 1.2;
   white-space: nowrap;
   text-decoration: none;
   border: none !important;
-  background: var(--color-white);
-  color: var(--color-primary-red) !important;
-  box-shadow: 0 4px 12px rgba(15, 76, 92, 0.2);
+  background: var(--color-red);
+  color: var(--color-white) !important;
+  box-shadow: 0 4px 14px rgba(227, 6, 19, 0.28);
   transition: all 200ms ease;
 }
 .ctaBtn:hover {
   transform: translateY(-2px);
-  background: var(--color-bg-light);
-  box-shadow: 0 6px 16px rgba(15, 76, 92, 0.28);
+  background: var(--color-red-2);
+  box-shadow: 0 8px 22px rgba(227, 6, 19, 0.34);
 }
 .ctaBtn:active { transform: translateY(0); }
 .ctaBtn svg { transition: transform 200ms ease; }

--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,0 +1,36 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Tipografia do site.
+ * Creato Display — grotesca geométrica, moderna e sóbria — é a única família
+ * usada em toda a aplicação. Os ficheiros são locais (public/fonts), pelo que
+ * a compilação não depende de nenhum serviço externo de fontes.
+ *
+ * `next/font/local` gera a variável CSS `--font-creato`, consumida pelo token
+ * `--font-body` em app/globals.css.
+ */
+
+import localFont from "next/font/local";
+
+export const creatoDisplay = localFont({
+  src: [
+    {
+      path: "../public/fonts/CreatoDisplay-Regular.otf",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "../public/fonts/CreatoDisplay-Medium.otf",
+      weight: "500",
+      style: "normal",
+    },
+    {
+      // O Bold cobre também os pesos 600/700/800 pedidos pelos módulos CSS,
+      // evitando que o browser sintetize um falso negrito.
+      path: "../public/fonts/CreatoDisplay-Bold.otf",
+      weight: "600 900",
+      style: "normal",
+    },
+  ],
+  variable: "--font-creato",
+  display: "swap",
+  fallback: ["Helvetica Neue", "Helvetica", "Arial", "sans-serif"],
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,12 +4,15 @@
  * secções e utilitários usados em toda a aplicação.
  *
  * PALETA OFICIAL (única fonte de verdade de cor do site):
- *   Vermelho  #EF3E4D — primária, CTAs e destaques
- *   Azul      #0F4C5C — primária, cabeçalho, rodapé e superfícies escuras
- *   Azul esc. #2A3F4B — subtítulos e texto secundário
- *   Cinzentos #6B8087 / #E8EEF1 / #F5F8FA — labels, linhas e fundos alternados
- *   Verde     #2ABF84 — sucesso e aprovações
- *   Laranja   #F39C12 — avisos
+ *   Vermelho  #E30613 — superfície principal: fundo do site e do cabeçalho
+ *   Vermelho  #C40510 — superfície alternada, para dar ritmo entre secções
+ *   Branco    #FFFFFF — texto principal sobre vermelho e painéis invertidos
+ *   Preto     #101012 — rodapé, painéis de contraste e detalhes
+ *
+ * O site é um sistema de dois tons: VERMELHO com texto BRANCO, e o inverso
+ * — painéis BRANCOS com texto quase-preto — usado nos blocos que pedem foco
+ * (formulários, cartões de preço, quiz, documento imprimível). O preto entra
+ * apenas como âncora (rodapé, chrome do leitor) e como sombra.
  *
  * Os nomes dos tokens legados (--brand, --surface, --ink, ...) mantêm-se e são
  * remapeados para esta paleta, para que os CSS Modules de cada página herdem o
@@ -22,37 +25,45 @@
    PARTE 1 — TOKENS: COR, ESPAÇAMENTO E RAIOS
    =================================================================== */
 :root {
-  /* Cores Primárias */
-  --color-primary-red: #ef3e4d;        /* Vermelho vibrante — CTAs, destaques */
-  --color-primary-blue: #0f4c5c;       /* Azul profundo — backgrounds, text */
-
-  /* Cores Secundárias */
-  --color-dark-blue: #2a3f4b;          /* Azul escuro — subtítulos, text secondary */
-  --color-gray-medium: #6b8087;        /* Cinzento médio — labels, hints */
-  --color-gray-light: #e8eef1;         /* Cinzento claro — borders, backgrounds alt */
-  --color-bg-light: #f5f8fa;           /* Fundo muito claro — cards, sections */
-  --color-success-green: #2abf84;      /* Verde — sucesso, checkmarks, aprovado */
-  --color-warning-orange: #f39c12;     /* Laranja — warning, atenção */
-
-  /* Neutros */
+  /* --- Paleta base ------------------------------------------------ */
+  --color-red: #e30613;                /* Vermelho da marca — superfície */
+  --color-red-2: #c40510;              /* Vermelho alternado — ritmo */
+  --color-red-3: #a00309;              /* Vermelho profundo — pressed */
+  --color-red-bright: #ff5147;         /* Vermelho vivo — acento sobre branco/preto */
   --color-white: #ffffff;
-  --color-text-primary: #1a1a1a;       /* Texto muito escuro para máx contraste */
-  --color-text-secondary: #6b8087;
+  --color-black: #101012;              /* Preto da marca — rodapé, chrome */
+  --color-black-2: #1b1b1f;            /* Preto elevado — painéis sobre preto */
 
-  /* Escalas derivadas do vermelho, para estados e fundos translúcidos. */
-  --color-red-hover: #d63442;
-  --color-red-active: #c62a35;
-  --color-red-ink: #9d1f29;
-  --color-red-soft: rgba(239, 62, 77, 0.12);
-  --color-red-tint: rgba(239, 62, 77, 0.06);
+  /* --- Superfícies -------------------------------------------------
+     `surface` = vermelho (o site). `invert` = branco (blocos de foco). */
+  --surface-brand: var(--color-red);
+  --surface-brand-alt: var(--color-red-2);
+  --surface-invert: var(--color-white);
+  --surface-ink: var(--color-black);
 
-  /* Vermelho clarificado para texto sobre as superfícies azuis escuras:
-     o #EF3E4D puro só atinge ~2.8:1 sobre #0F4C5C. */
-  --color-red-on-dark: #ff9ba3;
+  /* Painéis translúcidos sobre vermelho — evitam introduzir novas cores. */
+  --panel: rgba(255, 255, 255, 0.08);
+  --panel-strong: rgba(255, 255, 255, 0.14);
+  --panel-ink: rgba(0, 0, 0, 0.16);
 
-  /* Escalas derivadas do azul. */
-  --color-blue-deep: #06333d;
-  --color-blue-tint: rgba(15, 76, 92, 0.08);
+  /* --- Texto -------------------------------------------------------- */
+  --on-brand: var(--color-white);              /* texto sobre vermelho */
+  --on-brand-2: rgba(255, 255, 255, 0.82);     /* corpo secundário */
+  --on-brand-3: rgba(255, 255, 255, 0.64);     /* labels, hints */
+  --on-invert: #141416;                        /* texto sobre branco */
+  --on-invert-2: #4d4d55;                      /* corpo sobre branco */
+  --on-invert-3: #74747e;                      /* labels sobre branco */
+
+  /* --- Linhas ------------------------------------------------------- */
+  --hairline: rgba(255, 255, 255, 0.24);
+  --hairline-soft: rgba(255, 255, 255, 0.14);
+  --hairline-strong: rgba(255, 255, 255, 0.46);
+  --hairline-invert: #e7e7ea;
+
+  /* --- Estados semânticos (usados sobre painéis brancos) ------------ */
+  --color-success: #12a06d;
+  --color-warning: #b8730a;
+  --color-danger: #cf0a17;
 
   /* SPACING SCALE (8px base) */
   --sp-xs: 8px;
@@ -65,72 +76,156 @@
   --sp-4xl: 64px;
   --sp-5xl: 80px;
 
-  /* Tipografia base — pilha de sistema, sem pedidos externos de fonte. */
-  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", sans-serif;
+  /* Tipografia — Creato Display (ficheiros locais, ver app/fonts.ts).
+     `--font-creato` é injetado pelo next/font; a pilha de sistema fica como
+     alternativa para o primeiro paint e para ambientes sem a fonte. */
+  --font-body: var(--font-creato), "Helvetica Neue", Helvetica, Arial,
+    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-display: var(--font-body);
 
-  /* Raios de canto — escala única partilhada por todo o site. */
-  --radius-xs: 4px;      /* micro-detalhes: barras, marcadores */
-  --radius-sm: 6px;      /* chips, distintivos, ícones pequenos */
-  --radius-md: 8px;      /* botões, campos de formulário, itens de lista */
-  --radius-lg: 12px;     /* cartões e blocos de conteúdo */
-  --radius-xl: 16px;     /* painéis grandes: formulários, destaques */
+  /* Raios de canto — escala curta e discreta: o desenho é tipográfico,
+     não arredondado. */
+  --radius-xs: 2px;      /* micro-detalhes: barras, marcadores */
+  --radius-sm: 4px;      /* chips, distintivos, ícones pequenos */
+  --radius-md: 6px;      /* botões, campos de formulário, itens de lista */
+  --radius-lg: 10px;     /* cartões e blocos de conteúdo */
+  --radius-xl: 14px;     /* painéis grandes: formulários, destaques */
   --radius-pill: 999px;  /* pílulas, réguas finas e barras de progresso */
   --radius-sharp: var(--radius-md);
   --header-control-height: 38px;
 
-  /* Sombras — escala única de elevação. */
-  --shadow-sm: 0 2px 8px rgba(15, 76, 92, 0.08);
-  --shadow-md: 0 8px 24px rgba(15, 76, 92, 0.12);
-  --shadow-lg: 0 12px 32px rgba(15, 76, 92, 0.14);
+  /* Sombras — sobre vermelho só funcionam sombras pretas e discretas. */
+  --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.12);
+  --shadow-md: 0 10px 30px rgba(0, 0, 0, 0.18);
+  --shadow-lg: 0 18px 48px rgba(0, 0, 0, 0.24);
 
   /* ---------------------------------------------------------------
      CAMADA DE COMPATIBILIDADE
      Tokens legados usados pelos CSS Modules de cada página, agora
      apontados para a paleta acima. Alterar aqui muda o site inteiro.
      --------------------------------------------------------------- */
-  --turkish-red: var(--color-primary-red);
+  --turkish-red: var(--color-red);
   --moonlight-white: var(--color-white);
-  --light-carbon: var(--color-gray-medium);
-  --railroad-black: var(--color-primary-blue);
+  --light-carbon: var(--on-brand-3);
+  --railroad-black: var(--color-black);
 
   /* Superfícies e texto */
-  --background: var(--color-white);
-  --background-deep: var(--color-bg-light);
-  --foreground: var(--color-text-primary);
-  --surface: var(--color-white);
-  --surface-raised: var(--color-bg-light);
-  --surface-muted: var(--color-gray-light);
-  --ink: var(--color-text-primary);
-  --body: var(--color-dark-blue);
-  --muted: var(--color-gray-medium);
-  --line: var(--color-gray-light);
-  --line-light: #eef3f6;
-  --line-strong: #d3dee4;
-  --scrim: rgba(6, 51, 61, 0.6);
+  --background: var(--surface-brand);
+  --background-deep: var(--surface-brand-alt);
+  --foreground: var(--on-brand);
+  --surface: var(--surface-brand);
+  --surface-raised: var(--panel);
+  --surface-muted: var(--panel-strong);
+  --ink: var(--on-brand);
+  --body: var(--on-brand-2);
+  --muted: var(--on-brand-3);
+  --line: var(--hairline);
+  --line-light: var(--hairline-soft);
+  --line-strong: var(--hairline-strong);
+  --scrim: rgba(0, 0, 0, 0.62);
 
-  /* Marca — Vermelho */
-  --brand: var(--color-primary-red);
-  --brand-500: #f2606c;
-  --brand-600: var(--color-primary-red);
-  --brand-700: var(--color-red-hover);
-  --brand-deep: var(--color-red-active);
-  --brand-ink: var(--color-red-ink);
-  --brand-soft: var(--color-red-soft);
-  --brand-tint: var(--color-red-tint);
+  /* Nomes antigos da paleta anterior — mantidos para não partir módulos. */
+  --color-primary-red: var(--color-red);
+  /* O antigo azul era, ao mesmo tempo, superfície escura e texto forte.
+     O preto cobre bem os dois papéis dentro do novo sistema. */
+  --color-primary-blue: var(--color-black);
+  --color-blue-deep: #0a0a0b;
+  --color-blue-tint: rgba(0, 0, 0, 0.14);
+  --color-dark-blue: var(--on-brand-2);
+  --color-gray-medium: var(--on-brand-3);
+  --color-gray-light: var(--hairline);
+  --color-bg-light: var(--surface-brand-alt);
+  --color-text-primary: var(--on-brand);
+  --color-text-secondary: var(--on-brand-3);
+  --color-success-green: var(--color-success);
+  --color-warning-orange: var(--color-warning);
+
+  --color-red-hover: #f5232f;
+  --color-red-active: var(--color-red-3);
+  --color-red-ink: var(--color-danger);
+  --color-red-soft: rgba(255, 255, 255, 0.14);
+  --color-red-tint: rgba(255, 255, 255, 0.07);
+  --color-red-on-dark: var(--color-white);
+
+  /* Marca */
+  --brand: var(--color-white);          /* o acento sobre vermelho é branco */
+  --brand-on-invert: var(--color-red);  /* e sobre branco é vermelho */
+  --brand-500: var(--color-white);
+  --brand-600: var(--color-white);
+  --brand-700: var(--color-white);
+  --brand-deep: var(--color-red-3);
+  --brand-ink: var(--color-red-3);
+  --brand-soft: var(--panel);
+  --brand-tint: rgba(255, 255, 255, 0.07);
 
   /* Estados semânticos */
-  --accent: var(--color-primary-red);
-  --accent-600: var(--color-red-hover);
-  --accent-soft: var(--color-red-soft);
-  --amber: var(--color-warning-orange);
-  --amber-soft: rgba(243, 156, 18, 0.15);
-  --mint: var(--color-success-green);
-  --primary: var(--color-primary-red);
-  --primary-soft: var(--color-red-hover);
-  --accent-success: var(--color-success-green);
+  --accent: var(--color-white);
+  --accent-600: rgba(255, 255, 255, 0.86);
+  --accent-soft: var(--panel);
+  --amber: var(--color-warning);
+  --amber-soft: rgba(255, 255, 255, 0.14);
+  --mint: var(--color-success);
+  --primary: var(--color-white);
+  --primary-soft: rgba(255, 255, 255, 0.86);
+  --accent-success: var(--color-success);
+
+  /* Botão principal — sempre o oposto da superfície onde assenta.
+     Sobre vermelho é branco; qualquer painel `.on-light` inverte estes três
+     valores e todos os botões lá dentro seguem, sem seletores extra. */
+  --btn-bg: var(--color-white);
+  --btn-fg: var(--color-red);
+  --btn-bg-hover: var(--color-white);
+  --btn-fg-hover: var(--color-red-3);
+  --btn-shadow: 0 4px 14px rgba(0, 0, 0, 0.16);
+  --btn-shadow-hover: 0 8px 22px rgba(0, 0, 0, 0.22);
+  --focus-ring: var(--color-white);
 
   color-scheme: light;
+}
+
+/* -------------------------------------------------------------------
+   PAINÉIS INVERTIDOS
+   Aplicar `.on-light` a qualquer bloco branco: os tokens de texto e linha
+   viram para a escala escura, e tudo o que está dentro herda sem
+   declarações extra.
+   ------------------------------------------------------------------- */
+.on-light,
+.login-form,
+.mobile-menu-container,
+.dashboard-top-banner,
+.dashboard-sidebar {
+  --ink: var(--on-invert);
+  --body: var(--on-invert-2);
+  --muted: var(--on-invert-3);
+  --line: var(--hairline-invert);
+  --line-light: #f0f0f2;
+  --line-strong: #cfcfd5;
+  --brand: var(--color-red);
+  --brand-500: var(--color-red);
+  --brand-600: var(--color-red);
+  --brand-700: var(--color-red-2);
+  --brand-soft: rgba(227, 6, 19, 0.1);
+  --accent: var(--color-red);
+  --primary: var(--color-red);
+  --surface: var(--color-white);
+  --surface-raised: #f6f6f8;
+  --surface-muted: #ededf1;
+  --panel: #f6f6f8;
+  --panel-strong: #ededf1;
+  --color-text-primary: var(--on-invert);
+  --color-text-secondary: var(--on-invert-3);
+  --color-gray-light: var(--hairline-invert);
+  --color-gray-medium: var(--on-invert-3);
+  --color-bg-light: #f6f6f8;
+  --color-red-soft: rgba(227, 6, 19, 0.1);
+
+  --btn-bg: var(--color-red);
+  --btn-fg: var(--color-white);
+  --btn-bg-hover: var(--color-red-2);
+  --btn-fg-hover: var(--color-white);
+  --btn-shadow: 0 4px 14px rgba(227, 6, 19, 0.28);
+  --btn-shadow-hover: 0 8px 22px rgba(227, 6, 19, 0.34);
+  --focus-ring: var(--color-red);
 }
 
 @theme inline {
@@ -150,10 +245,6 @@
   --color-body: var(--body);
   --color-muted: var(--muted);
 
-  /* `bg-black/60` e afins passam a usar o azul profundo da paleta, para que
-     nenhum ecrã caia fora das cores da marca. */
-  --color-black: #06333d;
-
   --font-sans: var(--font-body);
 }
 
@@ -164,15 +255,15 @@
   html {
     font-size: 16px;
     scroll-behavior: smooth;
-    background: var(--color-white);
+    background: var(--surface-brand);
   }
 
   body {
     font-family: var(--font-body);
     font-size: 16px;
     line-height: 1.6;
-    color: var(--color-text-primary);
-    background: var(--color-white);
+    color: var(--on-brand);
+    background: var(--surface-brand);
     letter-spacing: 0;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
@@ -180,41 +271,47 @@
     overflow-x: hidden;
   }
 
-  /* HEADINGS — sem `color` fixo: herdam do <body>, para que qualquer
-     contentor de fundo escuro (painéis vermelhos/azuis) possa passar a sua
-     própria cor de texto aos títulos que contém. */
+  /* HEADINGS — sem `color` fixo: herdam do contentor, para que os painéis
+     brancos possam impor o seu próprio tom sem exceções. Tracking negativo
+     e peso alto dão o registo tipográfico moderno do sistema. */
   h1 {
-    font-size: 56px;
+    font-family: var(--font-display);
+    font-size: 60px;
     font-weight: 700;
-    line-height: 1.2;
-    letter-spacing: -0.5px;
+    line-height: 1.04;
+    letter-spacing: -0.035em;
     margin-bottom: 24px;
   }
 
   h2 {
-    font-size: 40px;
+    font-family: var(--font-display);
+    font-size: 42px;
     font-weight: 700;
-    line-height: 1.3;
-    letter-spacing: -0.3px;
+    line-height: 1.08;
+    letter-spacing: -0.03em;
     margin-bottom: 20px;
   }
 
   h3 {
+    font-family: var(--font-display);
     font-size: 28px;
-    font-weight: 600;
-    line-height: 1.3;
+    font-weight: 700;
+    line-height: 1.16;
+    letter-spacing: -0.02em;
     margin-bottom: 16px;
   }
 
   h4 {
     font-size: 22px;
-    font-weight: 600;
+    font-weight: 700;
+    letter-spacing: -0.015em;
     margin-bottom: 12px;
   }
 
   h5 {
     font-size: 18px;
     font-weight: 600;
+    letter-spacing: -0.01em;
     margin-bottom: 8px;
   }
 
@@ -227,8 +324,8 @@
   /* Os tamanhos fixos acima são desenhados para desktop; em ecrãs pequenos
      descem para não rebentar a linha. */
   @media (max-width: 768px) {
-    h1 { font-size: 38px; }
-    h2 { font-size: 30px; }
+    h1 { font-size: 40px; }
+    h2 { font-size: 31px; }
     h3 { font-size: 23px; }
     h4 { font-size: 20px; }
   }
@@ -244,22 +341,22 @@
 
 @layer components {
   .text-secondary {
-    color: var(--color-text-secondary);
+    color: var(--body);
     font-size: 16px;
   }
 
   .text-small {
     font-size: 14px;
-    color: var(--color-gray-medium);
+    color: var(--muted);
     line-height: 1.6;
   }
 
   .text-label {
-    font-size: 13px;
-    font-weight: 600;
+    font-size: 12px;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--color-gray-medium);
+    letter-spacing: 0.14em;
+    color: var(--muted);
   }
 
   /* Mantém texto branco legível em cartões de fundo colorido. */
@@ -274,7 +371,7 @@
   /* Realces específicos da home, com prioridade sobre regras globais. */
   .home-title-highlight-text {
     color: var(--ink) !important;
-    letter-spacing: -0.5px;
+    letter-spacing: -0.03em;
   }
 
   .home-benefits-highlight-text {
@@ -285,7 +382,7 @@
     color: var(--accent) !important;
   }
 
-  /* Régua vermelha curta — assinatura do sistema, usada abaixo de títulos. */
+  /* Régua curta — assinatura do sistema, usada abaixo de títulos. */
   .rule-accent::after {
     content: "";
     display: block;
@@ -293,7 +390,7 @@
     height: 3px;
     margin-top: 14px;
     border-radius: var(--radius-pill);
-    background: var(--color-primary-red);
+    background: var(--brand);
   }
 
 }
@@ -301,11 +398,11 @@
 @layer components {
   /* =================================================================
      PARTE 2 — BOTÕES
+     -----------------------------------------------------------------
+     Regra do sistema: o botão principal é sempre o oposto da superfície.
+     Sobre vermelho → botão branco com texto vermelho. Dentro de um painel
+     branco (`.on-light`, `.login-form`) → botão vermelho com texto branco.
      ================================================================= */
-
-  /* BUTTON BASE. Os nomes de classe legados (.btn-primary, .site-pill-button,
-     .submit, ...) partilham esta base para que nenhuma página precise de ser
-     reescrita. */
   button,
   .button,
   .btn-primary,
@@ -320,14 +417,14 @@
     align-items: center;
     justify-content: center;
     gap: 8px;
-    padding: 16px 32px;
+    padding: 15px 30px;
     border-radius: var(--radius-md);
     border: none;
     font-family: var(--font-body);
-    font-size: 16px;
-    font-weight: 600;
+    font-size: 15px;
+    font-weight: 700;
     line-height: 1.2;
-    letter-spacing: 0;
+    letter-spacing: -0.005em;
     text-transform: none;
     cursor: pointer;
     transition: all 200ms ease;
@@ -336,7 +433,8 @@
     white-space: nowrap;
   }
 
-  /* BUTTON PRIMARY — Vermelho (CTA) */
+  /* BUTTON PRIMARY — lê os tokens `--btn-*`, por isso inverte-se sozinho
+     dentro de qualquer painel branco. */
   button.primary,
   .button.primary,
   button[type="submit"],
@@ -347,9 +445,9 @@
   .button-size-login,
   .submit,
   .cssbuttons-io-button {
-    background-color: var(--color-primary-red);
-    color: var(--color-white);
-    box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+    background-color: var(--btn-bg);
+    color: var(--btn-fg);
+    box-shadow: var(--btn-shadow);
   }
 
   button.primary:hover,
@@ -361,10 +459,10 @@
   .button-size-login:hover,
   .submit:hover,
   .cssbuttons-io-button:hover {
-    background-color: var(--color-red-hover);
-    color: var(--color-white);
+    background-color: var(--btn-bg-hover);
+    color: var(--btn-fg-hover);
     transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(239, 62, 77, 0.35);
+    box-shadow: var(--btn-shadow-hover);
   }
 
   button.primary:active,
@@ -376,9 +474,8 @@
   .button-size-login:active,
   .submit:active,
   .cssbuttons-io-button:active {
-    background-color: var(--color-red-active);
     transform: translateY(0);
-    box-shadow: 0 2px 8px rgba(239, 62, 77, 0.25);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
   }
 
   button.primary:disabled,
@@ -387,40 +484,39 @@
   .btn-primary:disabled,
   .submit:disabled,
   .cssbuttons-io-button:disabled {
-    opacity: 0.6;
+    opacity: 0.55;
     cursor: not-allowed;
     transform: none;
     box-shadow: none;
   }
 
-  /* BUTTON SECONDARY — Azul/Border */
+  /* BUTTON SECONDARY — vazado, herda a cor do texto do contentor */
   button.secondary,
   .button.secondary,
   .btn-secondary,
   .site-pill-button-secondary {
     background-color: transparent;
-    color: var(--color-primary-blue);
-    border: 2px solid var(--color-primary-blue);
+    color: var(--ink);
+    border: 1.5px solid var(--line-strong);
     box-shadow: none;
-    /* Compensa os 2px de contorno para manter a mesma altura do primário. */
-    padding: 14px 30px;
+    padding: 13.5px 28.5px;
   }
 
   button.secondary:hover,
   .button.secondary:hover,
   .btn-secondary:hover,
   .site-pill-button-secondary:hover {
-    background-color: rgba(15, 76, 92, 0.05);
-    color: var(--color-primary-blue);
+    background-color: var(--panel-strong);
+    color: var(--ink);
+    border-color: var(--ink);
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(15, 76, 92, 0.15);
+    box-shadow: none;
   }
 
   button.secondary:active,
   .button.secondary:active,
   .btn-secondary:active,
   .site-pill-button-secondary:active {
-    background-color: rgba(15, 76, 92, 0.1);
     transform: translateY(0);
   }
 
@@ -428,17 +524,16 @@
   button.lg,
   .button.lg,
   .btn-lg {
-    padding: 20px 48px;
-    font-size: 18px;
-    font-weight: 700;
+    padding: 19px 44px;
+    font-size: 17px;
   }
 
   /* BUTTON SMALL */
   button.sm,
   .button.sm,
   .btn-sm {
-    padding: 12px 24px;
-    font-size: 14px;
+    padding: 11px 22px;
+    font-size: 13.5px;
   }
 
   /* BUTTON FULLWIDTH */
@@ -448,28 +543,27 @@
     width: 100%;
   }
 
-  /* Botões do cabeçalho — compactos e legíveis sobre o azul profundo. */
+  /* Botões do cabeçalho — compactos e legíveis sobre o vermelho. */
   .site-pill-button,
   .button-size-login,
   .site-pill-button-secondary {
     padding: 10px 20px;
     font-size: 13px;
-    font-weight: 600;
+    font-weight: 700;
+    letter-spacing: 0.01em;
   }
 
-  /* Vazado sobre o cabeçalho azul: contorno branco em vez de azul. */
-  .site-header .site-pill-button-secondary,
-  .site-header .site-pill-button.nav-login-btn {
+  /* Vazado sobre o cabeçalho vermelho: contorno branco. */
+  .site-header .site-pill-button-secondary {
     background-color: transparent;
     color: var(--color-white);
-    border: 1px solid rgba(255, 255, 255, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.45);
     padding: 11px 21px;
     box-shadow: none;
   }
 
-  .site-header .site-pill-button-secondary:hover,
-  .site-header .site-pill-button.nav-login-btn:hover {
-    background-color: rgba(255, 255, 255, 0.12);
+  .site-header .site-pill-button-secondary:hover {
+    background-color: rgba(255, 255, 255, 0.14);
     border-color: var(--color-white);
     color: var(--color-white);
     box-shadow: none;
@@ -485,9 +579,9 @@
     height: var(--header-control-height);
     min-width: 44px;
     min-height: 44px;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.4);
     border-radius: var(--radius-md);
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: transparent;
     box-shadow: none;
     cursor: pointer;
     transition: all 200ms ease;
@@ -551,12 +645,12 @@
     }
   }
 
-  /* Cartão do menu mobile. */
+  /* Cartão do menu mobile — painel branco invertido. */
   .mobile-menu-container {
     border-radius: var(--radius-lg);
     will-change: contents;
     box-shadow: var(--shadow-lg) !important;
-    border: 1px solid var(--color-gray-light) !important;
+    border: 1px solid var(--hairline-invert) !important;
     background: var(--color-white) !important;
   }
 
@@ -567,15 +661,15 @@
   }
 
   .mobile-menu-item {
-    color: var(--color-primary-blue) !important;
+    color: var(--on-invert) !important;
     min-height: 48px;
     display: flex;
     align-items: center;
   }
 
   .mobile-menu-item:hover {
-    color: var(--color-primary-red) !important;
-    background: var(--color-bg-light) !important;
+    color: var(--color-red) !important;
+    background: #f6f6f8 !important;
   }
 
   @media (max-width: 480px) {
@@ -587,7 +681,7 @@
 
   .button-text-standard {
     font-size: 0.875rem;
-    font-weight: 600;
+    font-weight: 700;
   }
 
   /* Reset para botões estruturais (toggles, seletores) que não são CTAs. */
@@ -614,28 +708,28 @@
      PARTE 3 — CARDS & CONTAINERS
      ================================================================= */
   .card {
-    background-color: var(--color-white);
-    border: 1px solid var(--color-gray-light);
+    background-color: var(--panel);
+    border: 1px solid var(--hairline);
     border-radius: var(--radius-lg);
     padding: 24px;
     transition: all 300ms ease;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    box-shadow: none;
   }
 
   .card:hover {
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    border-color: var(--hairline-strong);
     transform: translateY(-4px);
   }
 
   /* CARD DARK (fundo alternado) */
   .card.dark {
-    background-color: var(--color-bg-light);
+    background-color: var(--surface-brand-alt);
     border-color: transparent;
   }
 
   /* CARD WITH ACCENT BORDER LEFT */
   .card.accent-left {
-    border-left: 3px solid var(--color-primary-red);
+    border-left: 3px solid var(--color-white);
     padding-left: 28px;
   }
 
@@ -661,46 +755,62 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 8px 16px;
-    border-radius: var(--radius-sm);
-    font-size: 13px;
-    font-weight: 600;
+    padding: 7px 14px;
+    border-radius: var(--radius-pill);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
     white-space: nowrap;
   }
 
   .badge.success {
-    background-color: rgba(42, 191, 132, 0.15);
-    color: #1b6f4a;
-    border: 1px solid rgba(42, 191, 132, 0.3);
+    background-color: rgba(255, 255, 255, 0.16);
+    color: var(--color-white);
+    border: 1px solid rgba(255, 255, 255, 0.4);
   }
 
   .badge.error {
-    background-color: rgba(239, 62, 77, 0.15);
-    color: var(--color-red-ink);
-    border: 1px solid rgba(239, 62, 77, 0.3);
+    background-color: var(--color-black);
+    color: var(--color-white);
+    border: 1px solid var(--color-black);
   }
 
   .badge.warning {
-    background-color: rgba(243, 156, 18, 0.15);
-    color: #b85f0d;
-    border: 1px solid rgba(243, 156, 18, 0.3);
+    background-color: rgba(255, 255, 255, 0.16);
+    color: var(--color-white);
+    border: 1px solid rgba(255, 255, 255, 0.4);
   }
 
   .badge.info {
-    background-color: rgba(15, 76, 92, 0.15);
-    color: var(--color-dark-blue);
-    border: 1px solid rgba(15, 76, 92, 0.3);
+    background-color: transparent;
+    color: var(--color-white);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+  }
+
+  .on-light .badge.success {
+    background-color: rgba(18, 160, 109, 0.12);
+    color: var(--color-success);
+    border-color: rgba(18, 160, 109, 0.32);
+  }
+
+  .on-light .badge.error {
+    background-color: rgba(207, 10, 23, 0.1);
+    color: var(--color-danger);
+    border-color: rgba(207, 10, 23, 0.3);
   }
 
   .status-approved {
-    color: var(--color-success-green);
-    font-weight: 600;
+    color: var(--color-white);
+    font-weight: 700;
   }
 
   .status-rejected {
-    color: var(--color-primary-red);
-    font-weight: 600;
+    color: var(--color-black);
+    font-weight: 700;
   }
+
+  .on-light .status-approved { color: var(--color-success); }
+  .on-light .status-rejected { color: var(--color-danger); }
 
   /* =================================================================
      PARTE 5 — NAVEGAÇÃO & HEADER
@@ -710,15 +820,16 @@
      desenho do cabeçalho não contamina outros usos do elemento.
      ================================================================= */
   .site-header {
-    background-color: var(--color-primary-blue);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    background-color: var(--surface-brand);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.22);
+    box-shadow: none;
     z-index: 100;
   }
 
   /* A linha principal do cabeçalho: marca à esquerda, navegação e ações à
-     direita, com a altura de 70px definida no sistema. */
+     direita, com a altura de 72px definida no sistema. */
   .site-header-inner {
-    height: 70px;
+    height: 72px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -735,7 +846,7 @@
   .site-header .logo {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     text-decoration: none;
     font-size: 16px;
     font-weight: 700;
@@ -750,9 +861,11 @@
   /* Nota: o `display` da <nav> fica a cargo das utilitárias responsivas
      (hidden / lg:flex); defini-lo aqui quebraria o menu em ecrãs pequenos. */
   .site-header nav a {
-    font-size: 15px;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.85);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.78);
     text-decoration: none;
     transition: color 200ms ease;
     position: relative;
@@ -765,11 +878,11 @@
   .site-header nav a::after {
     content: "";
     position: absolute;
-    bottom: -4px;
+    bottom: -6px;
     left: 0;
     width: 0;
     height: 2px;
-    background-color: var(--color-primary-red);
+    background-color: var(--color-white);
     transition: width 200ms ease;
   }
 
@@ -777,19 +890,20 @@
     width: 100%;
   }
 
-  /* Página ativa: texto a branco cheio e régua vermelha permanente. */
+  /* Página ativa: texto a branco cheio e régua branca permanente. */
   .site-header nav a.nav-link-active {
     color: var(--color-white);
-    font-weight: 600;
+    font-weight: 700;
   }
 
   .site-header nav a.nav-link-active::after {
     width: 100%;
   }
 
-  /* O menu mobile é um cartão claro sobreposto — herda o seu próprio tema. */
+  /* O menu mobile é um cartão branco sobreposto — herda o seu próprio tema. */
   .site-header .mobile-menu-container a {
-    color: var(--color-primary-blue);
+    color: var(--on-invert);
+    text-transform: uppercase;
   }
 
   .site-header .mobile-menu-container a::after {
@@ -806,18 +920,23 @@
   /* LANGUAGE SELECTOR */
   .lang-selector {
     background: transparent;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.35);
     color: var(--color-white);
-    padding: 8px 12px;
+    padding: 7px 11px;
     border-radius: var(--radius-sm);
-    font-size: 13px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
     cursor: pointer;
+    box-shadow: none;
     transition: all 200ms ease;
   }
 
   .lang-selector:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.14);
     border-color: var(--color-white);
+    transform: none;
+    box-shadow: none;
   }
 
   /* USER MENU */
@@ -826,13 +945,13 @@
     align-items: center;
     gap: 16px;
     padding-left: 16px;
-    border-left: 1px solid rgba(255, 255, 255, 0.2);
+    border-left: 1px solid rgba(255, 255, 255, 0.28);
   }
 
   .user-name {
     color: var(--color-white);
     font-size: 14px;
-    font-weight: 500;
+    font-weight: 600;
   }
 
   /* =================================================================
@@ -844,17 +963,14 @@
     gap: var(--sp-lg);
     align-items: center;
     padding: var(--sp-5xl) var(--sp-md);
-    background: linear-gradient(
-      135deg,
-      var(--color-primary-blue) 0%,
-      rgba(15, 76, 92, 0.95) 100%
-    );
+    background: var(--surface-brand);
     color: var(--color-white);
   }
 
   .hero-content h1 {
-    font-size: 64px;
-    line-height: 1.15;
+    font-size: 68px;
+    line-height: 1.02;
+    letter-spacing: -0.04em;
     margin-bottom: 24px;
     color: var(--color-white);
   }
@@ -863,7 +979,7 @@
     font-size: 16px;
     line-height: 1.7;
     margin-bottom: 32px;
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(255, 255, 255, 0.82);
     max-width: 500px;
   }
 
@@ -880,7 +996,7 @@
     gap: var(--sp-md);
     align-items: center;
     padding-top: var(--sp-md);
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-top: 1px solid rgba(255, 255, 255, 0.24);
     margin-top: var(--sp-lg);
   }
 
@@ -894,8 +1010,8 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    background: var(--color-primary-red);
-    color: var(--color-white);
+    background: var(--color-white);
+    color: var(--color-red);
     padding: 4px 8px;
     border-radius: var(--radius-xs);
     font-size: 12px;
@@ -909,19 +1025,19 @@
 
   /* HERO MISSION CARD */
   .mission-card {
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(239, 62, 77, 0.4);
+    background: rgba(0, 0, 0, 0.16);
+    border: 1px solid rgba(255, 255, 255, 0.28);
     border-radius: var(--radius-lg);
     padding: 28px;
     backdrop-filter: blur(10px);
   }
 
   .mission-card h4 {
-    font-size: 13px;
+    font-size: 12px;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 0.16em;
     margin-bottom: 16px;
-    color: var(--color-primary-red);
+    color: var(--color-white);
     font-weight: 700;
   }
 
@@ -930,7 +1046,7 @@
     justify-content: space-between;
     align-items: flex-start;
     padding: 12px 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.18);
     font-size: 15px;
   }
 
@@ -939,25 +1055,25 @@
   }
 
   .mission-label {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.78);
   }
 
   .mission-value {
-    font-weight: 600;
+    font-weight: 700;
     color: var(--color-white);
   }
 
   .mission-value.approved {
-    color: var(--color-success-green);
+    color: var(--color-white);
   }
 
   .mission-value.rejected {
-    color: var(--color-primary-red);
+    color: var(--color-black);
   }
 
   .mission-price {
-    background: var(--color-primary-red);
-    color: var(--color-white);
+    background: var(--color-white);
+    color: var(--color-red);
     padding: 16px;
     border-radius: var(--radius-md);
     margin-top: 16px;
@@ -965,17 +1081,18 @@
   }
 
   .mission-price-label {
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.14em;
     margin-bottom: 8px;
-    opacity: 0.9;
+    opacity: 0.75;
   }
 
   .mission-price-amount {
     font-size: 36px;
     font-weight: 700;
+    letter-spacing: -0.03em;
   }
 
   @media (max-width: 768px) {
@@ -985,7 +1102,7 @@
     }
 
     .hero-content h1 {
-      font-size: 42px;
+      font-size: 44px;
     }
 
     .hero-buttons {
@@ -1014,16 +1131,15 @@
   .feature-card {
     text-align: center;
     padding: var(--sp-lg);
-    background: var(--color-white);
+    background: var(--panel);
     border-radius: var(--radius-lg);
-    border: 1px solid var(--color-gray-light);
+    border: 1px solid var(--hairline);
     transition: all 300ms ease;
   }
 
   .feature-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
-    border-color: rgba(239, 62, 77, 0.2);
+    border-color: var(--color-white);
   }
 
   .feature-icon {
@@ -1035,32 +1151,27 @@
     justify-content: center;
     font-size: 32px;
     border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.14);
+    color: var(--color-white);
   }
 
-  .feature-icon.red {
-    background: rgba(239, 62, 77, 0.1);
-    color: var(--color-primary-red);
-  }
-
-  .feature-icon.green {
-    background: rgba(42, 191, 132, 0.1);
-    color: var(--color-success-green);
-  }
-
+  .feature-icon.red,
+  .feature-icon.green,
   .feature-icon.orange {
-    background: rgba(243, 156, 18, 0.1);
-    color: var(--color-warning-orange);
+    background: rgba(255, 255, 255, 0.14);
+    color: var(--color-white);
   }
 
   .feature-card h3 {
     font-size: 24px;
     margin-bottom: 12px;
+    color: var(--color-white);
   }
 
   .feature-card p {
     font-size: 15px;
     line-height: 1.6;
-    color: var(--color-gray-medium);
+    color: rgba(255, 255, 255, 0.78);
   }
 
   @media (max-width: 768px) {
@@ -1081,43 +1192,46 @@
   }
 
   .sector-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-gray-light);
+    background: var(--panel);
+    border: 1px solid var(--hairline);
     border-radius: var(--radius-lg);
     padding: var(--sp-lg);
-    border-top: 3px solid var(--color-primary-red);
+    border-top: 3px solid var(--color-white);
     transition: all 300ms ease;
   }
 
   .sector-card:hover {
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
     transform: translateY(-4px);
+    border-color: var(--hairline-strong);
+    border-top-color: var(--color-white);
   }
 
   .sector-title {
     font-size: 20px;
     font-weight: 700;
-    color: var(--color-primary-blue);
+    letter-spacing: -0.02em;
+    color: var(--color-white);
     margin-bottom: 12px;
   }
 
   .sector-subtitle {
     font-size: 14px;
-    color: var(--color-gray-medium);
+    color: rgba(255, 255, 255, 0.7);
     margin-bottom: 16px;
   }
 
   .sector-price {
     font-size: 28px;
     font-weight: 700;
-    color: var(--color-success-green);
+    letter-spacing: -0.03em;
+    color: var(--color-white);
   }
 
   .sector-price-label {
-    font-size: 12px;
-    color: var(--color-gray-medium);
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.64);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.14em;
   }
 
   @media (max-width: 1024px) {
@@ -1149,18 +1263,18 @@
     display: flex;
     gap: var(--sp-md);
     padding: var(--sp-lg);
-    background: var(--color-white);
-    border: 1px solid var(--color-gray-light);
+    background: transparent;
+    border: 1px solid var(--hairline);
     border-radius: var(--radius-lg);
     transition: all 300ms ease;
   }
 
   .module-card:nth-child(even) {
-    background: var(--color-bg-light);
+    background: var(--panel);
   }
 
   .module-card:hover {
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+    border-color: var(--color-white);
     transform: translateY(-2px);
   }
 
@@ -1171,8 +1285,8 @@
     min-width: 56px;
     width: 56px;
     height: 56px;
-    background: var(--color-primary-red);
-    color: var(--color-white);
+    background: var(--color-white);
+    color: var(--color-red);
     border-radius: 50%;
     font-size: 24px;
     font-weight: 700;
@@ -1186,21 +1300,24 @@
   .module-title {
     font-size: 18px;
     font-weight: 700;
+    letter-spacing: -0.015em;
     margin-bottom: 8px;
-    color: var(--color-text-primary);
+    color: var(--color-white);
   }
 
   .module-desc {
     font-size: 15px;
-    color: var(--color-gray-medium);
+    color: rgba(255, 255, 255, 0.76);
     line-height: 1.6;
     margin-bottom: 0;
   }
 
   .module-duration {
-    font-size: 13px;
-    color: var(--color-gray-medium);
-    font-weight: 600;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.64);
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
     text-align: right;
     padding-top: var(--sp-md);
   }
@@ -1226,7 +1343,7 @@
      ================================================================= */
   .steps-section {
     padding: var(--sp-5xl) var(--sp-md);
-    background: var(--color-bg-light);
+    background: var(--surface-brand-alt);
   }
 
   .steps-grid {
@@ -1245,7 +1362,7 @@
     left: 60px;
     right: 60px;
     height: 1px;
-    background: var(--color-gray-light);
+    background: var(--hairline);
     z-index: 0;
   }
 
@@ -1266,29 +1383,29 @@
     border-radius: 50%;
     font-size: 24px;
     font-weight: 700;
-    color: var(--color-white);
+    color: var(--color-red);
     position: relative;
     z-index: 2;
-    background: var(--color-primary-blue);
+    background: var(--color-white);
   }
 
-  .step-card:nth-child(2) .step-number {
-    background: var(--color-primary-red);
-  }
-
+  .step-card:nth-child(2) .step-number,
   .step-card:nth-child(4) .step-number {
-    background: var(--color-success-green);
+    background: var(--color-white);
+    color: var(--color-red);
   }
 
   .step-title {
     font-size: 20px;
     font-weight: 700;
+    letter-spacing: -0.02em;
     margin-bottom: 12px;
+    color: var(--color-white);
   }
 
   .step-desc {
     font-size: 15px;
-    color: var(--color-gray-medium);
+    color: rgba(255, 255, 255, 0.76);
     line-height: 1.6;
   }
 
@@ -1318,11 +1435,7 @@
      ================================================================= */
   .pricing-section {
     padding: var(--sp-5xl) var(--sp-md);
-    background: linear-gradient(
-      135deg,
-      var(--color-primary-blue) 0%,
-      var(--color-blue-deep) 100%
-    );
+    background: var(--color-black);
     color: var(--color-white);
     text-align: center;
   }
@@ -1339,7 +1452,7 @@
 
   .pricing-subtext {
     font-size: 16px;
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.72);
     margin-bottom: var(--sp-2xl);
     line-height: 1.7;
   }
@@ -1356,13 +1469,14 @@
   .price-original {
     font-size: 28px;
     text-decoration: line-through;
-    color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.45);
     font-weight: 600;
   }
 
   .price-current {
-    font-size: 56px;
+    font-size: 60px;
     font-weight: 700;
+    letter-spacing: -0.04em;
     color: var(--color-white);
   }
 
@@ -1373,28 +1487,28 @@
   }
 
   .discount-badge {
-    background: var(--color-primary-red);
+    background: var(--color-red);
     color: var(--color-white);
     padding: 8px 16px;
-    border-radius: var(--radius-sm);
-    font-size: 13px;
+    border-radius: var(--radius-pill);
+    font-size: 12px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.14em;
     margin-bottom: var(--sp-lg);
     display: inline-block;
   }
 
   .pricing-section .button {
-    padding: 20px 48px;
-    font-size: 18px;
+    padding: 19px 44px;
+    font-size: 17px;
     margin-bottom: var(--sp-lg);
   }
 
   .pricing-features {
     list-style: none;
     padding: var(--sp-2xl) 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.2);
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
     text-align: left;
     margin-top: var(--sp-lg);
   }
@@ -1405,20 +1519,20 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(255, 255, 255, 0.86);
   }
 
   .pricing-features li::before {
-    content: "✓";
-    color: var(--color-success-green);
+    content: "→";
+    color: var(--color-red-bright);
     font-weight: 700;
-    font-size: 20px;
+    font-size: 18px;
     flex-shrink: 0;
   }
 
   .pricing-subtext-footer {
     font-size: 14px;
-    color: rgba(255, 255, 255, 0.7);
+    color: rgba(255, 255, 255, 0.6);
     margin-top: var(--sp-md);
   }
 
@@ -1429,7 +1543,7 @@
     }
 
     .price-current {
-      font-size: 44px;
+      font-size: 46px;
     }
   }
 
@@ -1447,10 +1561,12 @@
   }
 
   .footer-column h4 {
-    font-size: 16px;
+    font-size: 11px;
     font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
     margin-bottom: var(--sp-md);
-    color: var(--color-white);
+    color: rgba(255, 255, 255, 0.5);
   }
 
   .footer-column ul {
@@ -1459,19 +1575,19 @@
   }
 
   .footer-column li {
-    margin-bottom: var(--sp-sm);
+    margin-bottom: var(--sp-xs);
   }
 
   .footer-column a {
     font-size: 15px;
-    color: rgba(255, 255, 255, 0.75);
+    color: rgba(255, 255, 255, 0.8);
     text-decoration: none;
     transition: color 200ms ease;
-    line-height: 1.8;
+    line-height: 1.9;
   }
 
   .footer-column a:hover {
-    color: var(--color-primary-red);
+    color: var(--color-white);
   }
 
   /* NEWSLETTER FORM */
@@ -1481,47 +1597,54 @@
     margin-top: var(--sp-sm);
   }
 
+  /* `flex: 1 1 auto` (e não `1`) porque o rodapé empilha o formulário em
+     coluna: com base 0% o campo colapsaria em altura. */
   .newsletter-form input {
-    flex: 1;
-    height: 48px;
-    padding: 0 16px;
-    border: none;
+    flex: 1 1 auto;
+    width: 100%;
+    height: 46px;
+    min-height: 46px;
+    padding: 0 14px;
+    border: 1px solid rgba(255, 255, 255, 0.24);
     border-radius: var(--radius-md);
     font-size: 14px;
-    background: rgba(255, 255, 255, 0.95);
-    color: var(--color-text-primary);
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--color-white);
     outline: none;
   }
 
   .newsletter-form input::placeholder {
-    color: var(--color-gray-medium);
+    color: rgba(255, 255, 255, 0.45) !important;
   }
 
   .newsletter-form input:focus {
-    background: var(--color-white);
-    box-shadow: 0 0 0 2px var(--color-primary-red);
+    border-color: var(--color-white);
+    background: rgba(255, 255, 255, 0.1);
   }
 
   .newsletter-form button {
-    height: 48px;
-    padding: 0 32px;
-    background: var(--color-primary-red);
+    height: 46px;
+    padding: 0 28px;
+    background: var(--color-red);
     color: var(--color-white);
     border: none;
     border-radius: var(--radius-md);
-    font-weight: 600;
+    font-weight: 700;
     cursor: pointer;
+    box-shadow: none;
     transition: all 200ms ease;
   }
 
   .newsletter-form button:hover {
-    background: var(--color-red-hover);
+    background: var(--color-red-bright);
+    color: var(--color-white);
     transform: translateY(-2px);
+    box-shadow: none;
   }
 
   /* FOOTER BOTTOM */
   .footer-bottom {
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-top: 1px solid rgba(255, 255, 255, 0.14);
     padding-top: var(--sp-lg);
     display: flex;
     justify-content: space-between;
@@ -1534,13 +1657,14 @@
   }
 
   .footer-bottom-text {
-    font-size: 13px;
-    color: rgba(255, 255, 255, 0.6);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    color: rgba(255, 255, 255, 0.5);
   }
 
   .footer-socials {
     display: flex;
-    gap: var(--sp-md);
+    gap: var(--sp-sm);
   }
 
   .footer-socials a {
@@ -1550,7 +1674,8 @@
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: transparent;
     color: var(--color-white);
     text-decoration: none;
     font-size: 16px;
@@ -1558,7 +1683,8 @@
   }
 
   .footer-socials a:hover {
-    background: var(--color-primary-red);
+    background: var(--color-red);
+    border-color: var(--color-red);
     transform: translateY(-2px);
   }
 
@@ -1589,124 +1715,128 @@
      TIPOGRAFIA UTILITÁRIA (nomes legados usados pelas páginas)
      ================================================================= */
   .h1 {
-    font-size: 56px;
-    line-height: 1.2;
+    font-size: 60px;
+    line-height: 1.04;
     font-weight: 700;
-    color: var(--color-text-primary);
-    letter-spacing: -0.5px;
+    color: var(--ink);
+    letter-spacing: -0.035em;
   }
 
   .h2 {
-    font-size: 40px;
-    line-height: 1.3;
+    font-size: 42px;
+    line-height: 1.08;
     font-weight: 700;
-    color: var(--color-text-primary);
-    letter-spacing: -0.3px;
+    color: var(--ink);
+    letter-spacing: -0.03em;
   }
 
   .h3 {
     font-size: 28px;
-    font-weight: 600;
-    line-height: 1.3;
-    color: var(--color-text-primary);
+    font-weight: 700;
+    line-height: 1.16;
+    color: var(--ink);
+    letter-spacing: -0.02em;
   }
 
   .h4 {
     font-size: 22px;
-    font-weight: 600;
-    color: var(--color-text-primary);
+    font-weight: 700;
+    color: var(--ink);
+    letter-spacing: -0.015em;
   }
 
   .h5 {
     font-size: 18px;
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--ink);
   }
 
   @media (max-width: 768px) {
-    .h1 { font-size: 38px; }
-    .h2 { font-size: 30px; }
+    .h1 { font-size: 40px; }
+    .h2 { font-size: 31px; }
     .h3 { font-size: 23px; }
   }
 
   .text-body-lg {
     font-size: 18px;
     line-height: 1.7;
-    color: var(--color-text-primary);
+    color: var(--body);
   }
 
   .text-body {
     font-size: 16px;
     line-height: 1.7;
-    color: var(--color-text-primary);
+    color: var(--body);
   }
 
   .text-body-sm {
     font-size: 14px;
     line-height: 1.6;
-    color: var(--color-text-secondary);
+    color: var(--muted);
   }
 
   .text-body-xs {
     font-size: 13px;
     line-height: 1.5;
-    color: var(--color-gray-medium);
+    color: var(--muted);
   }
 
   .text-muted {
     font-size: 14px;
-    color: var(--color-gray-medium);
+    color: var(--muted);
   }
 
   .page-title {
-    font-size: 56px;
-    line-height: 1.2;
+    font-size: 60px;
+    line-height: 1.04;
     font-weight: 700;
-    color: var(--color-text-primary);
-    letter-spacing: -0.5px;
+    color: var(--ink);
+    letter-spacing: -0.035em;
   }
 
   .section-title {
-    font-size: 40px;
-    line-height: 1.3;
+    font-size: 42px;
+    line-height: 1.08;
     font-weight: 700;
-    color: var(--color-text-primary);
-    letter-spacing: -0.3px;
+    color: var(--ink);
+    letter-spacing: -0.03em;
   }
 
   .section-title-inverse {
-    font-size: 40px;
-    line-height: 1.3;
+    font-size: 42px;
+    line-height: 1.08;
     font-weight: 700;
     color: var(--color-white);
-    letter-spacing: -0.3px;
+    letter-spacing: -0.03em;
   }
 
   @media (max-width: 768px) {
-    .page-title { font-size: 38px; }
+    .page-title { font-size: 40px; }
     .section-title,
-    .section-title-inverse { font-size: 30px; }
+    .section-title-inverse { font-size: 31px; }
   }
 
   .card-title {
     font-size: 22px;
-    font-weight: 600;
-    color: var(--color-text-primary);
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    color: var(--ink);
   }
 
   .subsection-title {
     font-size: 24px;
-    font-weight: 600;
-    color: var(--color-text-primary);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--ink);
   }
 
   .section-label,
   .section-label-uppercase {
-    font-size: 13px;
-    font-weight: 600;
+    font-size: 11px;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--color-primary-red);
+    letter-spacing: 0.2em;
+    color: var(--brand);
   }
 
   /* =================================================================
@@ -1745,7 +1875,7 @@
     height: 24px;
     width: 24px;
     background-color: var(--color-white);
-    border: 1.5px solid var(--color-gray-light);
+    border: 1.5px solid var(--line);
     border-radius: var(--radius-sm);
     transition: all 200ms ease;
   }
@@ -1764,9 +1894,9 @@
   }
 
   .custom-checkbox:checked ~ .checkmark {
-    background: var(--color-primary-red);
-    border-color: var(--color-primary-red);
-    box-shadow: 0 0 0 3px rgba(239, 62, 77, 0.2);
+    background: var(--color-red);
+    border-color: var(--color-red);
+    box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.2);
   }
 
   .custom-checkbox:checked ~ .checkmark::after {
@@ -1775,7 +1905,7 @@
   }
 
   .custom-checkbox:focus-visible ~ .checkmark {
-    box-shadow: 0 0 0 3px rgba(239, 62, 77, 0.35);
+    box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.35);
   }
 
   @keyframes check-anim {
@@ -1796,9 +1926,10 @@
 @layer base {
   /* ===================================================================
      PARTE 12 — FOOTER (elemento)
+     Preto: fecha a página e separa-a claramente do corpo vermelho.
      =================================================================== */
   footer {
-    background: var(--color-primary-blue);
+    background: var(--color-black);
     color: var(--color-white);
     padding: var(--sp-3xl) var(--sp-md) var(--sp-lg);
   }
@@ -1807,11 +1938,11 @@
      SECÇÕES
      =================================================================== */
   section.light-bg {
-    background-color: var(--color-bg-light);
+    background-color: var(--surface-brand-alt);
   }
 
   section.dark-bg {
-    background-color: var(--color-primary-blue);
+    background-color: var(--color-black);
     color: var(--color-white);
   }
 
@@ -1822,7 +1953,7 @@
   }
 
   section.dark-bg .text-secondary {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.78);
   }
 
 }
@@ -1830,6 +1961,8 @@
 @layer components {
   /* ===================================================================
      FORMULÁRIOS
+     `.login-form` é um painel branco (ver `.on-light` no topo do ficheiro):
+     tudo o que está dentro herda a escala escura de texto e linhas.
      =================================================================== */
   .login-form {
     width: 100%;
@@ -1838,21 +1971,22 @@
     background: var(--color-white);
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-lg);
-    border: 1px solid var(--color-gray-light);
+    border: none;
     animation: fadeIn 0.6s ease-out;
     position: relative;
+    color: var(--on-invert);
   }
 
   /* Régua vermelha no topo do cartão de formulário. */
   .login-form::before {
     content: "";
     position: absolute;
-    top: -1px;
+    top: 0;
     left: var(--radius-xl);
     width: 62px;
-    height: 3px;
-    border-radius: var(--radius-pill);
-    background: var(--color-primary-red);
+    height: 4px;
+    border-radius: 0 0 var(--radius-pill) var(--radius-pill);
+    background: var(--color-red);
   }
 
   @media (max-width: 480px) {
@@ -1869,21 +2003,27 @@
   }
 
   .login-form * {
-    color: var(--color-text-primary);
+    color: var(--on-invert);
+  }
+
+  .login-form .text-muted,
+  .login-form .text-body-sm,
+  .login-form .text-body-xs {
+    color: var(--on-invert-3);
   }
 
   .form-heading {
     margin-bottom: 24px;
-    color: var(--color-text-primary) !important;
-    font-size: 28px;
+    color: var(--on-invert) !important;
+    font-size: 30px;
     font-weight: 700;
     text-align: center;
-    letter-spacing: -0.3px;
+    letter-spacing: -0.03em;
   }
 
   @media (max-width: 480px) {
     .form-heading {
-      font-size: 23px;
+      font-size: 24px;
       margin-bottom: 20px;
     }
   }
@@ -1903,11 +2043,11 @@
     position: absolute;
     top: -18px;
     left: 2px;
-    color: var(--color-gray-medium) !important;
-    font-size: 13px;
-    font-weight: 600;
+    color: var(--on-invert-3) !important;
+    font-size: 11px;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.14em;
     opacity: 1;
     transition: all 200ms ease;
   }
@@ -1917,11 +2057,11 @@
   .input-group select {
     width: 100%;
     padding: 13px 15px;
-    color: var(--color-text-primary) !important;
+    color: var(--on-invert) !important;
     font-family: var(--font-body);
     font-size: 15px;
-    background-color: var(--color-white) !important;
-    border: 1px solid var(--color-gray-light) !important;
+    background-color: #f7f7f9 !important;
+    border: 1px solid #e7e7ea !important;
     border-radius: var(--radius-md);
     outline: none;
     transition: all 200ms ease;
@@ -1952,29 +2092,32 @@
   .input-group input:hover,
   .input-group textarea:hover,
   .input-group select:hover {
-    border-color: var(--line-strong) !important;
+    border-color: #cfcfd5 !important;
   }
 
   .input-group input:focus,
   .input-group textarea:focus,
   .input-group select:focus {
-    border-color: var(--color-primary-red) !important;
-    box-shadow: 0 0 0 3px rgba(239, 62, 77, 0.15);
+    background-color: var(--color-white) !important;
+    border-color: var(--color-red) !important;
+    box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.14);
   }
 
   /* Ação destrutiva (ex.: terminar sessão). */
   .submit.is-danger {
-    background-color: var(--color-red-active);
+    background-color: var(--color-black) !important;
+    color: var(--color-white) !important;
   }
 
   .submit.is-danger:hover {
-    background-color: var(--color-red-ink);
+    background-color: var(--color-black-2) !important;
+    color: var(--color-white) !important;
   }
 
   .form-link {
-    color: var(--color-primary-red) !important;
+    color: var(--color-red) !important;
     font-size: 14px;
-    font-weight: 600;
+    font-weight: 700;
     text-decoration: none;
     transition: all 200ms ease;
     position: relative;
@@ -1987,12 +2130,12 @@
     left: 0;
     width: 0;
     height: 2px;
-    background: var(--color-primary-red);
+    background: var(--color-red);
     transition: width 200ms ease;
   }
 
   .form-link:hover {
-    color: var(--color-red-hover) !important;
+    color: var(--color-red-2) !important;
   }
 
   .form-link:hover::after {
@@ -2002,10 +2145,11 @@
   .form-feedback {
     padding: 12px 14px;
     font-size: 14px;
-    border: 1px solid rgba(239, 62, 77, 0.3);
-    border-radius: var(--radius-md);
-    background: rgba(239, 62, 77, 0.1);
-    color: var(--color-red-ink) !important;
+    border: none;
+    border-left: 3px solid var(--color-red);
+    border-radius: var(--radius-sm);
+    background: rgba(227, 6, 19, 0.08);
+    color: var(--color-danger) !important;
     font-weight: 600;
     line-height: 1.5;
   }
@@ -2023,6 +2167,7 @@
 
   /* ===================================================================
      DASHBOARD
+     Cartões brancos sobre o vermelho — o contraste faz de estrutura.
      =================================================================== */
   .dashboard-layout-shell {
     display: grid;
@@ -2033,24 +2178,27 @@
   .dashboard-top-banner {
     border-radius: var(--radius-xl);
     background: var(--color-white);
-    box-shadow: var(--shadow-sm);
-    border: 1px solid var(--color-gray-light);
+    box-shadow: var(--shadow-md);
+    border: none;
     padding: var(--sp-lg);
     transition: all 300ms ease;
+    color: var(--on-invert);
   }
 
   .dashboard-sidebar {
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-xl);
     background: var(--color-white);
-    box-shadow: var(--shadow-sm);
-    border: 1px solid var(--color-gray-light);
+    box-shadow: var(--shadow-md);
+    border: none;
     padding: var(--sp-md);
+    color: var(--on-invert);
   }
 
   .dashboard-sidebar-title {
-    color: var(--color-text-primary) !important;
+    color: var(--on-invert) !important;
     font-size: 18px;
     font-weight: 700;
+    letter-spacing: -0.015em;
   }
 
   .dashboard-menu {
@@ -2080,7 +2228,7 @@
 
   .dashboard-menu-item span {
     display: block;
-    color: var(--color-text-primary) !important;
+    color: var(--on-invert) !important;
     font-size: 15px;
     font-weight: 600;
   }
@@ -2088,35 +2236,35 @@
   .dashboard-menu-item small {
     display: block;
     margin-top: 0.3rem;
-    color: var(--color-gray-medium) !important;
+    color: var(--on-invert-3) !important;
     font-size: 13px;
     font-weight: 500;
   }
 
   .dashboard-menu-item.is-active {
-    background: rgba(239, 62, 77, 0.1);
-    border-color: var(--color-primary-red);
+    background: rgba(227, 6, 19, 0.08);
+    border-color: var(--color-red);
     box-shadow: none;
   }
 
   .dashboard-menu-item.is-active span {
-    color: var(--color-red-ink) !important;
+    color: var(--color-red) !important;
   }
 
   .dashboard-menu-item:hover {
-    border-color: var(--color-gray-light);
-    background: var(--color-bg-light);
+    border-color: #e7e7ea;
+    background: #f7f7f9;
     transform: none;
     box-shadow: none;
   }
 
   .dashboard-right-highlight {
-    border-radius: var(--radius-lg);
-    background: var(--color-bg-light);
+    border-radius: var(--radius-xl);
+    background: var(--color-black);
     box-shadow: none;
     padding: var(--sp-md);
     display: none;
-    border: 1px solid var(--color-gray-light);
+    border: none;
     position: relative;
     overflow: hidden;
   }
@@ -2127,26 +2275,26 @@
     top: 0;
     left: var(--radius-lg);
     width: 62px;
-    height: 3px;
-    border-radius: var(--radius-pill);
-    background: var(--color-primary-red);
+    height: 4px;
+    border-radius: 0 0 var(--radius-pill) var(--radius-pill);
+    background: var(--color-red);
     pointer-events: none;
   }
 
   .dashboard-right-highlight .card-title {
-    color: var(--color-text-primary) !important;
+    color: var(--color-white) !important;
     position: relative;
   }
 
   .dashboard-right-highlight p {
-    color: var(--color-text-secondary) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
     position: relative;
   }
 
   .dashboard-right-highlight-icon {
     font-size: 1.5rem;
     text-align: center;
-    color: var(--color-primary-red) !important;
+    color: var(--color-red-bright) !important;
     position: relative;
   }
 
@@ -2212,26 +2360,26 @@
 @layer base {
   /* SCROLLBAR */
   ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+    width: 10px;
+    height: 10px;
   }
 
   ::-webkit-scrollbar-track {
-    background: var(--color-bg-light);
+    background: var(--color-red-2);
   }
 
   ::-webkit-scrollbar-thumb {
-    background: var(--color-gray-medium);
-    border-radius: var(--radius-xs);
+    background: rgba(255, 255, 255, 0.45);
+    border-radius: var(--radius-pill);
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: var(--color-dark-blue);
+    background: var(--color-white);
   }
 
   ::selection {
-    background: var(--color-primary-red);
-    color: var(--color-white);
+    background: var(--color-white);
+    color: var(--color-red);
   }
 
   /* FOCUS STATES */
@@ -2244,7 +2392,7 @@
   input:focus-visible,
   select:focus-visible,
   textarea:focus-visible {
-    outline: 2px solid var(--color-primary-red);
+    outline: 2px solid var(--focus-ring);
     outline-offset: 2px;
   }
 
@@ -2277,13 +2425,13 @@
      =================================================================== */
   input::placeholder,
   textarea::placeholder {
-    color: var(--color-gray-medium) !important;
+    color: var(--on-invert-3) !important;
     opacity: 1;
     font-weight: 400;
   }
 
   select {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ef3e4d' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23e30613' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;
     background-size: 20px;
@@ -2306,9 +2454,9 @@
     .btn-primary,
     .btn-secondary
   )) {
-    color: var(--color-primary-blue);
+    color: var(--ink);
     text-decoration: none;
-    border-bottom: 1px solid rgba(239, 62, 77, 0.45);
+    border-bottom: 1px solid var(--line-strong);
     transition: all 200ms ease;
   }
 
@@ -2321,8 +2469,8 @@
     .btn-primary,
     .btn-secondary
   )):hover {
-    border-bottom-color: var(--color-primary-red);
-    color: var(--color-primary-red);
+    border-bottom-color: var(--ink);
+    opacity: 0.75;
   }
 
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import AppShell from "./components/AppShell";
+import { creatoDisplay } from "./fonts";
 import "./globals.css";
 
 const siteUrl = process.env.APP_BASE_URL?.trim() || "https://clientemisterio.onrender.com";
@@ -55,7 +56,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 5,
   userScalable: true,
-  themeColor: "#0f4c5c",
+  themeColor: "#e30613",
 };
 
 export default function RootLayout({
@@ -64,7 +65,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="pt-PT">
+    <html lang="pt-PT" className={creatoDisplay.variable}>
       <body className="bg-[color:var(--background)] text-[color:var(--foreground)] antialiased">
         <AppShell>{children}</AppShell>
       </body>

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,7 +1,7 @@
 export default function Loading() {
   return (
     <div className="flex min-h-[40vh] items-center justify-center">
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-[color:var(--brand-soft)] border-t-[color:var(--brand)]" />
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/25 border-t-white" />
     </div>
   );
 }

--- a/app/o-curso/page.module.css
+++ b/app/o-curso/page.module.css
@@ -1,5 +1,8 @@
 /*
- * O-curso — página de venda do curso (design "Turkish Red & Railroad Black").
+ * O-curso — página de venda do curso, sistema vermelho/branco.
+ * Vermelho de base, painéis brancos onde é preciso foco (cartão de preço,
+ * primeiro benefício) e um bloco preto para o currículo, que ancora a
+ * página a meio antes do CTA final.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -9,10 +12,8 @@
    LAYOUT PRIMITIVES
    ============================================================ */
 .page {
-  background:
-    radial-gradient(70% 45% at 85% 0%, rgba(239, 62, 77, 0.12) 0%, transparent 62%),
-    var(--background);
-  color: var(--body);
+  background: var(--surface-brand);
+  color: rgba(255, 255, 255, 0.82);
   font-size: 15px;
   line-height: 1.7;
   font-family: var(--font-body);
@@ -35,49 +36,53 @@
 .eyebrow {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.22em;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand);
+  color: rgba(255, 255, 255, 0.78);
   margin-bottom: 20px;
 }
 .eyebrow::before {
   content: "";
-  width: 30px;
+  width: 34px;
   height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  background: currentColor;
   flex-shrink: 0;
 }
 
 .displayLg {
-  font-family: var(--font-body);
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-text-primary);
-  font-size: clamp(30px, 4vw, 54px);
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  color: var(--color-white);
+  font-size: clamp(32px, 4.8vw, 64px);
   margin: 0;
 }
 .displayMd {
-  font-family: var(--font-body);
-  font-weight: 800;
-  letter-spacing: -0.3px;
-  line-height: 1.2;
-  color: var(--color-text-primary);
-  font-size: clamp(22px, 3vw, 38px);
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+  color: var(--color-white);
+  font-size: clamp(24px, 3.2vw, 42px);
   margin: 0;
 }
+/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
 .italic {
   font-style: normal;
-  color: var(--brand);
+  color: var(--color-red);
+  background: var(--color-white);
+  padding: 0 0.14em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 .lead {
-  font-size: clamp(15px, 1.1vw, 17px);
-  line-height: 1.75;
-  color: var(--body);
+  font-size: clamp(15px, 1.1vw, 18px);
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.82);
   max-width: 56ch;
   margin: 0;
 }
@@ -92,7 +97,7 @@
   gap: 8px;
   padding: 16px 32px;
   border-radius: var(--radius-md);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 16px;
   border: none;
   transition: all 200ms ease;
@@ -104,27 +109,27 @@
 .page .btn:hover { transform: translateY(-2px); }
 .page .btn:active { transform: translateY(0); }
 
-/* Sólido vermelho — CTA principal. */
+/* Sólido — CTA principal. Vive dentro do cartão branco, logo vermelho. */
 .page .btnDark {
-  background: var(--color-primary-red);
+  background: var(--color-red);
   color: var(--color-white);
-  box-shadow: 0 4px 12px rgba(239, 62, 77, 0.25);
+  box-shadow: 0 4px 14px rgba(227, 6, 19, 0.28);
 }
 .page .btnDark:hover {
-  background: var(--color-red-hover);
-  box-shadow: 0 6px 16px rgba(239, 62, 77, 0.35);
+  background: var(--color-red-2);
+  box-shadow: 0 8px 22px rgba(227, 6, 19, 0.34);
 }
 
-/* Vazado azul — ação secundária. */
+/* Vazado branco — ação secundária sobre superfícies vermelhas/pretas. */
 .page .btnAccent {
   background: transparent;
-  border: 2px solid var(--color-primary-blue);
-  color: var(--color-primary-blue);
-  padding: 14px 30px;
+  border: 1.5px solid rgba(255, 255, 255, 0.5);
+  color: var(--color-white);
+  padding: 14.5px 30.5px;
 }
 .page .btnAccent:hover {
-  background: rgba(15, 76, 92, 0.05);
-  box-shadow: 0 4px 12px rgba(15, 76, 92, 0.15);
+  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--color-white);
 }
 .arrow { transition: transform 200ms ease; }
 .page .btn:hover .arrow { transform: translateX(4px); }
@@ -159,80 +164,85 @@
   display: flex;
   gap: 40px;
   padding-top: 30px;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--hairline);
   flex-wrap: wrap;
 }
 .statNum {
-  font-size: clamp(22px, 2.4vw, 32px);
-  font-weight: 800;
-  letter-spacing: -0.5px;
+  font-size: clamp(24px, 2.6vw, 36px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
   line-height: 1;
-  color: var(--color-primary-blue);
+  color: var(--color-white);
 }
 .statNum em {
   font-style: normal;
-  color: var(--brand);
+  color: var(--color-white);
 }
 .statLabel {
-  font-size: 11px;
-  color: var(--muted);
-  margin-top: 8px;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 10px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.2em;
 }
 
-/* Cartão de preço (no hero) */
+/* Cartão de preço (no hero) — painel branco invertido. */
 .card {
+  --line: var(--hairline-invert);
+  --muted: var(--on-invert-3);
+  --body: var(--on-invert-2);
+
   position: relative;
   background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
-  border-radius: var(--radius-lg);
+  color: var(--on-invert);
+  border: none;
+  border-radius: var(--radius-xl);
   padding: 34px;
-  box-shadow: 0 8px 24px rgba(15, 76, 92, 0.1);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
 }
 .card::before {
   content: "";
   position: absolute;
-  top: -1px;
+  top: 0;
   left: var(--radius-xl);
   width: 72px;
-  height: 3px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  height: 4px;
+  background: var(--color-red);
 }
 .cardBadge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.18em;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--brand);
-  border: 1px solid rgba(239, 62, 77, 0.4);
+  color: var(--color-red);
+  border: 1px solid rgba(227, 6, 19, 0.35);
   border-radius: var(--radius-pill);
   padding: 6px 12px;
   margin-bottom: 22px;
 }
-.cardTitle { font-size: 14px; font-weight: 600; color: var(--color-text-primary); margin: 0 0 10px; }
+.cardTitle { font-size: 14px; font-weight: 600; color: var(--on-invert); margin: 0 0 10px; }
 .cardPriceRow { display: flex; align-items: baseline; gap: 12px; margin-bottom: 4px; }
-.cardOrig { font-size: 17px; color: var(--muted); text-decoration: line-through; }
+.cardOrig { font-size: 17px; color: var(--on-invert-3); text-decoration: line-through; }
 .cardPrice {
-  font-size: 38px;
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  color: var(--color-success-green);
+  font-size: 46px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--on-invert);
   line-height: 1;
 }
-.cardPayment { font-size: 12px; color: var(--muted); margin: 0 0 24px; text-transform: uppercase; letter-spacing: 0.1em; font-weight: 700; }
+.cardPayment { font-size: 10px; color: var(--on-invert-3); margin: 0 0 24px; text-transform: uppercase; letter-spacing: 0.18em; font-weight: 700; }
 .featureList {
   display: flex;
   flex-direction: column;
   gap: 14px;
   padding: 24px 0;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
+  border-top: 1px solid var(--hairline-invert);
+  border-bottom: 1px solid var(--hairline-invert);
   margin-bottom: 26px;
 }
 .featureItem {
@@ -240,25 +250,26 @@
   align-items: center;
   gap: 12px;
   font-size: 13.5px;
-  color: var(--body);
+  color: var(--on-invert-2);
 }
 .check {
   flex-shrink: 0;
   width: 20px; height: 20px;
   border-radius: var(--radius-sm);
-  background: var(--brand-soft);
-  color: var(--brand);
+  background: var(--color-red);
+  color: var(--color-white);
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 .secureNote {
   text-align: center;
-  font-size: 11px;
-  color: var(--muted);
+  font-size: 10px;
+  color: var(--on-invert-3);
   margin-top: 16px;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.16em;
+  font-weight: 700;
 }
 
 /* ============================================================
@@ -274,7 +285,7 @@
 @media (min-width: 880px) {
   .head { grid-template-columns: 1.3fr 1fr; gap: 64px; }
 }
-.headSub { font-size: 14.5px; line-height: 1.8; color: var(--muted); max-width: 44ch; margin: 0; }
+.headSub { font-size: 15px; line-height: 1.8; color: rgba(255, 255, 255, 0.7); max-width: 44ch; margin: 0; }
 
 .benefits {
   display: grid;
@@ -286,8 +297,8 @@
 
 .benefit {
   position: relative;
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
+  background: transparent;
+  border: 1px solid var(--hairline);
   border-radius: var(--radius-lg);
   padding: 32px 28px 36px;
   transition: all 300ms ease;
@@ -295,25 +306,30 @@
 }
 .benefit:hover {
   transform: translateY(-8px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
-  border-color: rgba(239, 62, 77, 0.2);
+  background: rgba(255, 255, 255, 0.07);
+  border-color: var(--color-white);
 }
-.benefit:first-child { background: var(--brand); border-color: var(--brand); }
-.benefit:first-child:hover { background: var(--brand); }
+/* O primeiro benefício inverte-se — painel branco a abrir a grelha. */
+.benefit:first-child {
+  background: var(--color-white);
+  border-color: var(--color-white);
+  box-shadow: var(--shadow-md);
+}
+.benefit:first-child:hover { background: var(--color-white); }
 .benefitIcon {
   width: 30px; height: 30px;
-  color: var(--brand);
+  color: var(--color-white);
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 24px;
 }
-.benefit:first-child .benefitIcon { color: var(--moonlight-white); }
+.benefit:first-child .benefitIcon { color: var(--color-red); }
 .benefitTitle {
-  font-size: 18px;
-  font-weight: 800;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--color-white);
   margin: 0 0 14px;
   padding-bottom: 14px;
   position: relative;
@@ -325,44 +341,39 @@
   bottom: 0;
   width: 34px;
   height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--brand);
+  background: var(--color-white);
 }
-.benefit:first-child .benefitTitle { color: var(--color-white); }
-.benefit:first-child .benefitTitle::after { background: var(--color-white); }
-.benefitDesc { font-size: 13.5px; color: var(--muted); line-height: 1.75; margin: 0; }
-.benefit:first-child .benefitDesc { color: rgba(255, 255, 255, .85); }
+.benefit:first-child .benefitTitle { color: var(--on-invert); }
+.benefit:first-child .benefitTitle::after { background: var(--color-red); }
+.benefitDesc { font-size: 13.5px; color: rgba(255, 255, 255, 0.72); line-height: 1.75; margin: 0; }
+.benefit:first-child .benefitDesc { color: var(--on-invert-2); }
 
 /* ============================================================
-   CURRÍCULO
+   CURRÍCULO — bloco preto
    ============================================================ */
 .curr {
   position: relative;
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-blue) 0%,
-    var(--color-blue-deep) 100%
-  );
+  background: var(--color-black);
   border: none;
   color: var(--color-white);
   border-radius: var(--radius-xl);
   padding: 56px 8px;
   overflow: hidden;
 }
+/* Régua vermelha a todo o comprimento no topo do bloco. */
 .curr::before {
   content: "";
   position: absolute;
-  width: 380px; height: 380px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(239, 62, 77, 0.16) 0%, transparent 70%);
-  top: -160px; right: -110px;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: var(--color-red);
   pointer-events: none;
 }
 @media (min-width: 880px) { .curr { padding: 76px 16px; } }
 .currInner { position: relative; max-width: 980px; margin: 0 auto; padding: 0 24px; }
-.currEyebrow { color: rgba(255, 255, 255, 0.85); }
+.currEyebrow { color: var(--color-red-bright); }
 .currDisplay { color: var(--color-white); }
-.currSub { color: rgba(255, 255, 255, 0.75); font-size: 14.5px; line-height: 1.8; max-width: 44ch; margin: 0; }
+.currSub { color: rgba(255, 255, 255, 0.62); font-size: 15px; line-height: 1.8; max-width: 44ch; margin: 0; }
 .currHead {
   display: grid;
   grid-template-columns: 1fr;
@@ -380,48 +391,48 @@
   grid-template-columns: 62px 1fr;
   gap: 20px;
   padding: 26px 14px;
-  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
   align-items: start;
   transition: background .25s;
 }
-.module:last-child { border-bottom: 1px solid rgba(255, 255, 255, 0.15); }
-.module:hover { background: rgba(255, 255, 255, .03); }
+.module:last-child { border-bottom: 1px solid rgba(255, 255, 255, 0.14); }
+.module:hover { background: rgba(255, 255, 255, .04); }
 .moduleNum {
-  font-family: var(--font-body);
-  font-weight: 800;
-  font-size: 22px;
-  letter-spacing: -0.02em;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: -0.04em;
   line-height: 1.2;
-  color: var(--color-red-on-dark);
+  color: var(--color-red-bright);
 }
 .moduleContent { flex: 1; min-width: 0; }
 .moduleTitle {
-  font-size: clamp(15px, 1.5vw, 18px);
-  font-weight: 800;
-  letter-spacing: -0.2px;
+  font-size: clamp(15px, 1.5vw, 19px);
+  font-weight: 700;
+  letter-spacing: -0.025em;
   color: var(--color-white);
   margin: 0 0 6px;
 }
 .moduleSubtitle {
-  font-size: 11px;
-  color: var(--color-red-on-dark);
+  font-size: 10px;
+  color: var(--color-red-bright);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 800;
+  letter-spacing: 0.2em;
+  font-weight: 700;
   margin: 0 0 10px;
 }
 .moduleDesc {
   font-size: 14px;
-  color: rgba(255, 255, 255, 0.75);
+  color: rgba(255, 255, 255, 0.65);
   line-height: 1.7;
   margin: 0 0 12px;
   max-width: 56ch;
 }
 .moduleTime {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.6);
-  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   white-space: nowrap;
 }
@@ -431,7 +442,7 @@
   margin-top: 12px;
 }
 .moduleDetails[open] {
-  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
   padding-top: 16px;
   margin-top: 16px;
 }
@@ -439,11 +450,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
-  color: var(--color-red-on-dark);
-  font-weight: 800;
+  font-size: 10px;
+  color: var(--color-red-bright);
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.2em;
   cursor: pointer;
   list-style: none;
   user-select: none;
@@ -469,16 +480,16 @@
 }
 .expandedItem {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(255, 255, 255, 0.72);
   line-height: 1.7;
 }
 .expandedItem > strong {
   color: var(--color-white);
   display: block;
   margin-bottom: 8px;
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.16em;
 }
 .objectivesList, .resourcesList {
   list-style: none;
@@ -499,74 +510,75 @@
   top: 9px;
   width: 8px;
   height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--color-red-on-dark);
+  background: var(--color-red-bright);
 }
 .caseExample {
-  background: rgba(255, 255, 255, .07);
+  background: rgba(255, 255, 255, .06);
   padding: 16px;
   border-radius: var(--radius-md);
-  border-left: 2px solid var(--color-red-on-dark);
+  border-left: 2px solid var(--color-red-bright);
   margin: 6px 0 0;
   font-size: 13px;
   line-height: 1.7;
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(255, 255, 255, 0.78);
 }
 
 /* ============================================================
-   CTA FINAL
+   CTA FINAL — painel branco, o momento mais claro da página
    ============================================================ */
 .final {
-  background: var(--color-primary-red);
-  color: var(--color-white);
+  background: var(--color-white);
+  color: var(--on-invert);
   border-radius: var(--radius-xl);
   padding: 64px 28px;
   position: relative;
   overflow: hidden;
   text-align: center;
+  box-shadow: var(--shadow-lg);
 }
 @media (min-width: 880px) { .final { padding: 80px 64px; } }
 .final::before {
   content: "";
   position: absolute;
-  border-radius: 50%;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: var(--color-red);
   pointer-events: none;
-  width: 420px; height: 420px; top: -200px; right: -140px;
-  background: radial-gradient(circle, rgba(15, 76, 92, 0.28) 0%, transparent 70%);
 }
-.finalInner { position: relative; max-width: 600px; margin: 0 auto; }
-.finalEyebrow { color: var(--color-white); justify-content: center; }
-.finalEyebrow::before { background: var(--color-white); }
+.finalInner { position: relative; max-width: 640px; margin: 0 auto; }
+.finalEyebrow { color: var(--color-red); justify-content: center; }
 .finalTitle {
-  font-size: clamp(26px, 3.4vw, 44px);
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  line-height: 1.15;
-  color: var(--color-white);
+  font-size: clamp(30px, 3.8vw, 50px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.04;
+  color: var(--on-invert);
   margin: 0 0 20px;
 }
 .finalTitle em {
   font-style: normal;
-  color: var(--color-blue-deep);
+  color: var(--color-red);
 }
 .finalSub {
-  font-size: 15px;
-  line-height: 1.75;
-  color: rgba(255, 255, 255, .84);
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--on-invert-2);
   margin: 0 0 34px;
 }
 .finalCta { display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; }
 .page .btnBlock { width: 100%; max-width: 340px; }
-/* Sobre o painel vermelho, o CTA passa a branco para máximo contraste. */
+/* É o CTA principal da página: dentro do painel branco fica sólido vermelho. */
 .page .final .btnAccent {
-  background: var(--color-white);
-  border-color: var(--color-white);
-  color: var(--color-primary-red);
-  box-shadow: 0 4px 12px rgba(15, 76, 92, 0.2);
+  background: var(--color-red);
+  border-color: var(--color-red);
+  color: var(--color-white);
+  box-shadow: 0 4px 14px rgba(227, 6, 19, 0.28);
 }
 .page .final .btnAccent:hover {
-  background: var(--color-bg-light);
-  box-shadow: 0 6px 16px rgba(15, 76, 92, 0.28);
+  background: var(--color-red-2);
+  border-color: var(--color-red-2);
+  color: var(--color-white);
+  box-shadow: 0 8px 22px rgba(227, 6, 19, 0.34);
 }
 
 /* ============================================================
@@ -574,60 +586,60 @@
    ============================================================ */
 .sectionSteps {
   padding: 96px 0;
-  background: var(--color-bg-light);
-  border-top: 1px solid var(--color-gray-light);
-  border-bottom: 1px solid var(--color-gray-light);
+  background: var(--surface-brand-alt);
+  border-top: 1px solid var(--hairline-soft);
+  border-bottom: 1px solid var(--hairline-soft);
 }
 @media (max-width: 720px) { .sectionSteps { padding: 64px 0; } }
 
 .headKicker {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--color-primary-red);
+  color: rgba(255, 255, 255, 0.6);
   margin: 16px 0 0;
 }
 
 .steps {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 24px;
+  gap: 20px;
 }
 @media (min-width: 760px) { .steps { grid-template-columns: repeat(2, 1fr); } }
 @media (min-width: 1060px) { .steps { grid-template-columns: repeat(4, 1fr); } }
 
 .step {
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-light);
+  background: transparent;
+  border: 1px solid var(--hairline);
   border-radius: var(--radius-lg);
   padding: 32px 28px;
   transition: all 300ms ease;
 }
 .step:hover {
   transform: translateY(-4px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
-  border-color: rgba(239, 62, 77, 0.2);
+  background: rgba(255, 255, 255, 0.07);
+  border-color: var(--color-white);
 }
 .stepNum {
   font-weight: 700;
-  font-size: 13px;
-  letter-spacing: 0.5px;
+  font-size: 11px;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--color-primary-red);
+  color: rgba(255, 255, 255, 0.6);
   margin-bottom: 16px;
 }
 .stepTitle {
-  font-size: 20px;
+  font-size: 21px;
   font-weight: 700;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
+  letter-spacing: -0.03em;
+  color: var(--color-white);
   margin: 0 0 12px;
 }
 .stepDesc {
   font-size: 15px;
-  color: var(--muted);
-  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.65;
   margin: 0;
   text-wrap: pretty;
 }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,7 +1,8 @@
 /*
  * Cliente Mistério — Homepage de ecrã único.
- * Fundo azul profundo (mesma superfície escura do resto do site), vermelho
- * #EF3E4D como cor de energia e números fantasma como decoração.
+ * Superfície vermelha da marca de bordo a bordo, tipografia branca de grande
+ * escala e números fantasma como única decoração. Sem gradientes: a força vem
+ * do contraste vermelho/branco e do tamanho do texto.
  * CSS Module ao lado de app/page.tsx.
  */
 
@@ -14,11 +15,7 @@
 .page {
   display: flex;
   flex: 1;
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-blue) 0%,
-    var(--color-blue-deep) 100%
-  );
+  background: var(--surface-brand);
   color: var(--color-white);
   font-family: var(--font-body);
   overflow-x: hidden;
@@ -32,23 +29,10 @@
   position: relative;
 }
 
-/* Halo vermelho discreto, alinhado com o resto do site. */
-.stage::before {
-  content: "";
-  position: absolute;
-  top: -180px;
-  right: -140px;
-  width: 480px;
-  height: 480px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(239, 62, 77, 0.25) 0%, transparent 70%);
-  pointer-events: none;
-}
-
 .wrap {
   position: relative;
   width: 100%;
-  max-width: 1200px;
+  max-width: 1240px;
   margin: 0 auto;
   padding: 0 var(--sp-md);
 }
@@ -59,38 +43,42 @@
 /* ============================================================
    PROPOSTA DE VALOR
    ============================================================ */
-.intro { max-width: 720px; }
+.intro { max-width: 900px; }
 
 .eyebrow {
   display: flex;
   align-items: center;
-  gap: 12px;
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
+  gap: 14px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.85);
-  margin: 0 0 var(--sp-sm);
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0 0 var(--sp-md);
 }
 .eyebrow::before {
   content: "";
-  width: 30px;
+  width: 34px;
   height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--color-primary-red);
+  background: var(--color-white);
   flex-shrink: 0;
 }
 
+/* Título de cartaz: grande, apertado e a branco cheio — a assinatura
+   tipográfica do site. */
 .title {
-  font-size: clamp(36px, 5.4vw, 64px);
+  font-family: var(--font-display);
+  font-size: clamp(42px, 7.6vw, 108px);
   font-weight: 700;
-  letter-spacing: -0.5px;
-  line-height: 1.12;
+  letter-spacing: -0.045em;
+  line-height: 0.94;
+  text-transform: uppercase;
   color: var(--color-white);
   margin: 0;
   text-wrap: balance;
 }
-.dot { color: var(--color-primary-red); }
+/* O ponto final fica a meio-tom: pontua sem competir com o título. */
+.dot { color: rgba(255, 255, 255, 0.5); }
 
 /* ============================================================
    PROCESSO
@@ -134,15 +122,15 @@
   top: calc(var(--node-y, 0px) + 26px);
   left: 40px;
   font-size: clamp(90px, 9vw, 140px);
-  font-weight: 800;
+  font-weight: 700;
   line-height: 0.8;
-  letter-spacing: -4px;
-  color: rgba(255, 255, 255, 0.07);
+  letter-spacing: -0.06em;
+  color: rgba(255, 255, 255, 0.1);
   pointer-events: none;
   user-select: none;
 }
 
-/* Nó: ícone dentro de um marcador redondo com halo. */
+/* Nó: ícone vermelho dentro de um marcador branco. */
 .node {
   position: relative;
   z-index: 1;
@@ -152,11 +140,9 @@
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: var(--color-primary-red);
-  color: var(--color-white);
-  box-shadow:
-    0 0 0 8px rgba(239, 62, 77, 0.14),
-    0 8px 20px rgba(0, 0, 0, 0.25);
+  background: var(--color-white);
+  color: var(--color-red);
+  box-shadow: 0 0 0 8px rgba(255, 255, 255, 0.14);
 }
 .node svg { width: 22px; height: 22px; }
 
@@ -165,21 +151,21 @@
   z-index: 1;
   display: block;
   margin-top: var(--sp-md);
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--color-red-on-dark);
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .stepTitle {
   position: relative;
   z-index: 1;
-  margin: 8px 0 0;
-  font-size: clamp(17px, 1.6vw, 22px);
+  margin: 10px 0 0;
+  font-size: clamp(17px, 1.6vw, 23px);
   font-weight: 700;
-  letter-spacing: -0.2px;
-  line-height: 1.35;
+  letter-spacing: -0.025em;
+  line-height: 1.25;
   color: var(--color-white);
   max-width: 22ch;
   text-wrap: pretty;
@@ -206,7 +192,7 @@
     left: 0;
     width: 44px;
     height: 44px;
-    box-shadow: 0 0 0 6px rgba(239, 62, 77, 0.14);
+    box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.14);
   }
   /* Fio vertical a ligar os nós. */
   .step:not(:last-child)::before {
@@ -216,10 +202,9 @@
     left: 21px;
     bottom: -24px;
     width: 2px;
-    border-radius: var(--radius-pill);
     background: linear-gradient(
       180deg,
-      rgba(239, 62, 77, 0.7) 0%,
+      rgba(255, 255, 255, 0.7) 0%,
       rgba(255, 255, 255, 0.15) 100%
     );
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,14 +65,20 @@ export default function HomePage() {
               aria-hidden
             >
               <defs>
+                {/* Branco a ganhar densidade ao subir: a curva acompanha o
+                    progresso sem sair da paleta vermelho/branco. */}
                 <linearGradient id="cmTrack" x1="0" y1="1" x2="1" y2="0">
-                  <stop offset="0%" stopColor="#ef3e4d" stopOpacity="0.25" />
-                  <stop offset="45%" stopColor="#ef3e4d" stopOpacity="0.9" />
-                  <stop offset="100%" stopColor="#ffffff" stopOpacity="0.55" />
+                  <stop offset="0%" stopColor="#ffffff" stopOpacity="0.18" />
+                  <stop offset="45%" stopColor="#ffffff" stopOpacity="0.55" />
+                  <stop offset="100%" stopColor="#ffffff" stopOpacity="1" />
                 </linearGradient>
               </defs>
+              {/* Os nós ficam encostados à esquerda de cada coluna da grelha,
+                  não ao centro: as âncoras horizontais (~2,5% / 36,5% / 70,5%)
+                  seguem os centros reais dos marcadores. Na vertical, 84,4 /
+                  46,8 / 15,6 são os `--node-y` convertidos para o viewBox. */}
               <path
-                d="M 0,95 C 8,86 11,84.4 16.7,84.4 C 31,84.4 36,46.8 50,46.8 C 64,46.8 69,15.6 83.3,15.6 C 90,15.6 95,11 100,6"
+                d="M 0,91 C 0.8,88 1.5,84.4 2.5,84.4 C 17,84.4 22,46.8 36.5,46.8 C 51,46.8 56,15.6 70.5,15.6 C 82,15.6 92,9 100,3"
                 fill="none"
                 stroke="url(#cmTrack)"
                 strokeWidth="2"

--- a/app/termos-e-condicoes/page.module.css
+++ b/app/termos-e-condicoes/page.module.css
@@ -1,5 +1,7 @@
 /*
- * Termos e Condições page — editorial design matching the homepage.
+ * Termos e Condições — sistema vermelho/branco.
+ * Documento longo: cada cláusula fica num bloco translúcido sobre o vermelho,
+ * com o número em caixa branca a servir de âncora de leitura.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -9,8 +11,8 @@
    LAYOUT PRIMITIVES
    ============================================================ */
 .page {
-  background: var(--color-white);
-  color: var(--color-text-primary);
+  background: var(--surface-brand);
+  color: var(--color-white);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -29,27 +31,27 @@
 .eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
+  gap: 14px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--brand-700);
+  color: rgba(255, 255, 255, 0.78);
   margin-bottom: 20px;
 }
 .eyebrow::before {
   content: "";
-  width: 24px; height: 1px;
-  background: var(--accent);
+  width: 34px; height: 2px;
+  background: currentColor;
 }
 
 .displayLg {
-  font-family: var(--font-body);
+  font-family: var(--font-display);
   font-weight: 700;
-  letter-spacing: -0.035em;
-  line-height: 1.1;
-  color: var(--color-text-primary);
-  font-size: clamp(26px, 3.5vw, 48px);
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  color: var(--color-white);
+  font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
 
@@ -58,24 +60,34 @@
    ============================================================ */
 .hero {
   padding: 96px 0;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--hairline);
 }
 @media (max-width: 720px) { .hero { padding: 64px 0; } }
 .heroTitle { margin-bottom: 20px; }
-.heroDate { font-size: 14px; color: var(--muted); margin-top: 16px; }
+.heroDate {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 16px;
+}
 
 /* ============================================================
    SECTIONS
    ============================================================ */
-.sections { display: flex; flex-direction: column; gap: 16px; }
+.sections { display: flex; flex-direction: column; gap: 12px; }
 .termSection {
-  background: var(--color-bg-light);
-  border: 1px solid var(--color-gray-light);
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid var(--hairline);
   border-radius: var(--radius-lg);
   padding: 32px 36px;
-  transition: border-color .2s;
+  transition: border-color .2s, background .2s;
 }
-.termSection:hover { border-color: rgba(239, 62, 77,.4); }
+.termSection:hover {
+  border-color: var(--color-white);
+  background: rgba(255, 255, 255, 0.11);
+}
 .termHeader {
   display: flex;
   align-items: flex-start;
@@ -86,26 +98,26 @@
   flex-shrink: 0;
   width: 44px; height: 44px;
   border-radius: var(--radius-sm);
-  background: var(--brand);
-  color: var(--moonlight-white);
-  font-weight: 800;
+  background: var(--color-white);
+  color: var(--color-red);
+  font-weight: 700;
   font-size: 18px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 .termTitle {
-  font-size: 20px;
+  font-size: 21px;
   font-weight: 700;
-  letter-spacing: -0.2px;
-  color: var(--color-text-primary);
+  letter-spacing: -0.03em;
+  color: var(--color-white);
   margin: 0;
-  padding-top: 10px;
+  padding-top: 9px;
 }
 .termContent {
   font-size: 16px;
-  color: var(--muted);
-  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.75;
   margin: 0;
   padding-left: 64px;
 }


### PR DESCRIPTION
## Summary
Complete visual rebrand of the site from a blue/red dual-tone system to a bold red/white system with improved typography. The new design uses Creato Display as the primary typeface and establishes a two-tone color system: red surfaces with white text, and inverted white panels with dark text for focus areas.

## Key Changes

### Color System Overhaul
- **New primary palette**: Red (#E30613) as main surface, white (#FFFFFF) for text on red, black (#101012) for footer/chrome
- **Removed**: Old blue (#0F4C5C), complex gray scales, and orange/green semantic colors
- **Added**: Semantic colors (success #12A06D, warning #B8730A, danger #CF0A17) now used only on white panels
- **Inverted panels**: New `.on-light` class system that flips all tokens (text, lines, buttons) for white background blocks
- **Translucent layers**: New panel tokens (`--panel`, `--panel-strong`, `--panel-ink`) for subtle depth on red surfaces

### Typography
- **New font**: Creato Display (local files, no external dependency) replaces system font stack
- **Refined scale**: Tighter letter-spacing (-0.03em to -0.04em), increased font weights (700 instead of 600), adjusted heading sizes
- **Text hierarchy**: New opacity-based scales for secondary/tertiary text on both red and white backgrounds

### Component Updates
- **Buttons**: Primary buttons now white on red (inverted from old red on white); secondary buttons use white outlines
- **Cards**: Progress cards and price cards now use `.on-light` to invert to white backgrounds with dark text
- **Accents**: Title highlights now use white background with red text (box-decoration-break for multi-line support)
- **Borders/lines**: Hairline tokens now use white with opacity instead of gray, with separate `--hairline-invert` for white panels

### Page-Specific Updates
- **Homepage**: Removed gradient backgrounds, now solid red surface
- **Course page**: Red header with white text, white reader overlay for long-form content
- **About/Contact/FAQ**: Consistent red backgrounds with white text, white panels for forms/CTAs
- **Catalog**: Print styles updated to white background

### Token Compatibility Layer
- Maintained legacy token names (`--brand`, `--color-primary-red`, etc.) mapped to new palette
- Ensures existing CSS Modules continue working without modification
- Old blue references now map to black for proper contrast

## Implementation Details
- CSS custom properties reorganized into logical groups: base palette, surfaces, text, lines, semantic states
- New `@layer components` rules for `.on-light` and specific component classes (`.login-form`, `.dashboard-sidebar`, etc.)
- Shadow system updated to use black with opacity instead of blue
- Radius scale reduced (4px → 2px minimum) for more typographic, less rounded aesthetic
- All pages now inherit red background by default; white panels opt-in via `.on-light` class

https://claude.ai/code/session_013hdn1JtXnVVQGFZAJkVZAf