### PR TITLE
Add evaluation examples to course modules

### DIFF
--- a/app/curso/courseData.ts
+++ b/app/curso/courseData.ts
@@ -226,6 +226,26 @@ export const courseModules: CourseModule[] = [
     ],
    },
   ],
+  evaluationExamples: [
+   {
+    title: "Exemplo 1 — A missão que parecia boa",
+    scenario:
+     "Uma plataforma anuncia \"missão de restauração — 50 €\". Inclui refeição reembolsada até 30 €, 35 minutos de carro (ida e volta) e um formulário que demora cerca de 45 minutos a preencher.",
+    correctApproach:
+     "\"Honorário real: 20 €. Tempo total: ~1h50 (deslocação + visita de 40 min + relatório). Valor líquido ≈ 11 €/hora — abaixo do meu mínimo. Só aceito se conseguir agrupar com outra missão na mesma zona.\"",
+    incorrectApproach:
+     "\"A missão paga 50 €, aceito já.\" — confunde honorário com valor total anunciado e ignora o tempo real gasto.",
+   },
+   {
+    title: "Exemplo 2 — Escolher a plataforma certa",
+    scenario:
+     "Uma \"plataforma\" nova pede 15 € de \"taxa de certificação\" antes de liberar o acesso às missões disponíveis na tua zona.",
+    correctApproach:
+     "\"Nenhuma plataforma séria cobra para dar acesso a missões. Não me registo e reporto o anúncio, se possível.\"",
+    incorrectApproach:
+     "\"Pago os 15 €, deve valer a pena para começar mais depressa.\" — é precisamente o sinal de alerta descrito nesta página.",
+   },
+  ],
   quiz: [
    {
     id: "m2q1",
@@ -598,6 +618,26 @@ export const courseModules: CourseModule[] = [
      "**Sei o meu cenário e as minhas perguntas.** Duas ou três, no máximo. E sei como saio.",
      "**Confirmei a morada exata e o horário de funcionamento.** Cadeias grandes têm lojas a 300 metros uma da outra: avaliar a errada acontece mais vezes do que imaginas.",
     ],
+   },
+  ],
+  evaluationExamples: [
+   {
+    title: "Exemplo 1 — Briefing lido na diagonal",
+    scenario:
+     "O briefing pede explicitamente o número da caixa registadora e a hora de abertura da loja. Só percebes isso ao preencher o formulário, já em casa, três horas depois da visita.",
+    correctApproach:
+     "\"Leio o briefing e o formulário completo antes de sair de casa, com lápis na mão, e só depois preparo o cenário — assim nenhum campo me apanha de surpresa.\"",
+    incorrectApproach:
+     "\"Li o briefing por alto, achei que percebia o essencial.\" — resultado: relatório incompleto e missão em risco de ser devolvida.",
+   },
+   {
+    title: "Exemplo 2 — Cenário pouco credível",
+    scenario:
+     "A missão pede que avalies uma loja de material de escritório. Inventas um cenário elaborado de \"gerente de uma empresa de eventos que vai abrir filial em três países\".",
+    correctApproach:
+     "\"Uso um cenário próximo da minha realidade: preciso de material para um pequeno escritório em casa. Fácil de sustentar em qualquer pergunta de seguimento.\"",
+    incorrectApproach:
+     "Manter a personagem elaborada — cai ao primeiro \"e para que é que precisa disso?\" e chama a atenção do colaborador.",
    },
   ],
   quiz: [
@@ -1072,6 +1112,26 @@ export const courseModules: CourseModule[] = [
     ],
    },
   ],
