### PR TITLE
Implement full-screen section layout with responsive spacing

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -27,8 +27,13 @@
 }
 @media (min-width: 768px) { .wrap { padding: 0 40px; } }
 
-.section { padding: 96px 0; }
-@media (max-width: 720px) { .section { padding: 64px 0; } }
+.section {
+  padding: clamp(28px, 8vh, 96px) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+@media (max-width: 720px) { .section { padding: clamp(20px, 6vh, 64px) 0; } }
 
 .eyebrow {
   display: inline-flex;
@@ -123,13 +128,16 @@
    HERO
    ============================================================ */
 .hero {
-  padding: 96px 0;
+  padding: clamp(28px, 8vh, 96px) 0;
   border-bottom: 1px solid var(--hairline);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-@media (max-width: 720px) { .hero { padding: 64px 0; } }
+@media (max-width: 720px) { .hero { padding: clamp(20px, 6vh, 64px) 0; } }
 .heroInner { max-width: 860px; }
-.heroTitle { margin-bottom: 28px; }
-.heroSub { margin-top: 24px; }
+.heroTitle { margin-bottom: clamp(12px, 3vh, 28px); }
+.heroSub { margin-top: clamp(10px, 2.4vh, 24px); }
 
 /* ============================================================
    CONTENT GRID
@@ -282,11 +290,14 @@
    SECÇÕES VINDAS DA ANTIGA PÁGINA INICIAL
    ============================================================ */
 .sectionAlt {
-  padding: 96px 0;
+  padding: clamp(28px, 8vh, 96px) 0;
   background: var(--surface-brand-alt);
   border-top: 1px solid var(--hairline-soft);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-@media (max-width: 720px) { .sectionAlt { padding: 64px 0; } }
+@media (max-width: 720px) { .sectionAlt { padding: clamp(20px, 6vh, 64px) 0; } }
 
 .dot { color: rgba(255, 255, 255, 0.5); }
 
@@ -440,6 +451,9 @@
   background: var(--color-black);
   border-top: none;
   border-bottom: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .stripGrid {
   display: grid;

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -166,7 +166,7 @@ export default function AboutPage() {
       {/* ============================================================
           HERO
           ============================================================ */}
-      <header className={styles.hero}>
+      <header className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.heroInner}>
             <div className={styles.eyebrow}>{t.about.badge}</div>
@@ -184,7 +184,7 @@ export default function AboutPage() {
       {/* ============================================================
           CONTENT
           ============================================================ */}
-      <section className={styles.section}>
+      <section className={`${styles.section} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.grid}>
             {/* Left column — advantages */}
@@ -233,7 +233,7 @@ export default function AboutPage() {
       {/* ============================================================
           PILARES
           ============================================================ */}
-      <section className={styles.sectionAlt}>
+      <section className={`${styles.sectionAlt} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.head}>
             <div>
@@ -267,7 +267,7 @@ export default function AboutPage() {
       {/* ============================================================
           SETORES
           ============================================================ */}
-      <section className={styles.section}>
+      <section className={`${styles.section} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.head}>
             <div>
@@ -304,7 +304,7 @@ export default function AboutPage() {
       {/* ============================================================
           NÚMEROS
           ============================================================ */}
-      <section className={styles.strip}>
+      <section className={`${styles.strip} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.stripGrid}>
             <div className={styles.stripItem}>

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -87,7 +87,7 @@ export default function AccountPage() {
   };
 
   return (
-    <section className="w-full space-y-8">
+    <section className="full-section full-section-scroll w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form max-w-[620px]">
           <h1 className="form-heading">{t.auth.registerTitle}</h1>

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -23,7 +23,7 @@ export default function ApiDocsPage() {
   }
 
   return (
-    <main className="min-h-screen bg-[color:var(--background)] px-4 py-6 sm:px-6 md:px-8">
+    <main className="full-section full-section-scroll bg-[color:var(--background)] px-4 py-6 sm:px-6 md:px-8">
       {/* Título e contexto rápido para orientar quem vai testar endpoints no browser. */}
       <header className="mx-auto mb-4 max-w-6xl">
         <h1 className="text-2xl font-bold tracking-[-0.03em] text-white">Swagger API Explorer</h1>

--- a/app/catalogo/page.tsx
+++ b/app/catalogo/page.tsx
@@ -47,7 +47,7 @@ export default function CatalogPage() {
         }
       `}</style>
 
-      <div className="min-h-screen bg-[color:var(--background)] py-10 px-4 print:bg-white print:py-0 print:px-0">
+      <div className="full-section full-section-scroll bg-[color:var(--background)] py-10 px-4 print:bg-white print:py-0 print:px-0">
         {/* Print button */}
         <div className="no-print mx-auto mb-6 max-w-[820px] flex justify-end">
           <button

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -17,7 +17,7 @@ export default function CheckoutPage() {
   }, [paymentLink]);
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="full-section flex items-center justify-center">
       <div className="text-center space-y-4">
         <h1 className="text-xl font-semibold home-title-highlight-text">Redirecionando para pagamento...</h1>
         <p className="text-sm sm:text-base leading-6 sm:leading-7">Se não for redirecionado automaticamente,</p>

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -40,12 +40,18 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           </div>
         </header>
 
-        {/* Na página inicial o conteúdo estica-se para ocupar o ecrã inteiro. */}
-        <main className={`flex-1 px-0 pb-0 ${isHome ? "flex flex-col" : ""}`}>
+        {/*
+          `screen-main` faz o conteúdo ocupar exatamente a altura do ecrã
+          abaixo do cabeçalho. Com uma só secção (home) isso elimina o
+          scroll; com várias secções, o scroll dentro de `main` fica com
+          "encaixe" — cada secção aparece por inteiro antes de a seguinte
+          entrar. O rodapé fica fora do encaixe, alcançável a seguir à
+          última secção.
+        */}
+        <main className={`screen-main px-0 pb-0 ${isHome ? "flex flex-col" : ""}`}>
           {children}
+          {!isHome ? <Footer /> : null}
         </main>
-
-        {!isHome ? <Footer /> : null}
       </div>
     </LanguageProvider>
   );

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -25,8 +25,13 @@
 }
 @media (min-width: 768px) { .wrap { padding: 0 40px; } }
 
-.section { padding: 96px 0; }
-@media (max-width: 720px) { .section { padding: 64px 0; } }
+.section {
+  padding: clamp(28px, 8vh, 96px) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+@media (max-width: 720px) { .section { padding: clamp(20px, 6vh, 64px) 0; } }
 
 .eyebrow {
   display: inline-flex;
@@ -77,10 +82,13 @@
    HERO
    ============================================================ */
 .hero {
-  padding: 96px 0;
+  padding: clamp(28px, 8vh, 96px) 0;
   border-bottom: 1px solid var(--hairline);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-@media (max-width: 720px) { .hero { padding: 64px 0; } }
+@media (max-width: 720px) { .hero { padding: clamp(20px, 6vh, 64px) 0; } }
 .heroTitle { margin-bottom: 24px; }
 .heroSub { margin-top: 20px; }
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -73,7 +73,7 @@ export default function ContactPage() {
       {/* ============================================================
           HERO
           ============================================================ */}
-      <header className={styles.hero}>
+      <header className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.eyebrow}>{t.contact.badge}</div>
           <h1 className={`${styles.displayLg} ${styles.heroTitle}`}>
@@ -88,7 +88,7 @@ export default function ContactPage() {
       {/* ============================================================
           CONTENT
           ============================================================ */}
-      <section className={styles.section}>
+      <section className={`${styles.section} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.grid}>
             {/* Left — contact info */}

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -169,10 +169,13 @@
    CABEÇALHO DO CURSO
    ============================================================ */
 .courseHead {
-  padding: 56px 0 32px;
+  padding: clamp(20px, 6vh, 56px) 0 clamp(14px, 3.5vh, 32px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 @media (max-width: 720px) {
-  .courseHead { padding: 34px 0 24px; }
+  .courseHead { padding: clamp(16px, 4vh, 34px) 0 clamp(10px, 2.5vh, 24px); }
 }
 .courseHeadGrid {
   display: grid;
@@ -279,9 +282,14 @@
 /* ============================================================
    LISTA DE MÓDULOS
    ============================================================ */
-.modList { padding-bottom: 88px; }
+.modList {
+  padding-bottom: clamp(28px, 8vh, 88px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
 @media (max-width: 720px) {
-  .modList { padding-bottom: 56px; }
+  .modList { padding-bottom: clamp(20px, 6vh, 56px); }
 }
 .modListHead {
   display: flex;

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -921,7 +921,7 @@ export default function CursoPage() {
           ============================================================ */}
       {!activeModule && (
         <>
-          <section className={styles.courseHead}>
+          <section className={`${styles.courseHead} full-section full-section-scroll`}>
             <div className={styles.wrap}>
               <div className={styles.courseHeadGrid}>
                 <div>
@@ -962,7 +962,7 @@ export default function CursoPage() {
             </div>
           </section>
 
-          <section className={styles.modList}>
+          <section className={`${styles.modList} full-section full-section-scroll`}>
             <div className={styles.wrap}>
               <div className={styles.modListHead}>
                 <h2 className={styles.modListTitle}>{cp.courseModulesTitle}</h2>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -417,7 +417,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <section className="w-full space-y-8 px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
+    <section className="full-section full-section-scroll w-full space-y-8 px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
       {mustCompleteProfile && (
         <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/70 p-4">
           <div className="login-form w-full max-w-2xl">

--- a/app/faq/page.module.css
+++ b/app/faq/page.module.css
@@ -48,11 +48,21 @@
 
 /* ---------- Hero ---------- */
 .hero {
-  padding: 96px 0 48px;
+  padding: clamp(28px, 8vh, 96px) 0 clamp(16px, 4vh, 48px);
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 @media (max-width: 720px) {
-  .hero { padding: 64px 0 32px; }
+  .hero { padding: clamp(20px, 6vh, 64px) 0 clamp(12px, 3vh, 32px); }
+}
+
+.contentSection {
+  padding-bottom: clamp(28px, 8vh, 92px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .eyebrow {
   display: inline-flex;

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -51,7 +51,7 @@ export default function FaqPage() {
 
   return (
     <div className={styles.page}>
-      <header className={styles.hero}>
+      <header className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.eyebrow}>Perguntas frequentes</div>
           <h1 className={styles.title}>Tudo o que precisas de saber.</h1>
@@ -62,7 +62,7 @@ export default function FaqPage() {
         </div>
       </header>
 
-      <main className={styles.wrap}>
+      <main className={`${styles.wrap} ${styles.contentSection} full-section full-section-scroll`}>
         <div className={styles.faq}>
           {faqs.map((f, i) => {
             const open = openFaq === i;

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -42,7 +42,7 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <section className="w-full space-y-8">
+    <section className="full-section full-section-scroll w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <h1 className="form-heading">{t.auth.forgotPasswordTitle}</h1>

--- a/app/globals.css
+++ b/app/globals.css
@@ -93,6 +93,7 @@
   --radius-pill: 999px;  /* pílulas, réguas finas e barras de progresso */
   --radius-sharp: var(--radius-md);
   --header-control-height: 38px;
+  --header-h: 72px;         /* altura fixa de .site-header-inner */
 
   /* Sombras — sobre vermelho só funcionam sombras pretas e discretas. */
   --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.12);
@@ -2234,6 +2235,46 @@
       top: 110px;
       display: block;
     }
+  }
+
+  /* ===================================================================
+     PARTE 14 — SECÇÕES DE ECRÃ INTEIRO
+     -------------------------------------------------------------------
+     Cada página ocupa exatamente a altura visível abaixo do cabeçalho
+     fixo (100dvh - --header-h). Numa página de secção única (ex: home)
+     isto elimina o scroll. Em páginas com várias secções, `.screen-main`
+     torna-se o contentor de scroll com "encaixe": cada `.full-section`
+     preenche o ecrã por inteiro e só a secção seguinte aparece quando se
+     desliza — nunca uma secção cortada a meio. Se o conteúdo de uma
+     secção for demasiado extenso para o ecrã (ex: um formulário longo em
+     ecrãs baixos), essa secção ganha `.full-section-scroll` para deslizar
+     internamente em vez de cortar texto.
+     =================================================================== */
+  .screen-main {
+    height: calc(100dvh - var(--header-h));
+    overflow-y: auto;
+    overflow-x: hidden;
+    scroll-snap-type: y proximity;
+  }
+
+  .full-section {
+    min-height: calc(100dvh - var(--header-h));
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+  }
+
+  .full-section-scroll {
+    max-height: calc(100dvh - var(--header-h));
+    overflow-y: auto;
+    /* Um flex column centrado (.full-section) com conteúdo maior do que a
+       caixa distribui o overflow para os dois lados: a posição de scroll 0
+       já começa a meio do conteúdo e o início fica inacessível. Quando a
+       secção pode precisar de scroll interno, o alinhamento tem de ser ao
+       topo para nunca esconder o começo do conteúdo. */
+    justify-content: flex-start;
   }
 
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -115,7 +115,7 @@ export default function LoginPage() {
   };
 
   return (
-    <section className="w-full space-y-8">
+    <section className="full-section full-section-scroll w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <h1 className="form-heading">{t.auth.loginTitle}</h1>

--- a/app/o-curso/page.module.css
+++ b/app/o-curso/page.module.css
@@ -26,11 +26,26 @@
 }
 @media (min-width: 768px) { .wrap { padding: 0 40px; } }
 
-.section { padding: 96px 0; }
-.sectionTight { padding: 64px 0; }
+.section {
+  padding: clamp(28px, 8vh, 96px) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.sectionTight {
+  padding: clamp(20px, 6vh, 64px) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.sectionSteps {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
 @media (max-width: 720px) {
-  .section { padding: 64px 0; }
-  .sectionTight { padding: 40px 0; }
+  .section { padding: clamp(20px, 6vh, 64px) 0; }
+  .sectionTight { padding: clamp(14px, 4vh, 40px) 0; }
 }
 
 .eyebrow {
@@ -138,11 +153,14 @@
    HERO
    ============================================================ */
 .hero {
-  padding: 96px 0;
+  padding: clamp(28px, 8vh, 96px) 0;
   position: relative;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-@media (max-width: 720px) { .hero { padding: 64px 0; } }
+@media (max-width: 720px) { .hero { padding: clamp(20px, 6vh, 64px) 0; } }
 
 .heroGrid {
   position: relative;
@@ -703,12 +721,12 @@
    COMO FUNCIONA — secção vinda da antiga página inicial
    ============================================================ */
 .sectionSteps {
-  padding: 96px 0;
+  padding: clamp(28px, 8vh, 96px) 0;
   background: var(--surface-brand-alt);
   border-top: 1px solid var(--hairline-soft);
   border-bottom: 1px solid var(--hairline-soft);
 }
-@media (max-width: 720px) { .sectionSteps { padding: 64px 0; } }
+@media (max-width: 720px) { .sectionSteps { padding: clamp(20px, 6vh, 64px) 0; } }
 
 .headKicker {
   font-size: 11px;

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -126,7 +126,7 @@ export default function CoursePage() {
       {/* ============================================================
           HERO
           ============================================================ */}
-      <header className={styles.hero}>
+      <header className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.heroGrid}>
             {/* Left — copy */}
@@ -193,7 +193,7 @@ export default function CoursePage() {
       {/* ============================================================
           BENEFITS
           ============================================================ */}
-      <section className={styles.section}>
+      <section className={`${styles.section} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.head}>
             <div>
@@ -221,7 +221,7 @@ Dez módulos curtos, casos reais e um plano de 30 dias para saíres daqui com a 
       {/* ============================================================
           CONFIANÇA — números + certificação
           ============================================================ */}
-      <section className={styles.sectionTight}>
+      <section className={`${styles.sectionTight} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.trustBar}>
             <div className={styles.trustBadgeChip}>
@@ -247,7 +247,7 @@ Dez módulos curtos, casos reais e um plano de 30 dias para saíres daqui com a 
       {/* ============================================================
           TESTEMUNHOS
           ============================================================ */}
-      <section className={styles.sectionTight}>
+      <section className={`${styles.sectionTight} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <h2 className={`${styles.displayLg} ${styles.testimonialsTitle}`}>
             {t.coursePage.testimonialsTitle}
@@ -274,7 +274,7 @@ Dez módulos curtos, casos reais e um plano de 30 dias para saíres daqui com a 
       {/* ============================================================
           COMO FUNCIONA
           ============================================================ */}
-      <section className={styles.sectionSteps}>
+      <section className={`${styles.sectionSteps} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.head}>
             <div>
@@ -307,7 +307,7 @@ Dez módulos curtos, casos reais e um plano de 30 dias para saíres daqui com a 
       {/* ============================================================
           CURRICULUM
           ============================================================ */}
-      <section className={styles.sectionTight}>
+      <section className={`${styles.sectionTight} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.curr}>
             <div className={styles.currInner}>
@@ -406,7 +406,7 @@ Teoria paginada, casos reais comentados e checklists. Cada módulo termina com u
           FINAL CTA (only shown when not logged in)
           ============================================================ */}
       {!isLoggedIn && (
-        <section className={styles.section}>
+        <section className={`${styles.section} full-section full-section-scroll`}>
           <div className={styles.wrap}>
             <div className={styles.final}>
               <div className={styles.finalInner}>

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -8,11 +8,12 @@
 .page {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   flex: 1;
+  min-height: 0;
   background: var(--color-white);
   color: var(--on-invert);
   font-family: var(--font-body);
-  overflow-x: hidden;
 }
 
 /* ============================================================
@@ -20,7 +21,8 @@
    ============================================================ */
 .hero {
   position: relative;
-  padding: clamp(var(--sp-2xl), 8vh, var(--sp-5xl)) 0 var(--sp-2xl);
+  flex: 0 1 auto;
+  padding: clamp(12px, 4vh, var(--sp-3xl)) 0 clamp(8px, 2.5vh, var(--sp-lg));
 }
 
 .heroInner {
@@ -49,7 +51,7 @@
   letter-spacing: 0.24em;
   text-transform: uppercase;
   color: var(--on-invert-3);
-  margin: 0 0 var(--sp-md);
+  margin: 0 0 clamp(8px, 1.6vh, var(--sp-md));
 }
 .eyebrow::before {
   content: "";
@@ -61,7 +63,7 @@
 
 .title {
   font-family: var(--font-display);
-  font-size: clamp(38px, 5.6vw, 64px);
+  font-size: clamp(30px, min(5.6vw, 7vh), 64px);
   font-weight: 800;
   letter-spacing: -0.04em;
   line-height: 1.02;
@@ -75,9 +77,9 @@
 .dot { color: var(--color-red); }
 
 .subtitle {
-  margin: var(--sp-md) 0 0;
+  margin: clamp(8px, 1.6vh, var(--sp-md)) 0 0;
   font-size: 17px;
-  line-height: 1.6;
+  line-height: 1.5;
   color: var(--on-invert-2);
   max-width: 46ch;
 }
@@ -86,7 +88,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin: var(--sp-sm) 0 0;
+  margin: clamp(6px, 1.2vh, var(--sp-sm)) 0 0;
   padding: 8px 14px;
   border-radius: var(--radius-pill);
   background: rgba(124, 92, 255, 0.1);
@@ -101,7 +103,7 @@
   align-items: center;
   gap: var(--sp-lg);
   flex-wrap: wrap;
-  margin-top: var(--sp-lg);
+  margin-top: clamp(10px, 2vh, var(--sp-lg));
 }
 
 .ctaPrimary {
@@ -151,7 +153,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 280px;
+  min-height: clamp(120px, 22vh, 280px);
 }
 
 .heroArtGlow {
@@ -186,20 +188,20 @@
 @media (max-width: 860px) {
   .heroInner {
     grid-template-columns: 1fr;
-    gap: var(--sp-xl);
+    gap: clamp(8px, 2vh, var(--sp-xl));
   }
-  .heroArt { order: -1; min-height: 200px; }
-  .heroArtGlow { width: 260px; }
-  .heroArtRing { width: 100px; height: 100px; }
-  .heroArtRing svg { width: 42px; height: 42px; }
-  .title { font-size: clamp(32px, 10vw, 46px); }
+  /* Em ecrãs baixos o destaque decorativo é o primeiro a ceder espaço
+     ao conteúdo, para o texto nunca ficar cortado. */
+  .heroArt { display: none; }
+  .title { font-size: clamp(26px, min(10vw, 8vh), 46px); }
 }
 
 /* ============================================================
    PROCESSO
    ============================================================ */
 .process {
-  padding: var(--sp-2xl) 0 var(--sp-5xl);
+  flex: 0 1 auto;
+  padding: clamp(8px, 2.4vh, var(--sp-2xl)) 0 clamp(8px, 3vh, var(--sp-4xl));
 }
 
 .processInner {
@@ -221,7 +223,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 154px;
+  height: clamp(90px, 16vh, 154px);
   overflow: visible;
   pointer-events: none;
 }
@@ -229,7 +231,7 @@
 .steps {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--sp-lg);
+  gap: clamp(var(--sp-sm), 2.5vh, var(--sp-lg));
   list-style: none;
   margin: 0;
   padding: 0;
@@ -267,7 +269,7 @@
   position: relative;
   z-index: 1;
   display: block;
-  margin-top: var(--sp-md);
+  margin-top: clamp(8px, 1.6vh, var(--sp-md));
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.24em;
@@ -305,25 +307,28 @@
   .track { display: none; }
   .steps {
     grid-template-columns: 1fr;
-    gap: var(--sp-xl);
+    gap: clamp(8px, 2.4vh, var(--sp-xl));
   }
   .step {
     padding-top: 0;
-    padding-left: 72px;
-    min-height: 56px;
+    padding-left: 60px;
+    min-height: 44px;
   }
   .node {
     position: absolute;
     top: 0;
     left: 0;
+    width: 44px;
+    height: 44px;
   }
+  .node svg { width: 20px; height: 20px; }
   /* Fio vertical a ligar os nós. */
   .step:not(:last-child)::before {
     content: "";
     position: absolute;
-    top: 56px;
-    left: 27px;
-    bottom: -32px;
+    top: 44px;
+    left: 21px;
+    bottom: clamp(-28px, -3vh, -12px);
     width: 2px;
     background: linear-gradient(
       180deg,
@@ -332,5 +337,27 @@
     );
   }
   .stepIndex { margin-top: 0; }
+  .stepTitle {
+    margin: 6px 0 2px;
+    font-size: clamp(15px, 4vw, 21px);
+  }
+  .stepDesc { font-size: 14px; line-height: 1.5; }
   .stepTitle, .stepDesc { max-width: none; }
+}
+
+/* ============================================================
+   ECRÃS BAIXOS — telemóveis pequenos, em que o total ainda não
+   coubesse com as regras acima; comprime mais um nível.
+   ============================================================ */
+@media (max-width: 860px) and (max-height: 760px) {
+  .eyebrow { display: none; }
+  .title { font-size: clamp(22px, 8vw, 34px); line-height: 1.05; }
+  .subtitle { font-size: 14px; line-height: 1.4; }
+  .ctaPrimary, .ctaSecondary { min-height: 40px; padding: 10px 18px; font-size: 14px; }
+  .node { width: 36px; height: 36px; }
+  .node svg { width: 16px; height: 16px; }
+  .step { padding-left: 50px; min-height: 36px; }
+  .step:not(:last-child)::before { top: 36px; left: 17px; }
+  .stepTitle { font-size: 14px; }
+  .stepDesc { font-size: 13px; line-height: 1.4; }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,7 +43,7 @@ export default function HomePage() {
   ];
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} full-section`}>
       {/* ----------------------------------------------------------
           HERO — proposta de valor à esquerda, destaque à direita
           ---------------------------------------------------------- */}
@@ -130,7 +130,11 @@ export default function HomePage() {
               <li
                 className={styles.step}
                 key={step.title}
-                style={{ "--node-y": `${[106, 48, 0][i]}px` } as React.CSSProperties}
+                style={
+                  {
+                    "--node-y": `clamp(0px, ${[13, 6, 0][i]}vh, ${[106, 48, 0][i]}px)`,
+                  } as React.CSSProperties
+                }
               >
                 <span className={`${styles.node} ${i === 2 ? styles.nodeFilled : ""}`} aria-hidden>
                   {StepIcons[i]}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -19,7 +19,7 @@ export default function ResetPasswordPage() {
 
 function ResetPasswordLoadingState() {
   return (
-    <section className="w-full space-y-8">
+    <section className="full-section full-section-scroll w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <p className="text-center text-sm">Loading recovery form...</p>
@@ -66,7 +66,7 @@ function ResetPasswordContent() {
   };
 
   return (
-    <section className="w-full space-y-8">
+    <section className="full-section full-section-scroll w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <h1 className="form-heading">{t.auth.resetPasswordTitle}</h1>

--- a/app/termos-e-condicoes/page.module.css
+++ b/app/termos-e-condicoes/page.module.css
@@ -25,8 +25,13 @@
 }
 @media (min-width: 768px) { .wrap { padding: 0 40px; } }
 
-.section { padding: 96px 0; }
-@media (max-width: 720px) { .section { padding: 64px 0; } }
+.section {
+  padding: clamp(28px, 8vh, 96px) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+@media (max-width: 720px) { .section { padding: clamp(20px, 6vh, 64px) 0; } }
 
 .eyebrow {
   display: inline-flex;
@@ -59,10 +64,13 @@
    HERO
    ============================================================ */
 .hero {
-  padding: 96px 0;
+  padding: clamp(28px, 8vh, 96px) 0;
   border-bottom: 1px solid var(--hairline);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-@media (max-width: 720px) { .hero { padding: 64px 0; } }
+@media (max-width: 720px) { .hero { padding: clamp(20px, 6vh, 64px) 0; } }
 .heroTitle { margin-bottom: 20px; }
 .heroDate {
   font-size: 11px;

--- a/app/termos-e-condicoes/page.tsx
+++ b/app/termos-e-condicoes/page.tsx
@@ -22,7 +22,7 @@ export default function TermosECondicoes() {
       {/* ============================================================
           HERO
           ============================================================ */}
-      <header className={styles.hero}>
+      <header className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.eyebrow}>{headerLabel}</div>
           <h1 className={`${styles.displayLg} ${styles.heroTitle}`}>
@@ -37,7 +37,7 @@ export default function TermosECondicoes() {
       {/* ============================================================
           SECTIONS
           ============================================================ */}
-      <section className={styles.section}>
+      <section className={`${styles.section} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.sections}>
             {sections.map((section) => (


### PR DESCRIPTION
## Summary
This PR refactors the layout system to implement full-screen sections with viewport-height-aware spacing and improved responsive behavior across all pages. The changes ensure sections occupy exactly the visible viewport height below the fixed header, with intelligent scroll snapping and internal scrolling for content that exceeds screen height.

## Key Changes

### Layout Architecture
- Added `.screen-main`, `.full-section`, and `.full-section-scroll` utility classes in `globals.css` to create full-viewport-height sections with scroll snap behavior
- Introduced `--header-h` CSS variable (72px) for consistent header height calculations
- Modified `AppShell.tsx` to apply `screen-main` class to main content area, enabling viewport-height-based layout
- Updated all page sections to use `full-section` and `full-section-scroll` classes for consistent full-screen behavior

### Responsive Spacing
- Replaced fixed padding values with `clamp()` functions throughout all page modules to scale spacing based on viewport height (vh) and width (vw)
- Updated spacing in: `page.module.css`, `o-curso/page.module.css`, `about/page.module.css`, `contact/page.module.css`, `curso/page.module.css`, `faq/page.module.css`, `termos-e-condicoes/page.module.css`
- Examples: `padding: 96px 0` → `padding: clamp(28px, 8vh, 96px) 0`

### Home Page Optimizations
- Removed `overflow-x: hidden` from `.page` class
- Added `justify-content: center` and `min-height: 0` to `.page` for proper flex centering
- Adjusted hero section padding with viewport-aware `clamp()` values
- Updated title font-size to use `min(5.6vw, 7vh)` for better scaling on tall/short screens
- Modified `.heroArt` to `display: none` on mobile (≤860px) to prioritize text content
- Updated step node positioning to use viewport-height-based calculations

### Mobile & Low-Height Screen Handling
- Added new media query `@media (max-width: 860px) and (max-height: 760px)` for small phones with limited vertical space
- Hides eyebrow text and reduces font sizes, padding, and component dimensions for ultra-compact screens
- Adjusted step connector positioning and node sizes for mobile layouts

### Typography & Spacing Details
- Updated margins and line-heights with `clamp()` for responsive scaling
- Changed subtitle line-height from 1.6 to 1.5 for better density
- Adjusted process section gap and step spacing with viewport-aware values
- Updated hero art container min-height to `clamp(120px, 22vh, 280px)`

## Implementation Details
- All sections now use flexbox with `justify-content: center` to vertically center content within their viewport-height containers
- Scroll snap is applied at proximity level, allowing smooth scrolling while snapping to section starts
- Sections with potentially overflowing content use `.full-section-scroll` with `justify-content: flex-start` to prevent content cutoff
- Footer moved inside `screen-main` to be part of the scroll snap flow
- Responsive calculations use `clamp(min, preferred, max)` to smoothly transition between breakpoints based on both viewport width and height

https://claude.ai/code/session_01CsQwiCdtVwzUaNY5WHPtw3