### PR TITLE
Justifica texto do curso, adiciona ícones por módulo e corrige overlaps mobile

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -216,6 +216,9 @@
   top: 100px;
   overflow: hidden;
 }
+@media (max-width: 880px) {
+  .card { position: static; }
+}
 /* Régua vermelha no topo, assinatura dos painéis brancos. */
 .card::before {
   content: "";

--- a/app/curso/moduleIcons.tsx
+++ b/app/curso/moduleIcons.tsx
@@ -1,0 +1,99 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Ícones ilustrativos por módulo, usados no cabeçalho do leitor
+ * para dar contexto visual imediato ao tema de cada módulo.
+ */
+
+import React from "react";
+
+const iconProps = {
+  width: 28,
+  height: 28,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.8,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+const moduleIcons: Record<number, React.ReactNode> = {
+  1: (
+    <svg {...iconProps}>
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ),
+  2: (
+    <svg {...iconProps}>
+      <path d="M12 21s7-6.1 7-11.5A7 7 0 0 0 5 9.5C5 14.9 12 21 12 21Z" />
+      <circle cx="12" cy="9.5" r="2.5" />
+    </svg>
+  ),
+  3: (
+    <svg {...iconProps}>
+      <path d="M12 3 4 6v6c0 5 3.4 8.4 8 9 4.6-.6 8-4 8-9V6l-8-3Z" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  ),
+  4: (
+    <svg {...iconProps}>
+      <path d="M12 3v18" />
+      <path d="M7 7h10" />
+      <path d="M4 7 2 12a2 2 0 0 0 4 0Z" />
+      <path d="M20 7l-2 5a2 2 0 0 0 4 0Z" />
+    </svg>
+  ),
+  5: (
+    <svg {...iconProps}>
+      <rect x="5" y="4" width="14" height="17" rx="2" />
+      <path d="M9 3h6a1 1 0 0 1 1 1v1H8V4a1 1 0 0 1 1-1Z" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  ),
+  6: (
+    <svg {...iconProps}>
+      <path d="M15 5.5a2 2 0 1 0-2-2 2 2 0 0 0 2 2Z" />
+      <path d="m9 21 2-6-2-2 1-5 4 3 3 1" />
+      <path d="m5 21 2-4 3-2" />
+    </svg>
+  ),
+  7: (
+    <svg {...iconProps}>
+      <path d="M4 8h3l1.5-2h7L17 8h3a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1Z" />
+      <circle cx="12" cy="13" r="3.2" />
+    </svg>
+  ),
+  8: (
+    <svg {...iconProps}>
+      <path d="M7 3h8l4 4v14H7Z" />
+      <path d="M15 3v4h4" />
+      <path d="M9.5 12.5h5" />
+      <path d="M9.5 16h5" />
+    </svg>
+  ),
+  9: (
+    <svg {...iconProps}>
+      <circle cx="12" cy="12" r="9.5" />
+      <path d="M9 8.5c0-1 1-1.5 3-1.5s3 .8 3 1.8-1 1.4-3 1.7-3 .8-3 1.9 1 1.6 3 1.6 3-.5 3-1.5" />
+    </svg>
+  ),
+  10: (
+    <svg {...iconProps}>
+      <rect x="3.5" y="5" width="17" height="16" rx="2" />
+      <path d="M3.5 9.5h17" />
+      <path d="M8 3v4" />
+      <path d="M16 3v4" />
+      <path d="m8 14 2.5 2.5L16 12" />
+    </svg>
+  ),
+  11: (
+    <svg {...iconProps}>
+      <circle cx="12" cy="9" r="5.5" />
+      <path d="m8.5 13.5-1.5 7 5-2.5 5 2.5-1.5-7" />
+    </svg>
+  ),
+};
+
+export function getModuleIcon(moduleId: number): React.ReactNode {
+  return moduleIcons[moduleId] ?? moduleIcons[1];
+}

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -612,6 +612,18 @@
   .readerContainer { grid-template-columns: minmax(0, 1fr) 320px; gap: 56px; }
 }
 
+.readerIcon {
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-lg);
+  background: var(--color-red);
+  color: var(--color-white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 0 22px;
+}
+
 .readerChap {
   font-size: 11px;
   font-weight: 700;
@@ -662,11 +674,13 @@
   font-size: 16px;
   line-height: 1.8;
   color: var(--on-invert-2);
-  text-wrap: pretty;
 }
 .readerProse p {
   margin: 0 0 20px;
   max-width: 66ch;
+  text-align: justify;
+  text-justify: inter-word;
+  hyphens: auto;
 }
 .readerProse strong { color: var(--on-invert); font-weight: 700; }
 .readerProse ul {
@@ -772,7 +786,7 @@
   background: #f7f7f9;
   padding: 26px;
 }
-.example p { margin: 0 0 10px; font-size: 14px; color: var(--on-invert-2); line-height: 1.7; }
+.example p { margin: 0 0 10px; font-size: 14px; color: var(--on-invert-2); line-height: 1.7; text-align: justify; }
 .example p:last-child { margin-bottom: 0; }
 .exampleTitle {
   font-size: 17px;
@@ -798,6 +812,9 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+@media (max-width: 980px) {
+  .aside { position: static; }
 }
 .asideCard {
   background: #f7f7f9;

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { courseModules as courseModulesPt, type QuizQuestion } from "./courseData";
 import { courseModules as courseModulesEn } from "./courseDataEn";
+import { getModuleIcon } from "./moduleIcons";
 import { useLanguage } from "@/app/context/LanguageContext";
 import styles from "./page.module.css";
 
@@ -1101,6 +1102,7 @@ export default function CursoPage() {
             <div className={styles.readerContainer}>
               {/* MAIN COLUMN */}
               <article>
+                <div className={styles.readerIcon} aria-hidden="true">{getModuleIcon(activeModule.id)}</div>
                 <p className={styles.readerChap}>{currentTheoryPage.title}</p>
                 <h1 className={styles.readerHeading}>{activeModule.title}</h1>
                 {activeModule.description && (


### PR DESCRIPTION
- Alinha o texto teórico do curso (readerProse, exemplos) a justificado
- Adiciona um ícone ilustrativo por módulo no cabeçalho do leitor
- Desativa position:sticky no cartão de preço (/about) e na sidebar do
  leitor do curso abaixo do breakpoint onde o layout colapsa para uma
  coluna, evitando que fiquem sobrepostos ao conteúdo durante o scroll
  em mobile