### PR TITLE
Refactor scroll behavior: single page scroll instead of snap sections

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -41,14 +41,15 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </header>
 
         {/*
-          `screen-main` faz o conteúdo ocupar exatamente a altura do ecrã
-          abaixo do cabeçalho. Com uma só secção (home) isso elimina o
-          scroll; com várias secções, o scroll dentro de `main` fica com
-          "encaixe" — cada secção aparece por inteiro antes de a seguinte
-          entrar. O rodapé fica fora do encaixe, alcançável a seguir à
-          última secção.
+          Há sempre uma única barra de scroll no site. Na home, uma só
+          secção, `screen-main-single` fixa a altura ao ecrã e elimina o
+          scroll. Nas restantes páginas, `screen-main` cresce com o
+          conteúdo e é o `body` que percorre a página inteira — as
+          secções nunca têm scroll próprio, evitando sobreposições.
         */}
-        <main className={`screen-main px-0 pb-0 ${isHome ? "flex flex-col" : ""}`}>
+        <main
+          className={`screen-main px-0 pb-0 ${isHome ? "screen-main-single flex flex-col" : ""}`}
+        >
           {children}
           {!isHome ? <Footer /> : null}
         </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2238,23 +2238,28 @@
   }
 
   /* ===================================================================
-     PARTE 14 — SECÇÕES DE ECRÃ INTEIRO
+     PARTE 14 — SECÇÕES DE ECRÃ
      -------------------------------------------------------------------
-     Cada página ocupa exatamente a altura visível abaixo do cabeçalho
-     fixo (100dvh - --header-h). Numa página de secção única (ex: home)
-     isto elimina o scroll. Em páginas com várias secções, `.screen-main`
-     torna-se o contentor de scroll com "encaixe": cada `.full-section`
-     preenche o ecrã por inteiro e só a secção seguinte aparece quando se
-     desliza — nunca uma secção cortada a meio. Se o conteúdo de uma
-     secção for demasiado extenso para o ecrã (ex: um formulário longo em
-     ecrãs baixos), essa secção ganha `.full-section-scroll` para deslizar
-     internamente em vez de cortar texto.
+     Existe uma única barra de scroll no site: a da página (via `body`/
+     `main`), nunca uma por secção. Isso evita que conteúdos fiquem
+     sobrepostos ou cortados dentro de uma secção.
+
+     Numa página de secção única (ex: home) `.screen-main-single` fixa a
+     altura ao ecrã visível abaixo do cabeçalho (100dvh - --header-h), pelo
+     que não há nada para percorrer. Nas restantes páginas, `.screen-main`
+     não tem altura fixa nem overflow próprio — cresce com o conteúdo e é o
+     `body` que faz o scroll da página inteira. Cada `.full-section` tenta
+     preencher o ecrã (min-height), mas nunca corta nem faz scroll
+     internamente: se o conteúdo for maior do que o ecrã, a secção cresce e
+     empurra as seguintes para baixo, mantendo o scroll único da página.
      =================================================================== */
   .screen-main {
-    height: calc(100dvh - var(--header-h));
-    overflow-y: auto;
     overflow-x: hidden;
-    scroll-snap-type: y proximity;
+  }
+
+  .screen-main-single {
+    height: calc(100dvh - var(--header-h));
+    overflow: hidden;
   }
 
   .full-section {
@@ -2262,18 +2267,14 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    scroll-snap-align: start;
-    scroll-snap-stop: always;
   }
 
   .full-section-scroll {
-    max-height: calc(100dvh - var(--header-h));
-    overflow-y: auto;
     /* Um flex column centrado (.full-section) com conteúdo maior do que a
        caixa distribui o overflow para os dois lados: a posição de scroll 0
-       já começa a meio do conteúdo e o início fica inacessível. Quando a
-       secção pode precisar de scroll interno, o alinhamento tem de ser ao
-       topo para nunca esconder o começo do conteúdo. */
+       já começa a meio do conteúdo e o início fica inacessível. Secções que
+       podem exceder o ecrã alinham-se ao topo para nunca esconder o começo
+       do conteúdo — o excesso simplesmente cresce a página. */
     justify-content: flex-start;
   }
 


### PR DESCRIPTION
## Summary
This PR refactors the scroll architecture to use a single page-level scroll instead of section-based scroll snapping. The changes eliminate internal section scrolling and scroll snap behavior, ensuring content never gets cut off or overlapped.

## Key Changes

- **Removed scroll snap behavior**: Eliminated `scroll-snap-type`, `scroll-snap-align`, and `scroll-snap-stop` CSS properties from `.screen-main` and `.full-section`
- **Restructured `.screen-main`**: Removed fixed height and `overflow-y: auto` properties; now only prevents horizontal overflow and lets content flow naturally
- **Introduced `.screen-main-single`**: New class for single-section pages (like home) that maintains the fixed viewport height and prevents scrolling
- **Updated `.full-section`**: Changed from scroll-snap-aligned sections to flexible sections with `min-height` that grow when content exceeds viewport
- **Simplified `.full-section-scroll`**: Removed `max-height` and `overflow-y: auto` constraints; sections now grow naturally with content instead of scrolling internally
- **Updated AppShell component**: Applied `screen-main-single` class conditionally for home page, updated comments to reflect new scroll behavior

## Implementation Details

The new approach ensures:
- Single scroll bar at the page level (`body`/`main`) for all pages
- Home page (single section) maintains fixed viewport height with no scrolling
- Multi-section pages allow sections to expand beyond viewport height, pushing subsequent sections down
- Content is never cut off or hidden due to internal section scrolling
- Improved accessibility by avoiding overlapping content and complex scroll snap interactions

https://claude.ai/code/session_01QTs1UWvVKfgxbScQ7uj8V8