### PR TITLE
Adjust header height to account for border-bottom

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -93,7 +93,7 @@
   --radius-pill: 999px;  /* pílulas, réguas finas e barras de progresso */
   --radius-sharp: var(--radius-md);
   --header-control-height: 38px;
-  --header-h: 72px;         /* altura fixa de .site-header-inner */
+  --header-h: 73px;         /* 72px de .site-header-inner + 1px de border-bottom do .site-header */
 
   /* Sombras — sobre vermelho só funcionam sombras pretas e discretas. */
   --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
## Summary
Updated the `--header-h` CSS custom property to correctly account for the total height of the site header including its border-bottom.

## Changes
- Increased `--header-h` from `72px` to `73px` to include the `1px` border-bottom of `.site-header`
- Updated the accompanying comment to clarify that the height now comprises both the `.site-header-inner` height (72px) and the border-bottom (1px)

## Details
This adjustment ensures that layout calculations and spacing that depend on the `--header-h` variable accurately reflect the full visual height of the header element, preventing potential layout shifts or misalignment issues caused by the previously unaccounted border.

https://claude.ai/code/session_018Vqi7dbC1TEaqMEZVEcHZ9