+  evaluationExamples: [
+   {
+    title: "Exemplo 1 — Separar honorário de reembolso",
+    scenario:
+     "No fim do mês, somas todos os valores recebidos das plataformas e concluis que \"ganhaste 480 €\" com cinco missões.",
+    correctApproach:
+     "\"Separo a folha em duas colunas: honorário (o que é rendimento real) e reembolso (despesa devolvida). Só declaro e conto como ganho a coluna do honorário — nesse mês, 210 €.\"",
+    incorrectApproach:
+     "\"Ganhei 480 €\" — confunde o total recebido com rendimento e distorce por completo a perceção de rentabilidade.",
+   },
+   {
+    title: "Exemplo 2 — Excesso sobre o limite de reembolso",
+    scenario:
+     "O briefing indica um limite de reembolso de 20 € para a compra obrigatória. Na loja, o artigo mais barato que cumpre o pedido custa 27 €.",
+    correctApproach:
+     "\"Contacto a agência antes de comprar, a confirmar se há tolerância ou se assumo os 7 € de diferença. Guardo sempre o talão como prova do valor total gasto.\"",
+    incorrectApproach:
+     "\"Compro e assumo que a plataforma paga o valor todo.\" — o excesso sobre o limite fica quase sempre a cargo do avaliador, e a surpresa chega tarde de mais.",
+   },
+  ],
   quiz: [
    {
     id: "m9q1",
@@ -1174,6 +1234,26 @@ export const courseModules: CourseModule[] = [
      "**Constrói relação com as agências.** Responde rápido, cumpre prazos, avisa quando algo corre mal e sê educado com quem revê os teus relatórios. Passados alguns meses começam a chegar convites diretos — as missões que nunca chegam a ser publicadas.",
      "**Meta realista para os primeiros três meses:** 4 a 8 missões por mês, entre 80 € e 250 € de honorário mensal, e uma classificação acima da média. A partir daí, é escolher: manter como complemento ou empurrar para valores que já pagam contas.",
     ],
+   },
+  ],
+  evaluationExamples: [
+   {
+    title: "Exemplo 1 — Arranque comedido vs. arranque atabalhoado",
+    scenario:
+     "Na primeira semana já registada em várias plataformas, aparecem cinco convites de missão para a mesma semana.",
+    correctApproach:
+     "\"Aceito uma ou duas, próximas de casa e simples, para fechar bem o ciclo completo — candidatura, execução, relatório, aprovação — antes de escalar o volume.\"",
+    incorrectApproach:
+     "\"Aceito as cinco, mais vale aproveitar.\" — o risco de falhar um prazo é alto e uma classificação inicial baixa demora meses a recuperar.",
+   },
+   {
+    title: "Exemplo 2 — Ler o feedback da agência",
+    scenario:
+     "O primeiro relatório volta com uma nota de qualidade média e três comentários do revisor sobre falta de horas na narrativa.",
+    correctApproach:
+     "\"Leio os comentários com atenção, ajusto o próximo relatório para incluir sempre horas concretas, e trato o feedback como formação gratuita.\"",
+    incorrectApproach:
+     "\"Ignoro os comentários, o importante é que já fui pago.\" — repete o mesmo erro e mantém a classificação estagnada.",
    },
   ],
   quiz: [

--- a/app/curso/courseDataEn.ts
+++ b/app/curso/courseDataEn.ts
@@ -227,6 +227,26 @@ export const courseModules: CourseModule[] = [
     ],
    },
   ],
+  evaluationExamples: [
+   {
+    title: "Example 1 — The mission that looked good",
+    scenario:
+     "A platform advertises \"restaurant mission — €50\". It includes a meal reimbursed up to €30, 35 minutes of driving round trip, and a form that takes about 45 minutes to fill in.",
+    correctApproach:
+     "\"Real fee: €20. Total time: ~1h50 (travel + a 40-minute visit + report). Net value ≈ €11/hour — below my minimum. I only accept if I can group it with another mission in the same area.\"",
+    incorrectApproach:
+     "\"The mission pays €50, I'll take it.\" — confuses the fee with the advertised total and ignores the actual time spent.",
+   },
+   {
+    title: "Example 2 — Picking the right platform",
+    scenario:
+     "A new \"platform\" asks for a €15 \"certification fee\" before unlocking access to the missions available in your area.",
+    correctApproach:
+     "\"No serious platform charges for access to missions. I don't register, and I report the listing if possible.\"",
+    incorrectApproach:
+     "\"I'll pay the €15, it's probably worth it to get started faster.\" — that's exactly the warning sign described on this page.",
+   },
+  ],
   quiz: [
    {
     id: "m2q1",
@@ -599,6 +619,26 @@ export const courseModules: CourseModule[] = [
      "**I know my scenario and my questions.** Two or three, maximum. And I know how I'll leave.",
      "**I've confirmed the exact address and opening hours.** Big chains have stores 300 metres apart: evaluating the wrong one happens more often than you'd think.",
     ],
+   },
+  ],
+  evaluationExamples: [
+   {
+    title: "Example 1 — Brief skimmed too fast",
+    scenario:
+     "The brief explicitly asks for the till number and the store's opening time. You only notice that while filling in the form, three hours after the visit, at home.",
+    correctApproach:
+     "\"I read the brief and the full form before leaving home, pencil in hand, and only then prepare the scenario — so no field catches me off guard.\"",
+    incorrectApproach:
+     "\"I skimmed the brief, figured I got the gist.\" — result: an incomplete report and a mission at risk of being rejected.",
+   },
+   {
+    title: "Example 2 — An unconvincing scenario",
+    scenario:
+     "The mission asks you to evaluate an office-supplies store. You invent an elaborate scenario: \"manager of an events company opening branches in three countries\".",
+    correctApproach:
+     "\"I use a scenario close to my real life: I need supplies for a small home office. Easy to sustain under any follow-up question.\"",
+    incorrectApproach:
+     "Keeping the elaborate character — it collapses at the first \"and what do you need that for?\" and draws the employee's attention.",
    },
   ],
   quiz: [
@@ -1073,6 +1113,26 @@ export const courseModules: CourseModule[] = [
     ],
    },
   ],
