### PR TITLE
Simplify home page layout and remove conditional footer rendering

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -12,11 +12,6 @@ import TopNav from "./TopNav";
 import Footer from "./Footer";
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  // A página inicial ocupa exatamente um ecrã: sem rodapé não há nada para
-  // percorrer abaixo do processo. As restantes páginas mantêm o rodapé.
-  const isHome = pathname === "/";
-
   return (
     <LanguageProvider>
       <div className="mx-auto flex min-h-screen w-full flex-col bg-transparent">
@@ -41,17 +36,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </header>
 
         {/*
-          Há sempre uma única barra de scroll no site. Na home, uma só
-          secção, `screen-main-single` fixa a altura ao ecrã e elimina o
-          scroll. Nas restantes páginas, `screen-main` cresce com o
-          conteúdo e é o `body` que percorre a página inteira — as
+          Há sempre uma única barra de scroll no site: `screen-main` cresce
+          com o conteúdo e é o `body` que percorre a página inteira — as
           secções nunca têm scroll próprio, evitando sobreposições.
         */}
-        <main
-          className={`screen-main px-0 pb-0 ${isHome ? "screen-main-single flex flex-col" : ""}`}
-        >
+        <main className="screen-main px-0 pb-0">
           {children}
-          {!isHome ? <Footer /> : null}
+          <Footer />
         </main>
       </div>
     </LanguageProvider>

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -965,7 +965,7 @@
 .qOptSelected {
   border-color: var(--color-red) !important;
   background: rgba(124, 92, 255, 0.07) !important;
-  color: var(--color-danger) !important;
+  color: var(--color-red) !important;
 }
 .qOptLetter {
   flex-shrink: 0;

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -895,7 +895,7 @@ export default function CursoPage() {
   const premiumTheoryPage = activeSupportContent
     ? {
         title: cp.premiumPageTitle,
-        blocks: [activeSupportContent.realScenario],
+        blocks: [] as string[],
       }
     : null;
   const allTheoryPages = premiumTheoryPage ? [...baseTheoryPages, premiumTheoryPage] : baseTheoryPages;

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -9,10 +9,7 @@
 .page {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  flex: 1;
-  min-height: 0;
-  padding: clamp(16px, 6vh, 96px) 0;
+  padding: clamp(48px, 10vh, 120px) 0;
   background: var(--surface-brand);
   color: var(--color-white);
   font-family: var(--font-body);
@@ -24,7 +21,7 @@
 .hero {
   position: relative;
   flex: 0 1 auto;
-  padding: clamp(12px, 4vh, var(--sp-3xl)) 0 clamp(8px, 2.5vh, var(--sp-lg));
+  padding: clamp(24px, 6vh, var(--sp-3xl)) 0 clamp(32px, 6vh, var(--sp-2xl));
 }
 
 .heroInner {
@@ -210,7 +207,7 @@
    ============================================================ */
 .process {
   flex: 0 1 auto;
-  padding: clamp(8px, 2.4vh, var(--sp-2xl)) 0 clamp(8px, 3vh, var(--sp-4xl));
+  padding: clamp(16px, 4vh, var(--sp-2xl)) 0 clamp(16px, 4vh, var(--sp-4xl));
 }
 
 .processInner {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,25 +60,12 @@ export default function HomePage() {
               </span>
             </h1>
             <p className={styles.subtitle}>{t.home.subtitle}</p>
-            <p className={styles.valueProp}>
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                <line x1="12" y1="1" x2="12" y2="23" />
-                <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-              </svg>
-              {t.home.valueProp}
-            </p>
 
             <div className={styles.ctaRow}>
               <Link href="/login" className={styles.ctaPrimary}>
                 {t.home.ctaPrimary}
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
                   <path d="M5 12h14M13 6l6 6-6 6" />
-                </svg>
-              </Link>
-              <Link href="/about" className={styles.ctaSecondary}>
-                {t.home.ctaSecondary}
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                  <path d="M6 9l6 6 6-6" />
                 </svg>
               </Link>
             </div>


### PR DESCRIPTION
## Summary
This PR simplifies the AppShell layout by removing home page-specific styling and always rendering the Footer component. It also streamlines the home page hero section and fixes a few styling inconsistencies across the application.

## Key Changes

- **AppShell Layout Simplification**
  - Removed `usePathname()` hook and `isHome` conditional logic
  - Removed `screen-main-single` class and conditional flex styling from main element
  - Footer is now always rendered instead of being conditionally hidden on home page
  - Updated scroll behavior documentation to reflect unified approach

- **Home Page Content Reduction**
  - Removed value proposition section with SVG icon from hero
  - Removed secondary CTA button linking to /about page
  - Kept primary login CTA button

- **Home Page Styling Updates**
  - Removed `justify-content: center`, `flex: 1`, and `min-height: 0` from `.page` class
  - Adjusted padding from `clamp(16px, 6vh, 96px)` to `clamp(48px, 10vh, 120px)`
  - Increased hero section padding for better spacing
  - Increased process section padding for improved visual hierarchy

- **Bug Fixes**
  - Fixed quiz option selected state color from `--color-danger` to `--color-red` in curso page
  - Cleared premium theory page blocks array (changed from `[activeSupportContent.realScenario]` to `[]`)

## Implementation Details
The changes move away from a full-screen home page design to a more consistent layout where all pages follow the same scrolling behavior. The Footer is now a permanent part of the layout rather than being hidden on the home page, simplifying component logic and improving consistency across the application.

https://claude.ai/code/session_01VwXyAnPw9aGBQgECBPsfvU