+  evaluationExamples: [
+   {
+    title: "Example 1 — Separating fee from reimbursement",
+    scenario:
+     "At the end of the month, you add up everything received from the platforms and conclude you \"earned €480\" across five missions.",
+    correctApproach:
+     "\"I split the sheet into two columns: fee (real income) and reimbursement (returned expense). I only declare and count the fee column as earnings — that month, €210.\"",
+    incorrectApproach:
+     "\"I earned €480\" — confuses total received with income and completely distorts your sense of profitability.",
+   },
+   {
+    title: "Example 2 — Going over the reimbursement cap",
+    scenario:
+     "The brief sets a €20 reimbursement cap for the mandatory purchase. In the store, the cheapest item that fits the request costs €27.",
+    correctApproach:
+     "\"I contact the agency before buying, to confirm whether there's tolerance or whether I absorb the €7 difference. I always keep the receipt as proof of the total spent.\"",
+    incorrectApproach:
+     "\"I buy it and assume the platform pays the full amount.\" — the excess over the cap almost always falls on the evaluator, and the surprise arrives too late.",
+   },
+  ],
   quiz: [
    {
     id: "m9q1",
@@ -1175,6 +1235,26 @@ export const courseModules: CourseModule[] = [
      "**Build a relationship with agencies.** Reply quickly, meet deadlines, flag problems early and be courteous with whoever reviews your reports. After a few months, direct invitations start arriving — the missions that never get published.",
      "**A realistic target for the first three months:** 4 to 8 missions a month, €80 to €250 in monthly fees, and an above-average rating. From there it's your choice: keep it as side income or push it towards figures that pay bills.",
     ],
+   },
+  ],
+  evaluationExamples: [
+   {
+    title: "Example 1 — A measured start vs. an overloaded one",
+    scenario:
+     "In your first week registered on several platforms, five mission invitations arrive for the same week.",
+    correctApproach:
+     "\"I accept one or two, close to home and simple, to properly close the full cycle — apply, execute, report, get approved — before scaling up volume.\"",
+    incorrectApproach:
+     "\"I accept all five, might as well.\" — the risk of missing a deadline is high, and a poor early rating takes months to recover from.",
+   },
+   {
+    title: "Example 2 — Reading the agency's feedback",
+    scenario:
+     "Your first report comes back with an average quality score and three reviewer comments about missing timestamps in the narrative.",
+    correctApproach:
+     "\"I read the comments carefully, adjust the next report to always include concrete times, and treat the feedback as free training.\"",
+    incorrectApproach:
+     "\"I ignore the comments, what matters is I already got paid.\" — repeats the same mistake and keeps the rating stuck.",
    },
   ],
   quiz: [


### PR DESCRIPTION
## Summary
Added practical evaluation examples to four course modules in both Portuguese and English versions. These examples demonstrate correct and incorrect approaches to common scenarios evaluators encounter.

## Key Changes
- **Module 2 (Platform Selection)**: Added 2 examples covering mission fee calculation and platform legitimacy checks
- **Module 5 (Briefing & Scenario)**: Added 2 examples on briefing comprehension and scenario credibility
- **Module 9 (Financial Management)**: Added 2 examples on separating fees from reimbursements and handling reimbursement limits
- **Module 10 (Getting Started)**: Added 2 examples on pacing workload and responding to feedback
- **Bilingual support**: All examples added to both `courseData.ts` (Portuguese) and `courseDataEn.ts` (English)

## Implementation Details
Each evaluation example includes:
- A descriptive title
- A realistic scenario description
- A "correct approach" with reasoning
- An "incorrect approach" showing common mistakes

The examples are positioned before the quiz sections in each module, providing practical context before assessment questions.

https://claude.ai/code/session_01XmVG1sgds2psuk4z214cTU