### PR TITLE
Fase 1/2 (P1): menu acessível, foco, formulários, JSON-LD, páginas le…

### DIFF
--- a/app/account/layout.tsx
+++ b/app/account/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function AccountLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -98,65 +98,83 @@ export default function AccountPage() {
           <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
             <div className="input-group">
               <input
+                id="register-first-name"
                 name="firstName"
                 placeholder="Enter your first name"
                 type="text"
+                autoComplete="given-name"
+                required
                 value={formData.firstName}
                 onChange={(event) => handleChange("firstName", event.target.value)}
               />
-              <span className="label">{t.auth.firstNameLabel}</span>
+              <label className="label" htmlFor="register-first-name">{t.auth.firstNameLabel}</label>
             </div>
 
             <div className="input-group">
               <input
+                id="register-last-name"
                 name="lastName"
                 placeholder="Enter your last name"
                 type="text"
+                autoComplete="family-name"
+                required
                 value={formData.lastName}
                 onChange={(event) => handleChange("lastName", event.target.value)}
               />
-              <span className="label">{t.auth.lastNameLabel}</span>
+              <label className="label" htmlFor="register-last-name">{t.auth.lastNameLabel}</label>
             </div>
 
             <div className="input-group md:col-span-2">
               <input
+                id="register-email"
                 name="email"
                 placeholder="name@example.com"
                 type="email"
+                inputMode="email"
+                autoComplete="email"
+                required
                 value={formData.email}
                 onChange={(event) => handleChange("email", event.target.value)}
               />
-              <span className="label">{t.auth.emailLabel}</span>
+              <label className="label" htmlFor="register-email">{t.auth.emailLabel}</label>
             </div>
 
             <div className="input-group">
               <input
+                id="register-password"
                 name="password"
                 placeholder="Create a secure password"
                 type="password"
+                autoComplete="new-password"
+                required
                 value={formData.password}
                 onChange={(event) => handleChange("password", event.target.value)}
               />
-              <span className="label">{t.auth.passwordLabel}</span>
+              <label className="label" htmlFor="register-password">{t.auth.passwordLabel}</label>
             </div>
 
             <div className="input-group">
               <input
+                id="register-password-confirm"
                 name="confirmPassword"
                 placeholder="Repeat the password"
                 type="password"
+                autoComplete="new-password"
+                required
                 value={formData.confirmPassword}
                 onChange={(event) => handleChange("confirmPassword", event.target.value)}
               />
-              <span className="label">{t.auth.passwordConfirmLabel}</span>
+              <label className="label" htmlFor="register-password-confirm">{t.auth.passwordConfirmLabel}</label>
             </div>
 
-            {feedback && (
-              <p className="form-feedback md:col-span-2">{feedback.message}</p>
-            )}
+            <div className="md:col-span-2" role="status" aria-live="polite">
+              {feedback && (
+                <p className="form-feedback">{feedback.message}</p>
+              )}
+            </div>
 
             <div className="md:col-span-2 mt-2 space-y-3">
-              <button className="submit" type="submit">
+              <button className="submit" type="submit" aria-busy={isSubmitting}>
                 {isSubmitting ? t.auth.registerSubmitting : t.auth.registerButton}
               </button>
               <div className="text-center">

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -15,6 +15,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <LanguageProvider>
       <div className="mx-auto flex min-h-dvh w-full flex-col bg-transparent">
+        <a href="#conteudo" className="skip-link">
+          Saltar para o conteúdo
+        </a>
+
         {/* Cabeçalho branco: marca à esquerda, navegação e ações à direita. */}
         <header className="site-header on-light sticky top-0 z-50">
           <div className="site-header-inner mx-auto w-full max-w-[1400px]">

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -16,6 +16,9 @@ export default function Footer() {
         <Link href="/termos-e-condicoes" className="footer-mini-link">
           {t.footer.termsLink}
         </Link>
+        <Link href="/privacidade" className="footer-mini-link">
+          Privacidade
+        </Link>
       </div>
     </footer>
   );

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -9,12 +9,15 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useLanguage } from "@/app/context/LanguageContext";
 
+const MOBILE_MENU_ID = "mobile-menu-panel";
+
 export default function TopNav() {
   const pathname = usePathname();
   const { t } = useLanguage();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [lastPathname, setLastPathname] = useState(pathname);
   const menuContainerRef = useRef<HTMLDivElement | null>(null);
+  const menuToggleRef = useRef<HTMLButtonElement | null>(null);
 
   const navigationItems = [
     { href: "/", label: t.nav.home },
@@ -37,6 +40,65 @@ export default function TopNav() {
     // Fecha o menu após navegação para melhorar a experiência em ecrãs pequenos.
     setIsMenuOpen(false);
   };
+
+  useEffect(() => {
+    // Torna o resto da página inerte enquanto o menu mobile está aberto,
+    // devolve o foco ao botão de abrir/fechar quando o menu fecha.
+    const mainContent = document.getElementById("conteudo");
+    const logo = document.querySelector<HTMLElement>(".site-header .logo");
+
+    if (isMenuOpen) {
+      mainContent?.setAttribute("inert", "");
+      logo?.setAttribute("inert", "");
+    } else {
+      mainContent?.removeAttribute("inert");
+      logo?.removeAttribute("inert");
+    }
+
+    return () => {
+      mainContent?.removeAttribute("inert");
+      logo?.removeAttribute("inert");
+    };
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    // Foca o primeiro link do painel ao abrir.
+    const panel = menuContainerRef.current;
+    const focusable = panel?.querySelectorAll<HTMLElement>("a, button");
+    focusable?.[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setIsMenuOpen(false);
+        menuToggleRef.current?.focus();
+        return;
+      }
+
+      if (event.key !== "Tab" || !focusable || focusable.length === 0) {
+        return;
+      }
+
+      // Focus trap: mantém o Tab dentro do painel enquanto está aberto.
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMenuOpen]);
 
   useEffect(() => {
     // Fecha o menu ao clicar fora do contêiner para evitar sobreposição visual persistente.
@@ -64,8 +126,10 @@ export default function TopNav() {
     <>
       {/* Exibe botão hamburguer apenas no mobile para manter o desktop limpo e alinhado ao centro. */}
       <button
+        ref={menuToggleRef}
         aria-expanded={isMenuOpen}
-        aria-label="Abrir menu principal"
+        aria-controls={MOBILE_MENU_ID}
+        aria-label={isMenuOpen ? "Fechar menu principal" : "Abrir menu principal"}
         className={`menu-toggle-button lg:hidden ${isMenuOpen ? "is-open" : ""}`}
         onClick={() => setIsMenuOpen((current) => !current)}
         type="button"
@@ -78,7 +142,7 @@ export default function TopNav() {
       </button>
 
       {/* Links do cabeçalho, com régua vermelha na página ativa (ver globals.css). */}
-      <nav className="hidden items-center justify-center gap-6 lg:flex xl:gap-8">
+      <nav className="hidden items-center justify-center gap-6 lg:flex xl:gap-8" aria-label="Navegação principal">
         {navigationItems.map((item) => {
           const isActive = pathname === item.href;
 
@@ -101,6 +165,7 @@ export default function TopNav() {
       {isMenuOpen ? (
         <div className="fixed inset-0 z-40 bg-black/60 lg:hidden" role="presentation">
           <nav
+            id={MOBILE_MENU_ID}
             aria-label="Menu principal mobile"
             className="mobile-menu-container absolute left-3 right-3 top-[76px] flex flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[color:var(--line)] sm:left-4 sm:right-4 sm:top-[82px]"
             ref={menuContainerRef}
@@ -116,6 +181,7 @@ export default function TopNav() {
                     isActive ? "bg-[color:var(--brand-soft)]" : ""
                   } ${isLast ? "border-b-0" : "border-b border-[color:var(--line-light)]"}`}
                   href={item.href}
+                  aria-current={isActive ? "page" : undefined}
                   onClick={closeMenu}
                 >
                   {item.label}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -142,15 +142,21 @@ export default function ContactPage() {
 
             {/* Right — form card */}
             <div className={styles.card}>
-              <h2 className={styles.cardTitle}>Enviar mensagem</h2>
-              <form className={styles.form} onSubmit={handleSubmit}>
+              <h2 id="contact-form-heading" className={styles.cardTitle}>Enviar mensagem</h2>
+              <form
+                className={styles.form}
+                onSubmit={handleSubmit}
+                aria-labelledby="contact-form-heading"
+              >
                 <div className={styles.row}>
                   <div className={styles.field}>
-                    <label className={styles.label}>{t.contact.formNameLabel}</label>
+                    <label className={styles.label} htmlFor="contact-name">{t.contact.formNameLabel}</label>
                     <input
+                      id="contact-name"
                       className={styles.input}
                       name="name"
                       type="text"
+                      autoComplete="name"
                       placeholder={t.contact.formNamePlaceholder}
                       required
                       value={formData.name}
@@ -158,11 +164,14 @@ export default function ContactPage() {
                     />
                   </div>
                   <div className={styles.field}>
-                    <label className={styles.label}>{t.contact.formEmailLabel}</label>
+                    <label className={styles.label} htmlFor="contact-email">{t.contact.formEmailLabel}</label>
                     <input
+                      id="contact-email"
                       className={styles.input}
                       name="email"
                       type="email"
+                      inputMode="email"
+                      autoComplete="email"
                       placeholder={t.contact.formEmailPlaceholder}
                       required
                       value={formData.email}
@@ -172,8 +181,9 @@ export default function ContactPage() {
                 </div>
 
                 <div className={styles.field}>
-                  <label className={styles.label}>{t.contact.formSubjectLabel}</label>
+                  <label className={styles.label} htmlFor="contact-subject">{t.contact.formSubjectLabel}</label>
                   <input
+                    id="contact-subject"
                     className={styles.input}
                     name="subject"
                     type="text"
@@ -185,8 +195,9 @@ export default function ContactPage() {
                 </div>
 
                 <div className={styles.field}>
-                  <label className={styles.label}>{t.contact.formMessageLabel}</label>
+                  <label className={styles.label} htmlFor="contact-message">{t.contact.formMessageLabel}</label>
                   <textarea
+                    id="contact-message"
                     className={styles.textarea}
                     name="message"
                     placeholder={t.contact.formMessagePlaceholder}
@@ -196,21 +207,24 @@ export default function ContactPage() {
                   />
                 </div>
 
-                {statusMessage && (
-                  <div className={styles.status}>
-                    <div>{statusMessage}</div>
-                    {statusReference && (
-                      <div className={styles.statusRef}>
-                        Referência: <strong>{statusReference}</strong>
-                      </div>
-                    )}
-                  </div>
-                )}
+                <div role="status" aria-live="polite">
+                  {statusMessage && (
+                    <div className={styles.status}>
+                      <div>{statusMessage}</div>
+                      {statusReference && (
+                        <div className={styles.statusRef}>
+                          Referência: <strong>{statusReference}</strong>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
 
                 <button
                   type="submit"
                   className={styles.submit}
                   disabled={isSubmitting}
+                  aria-busy={isSubmitting}
                 >
                   {isSubmitting ? t.contact.formSubmittingButton : t.contact.formSubmitButton}
                   {!isSubmitting && <ArrowIcon />}

--- a/app/curso/layout.tsx
+++ b/app/curso/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function CursoLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/faq/faqData.ts
+++ b/app/faq/faqData.ts
@@ -1,0 +1,35 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Fonte única das perguntas frequentes — usada pela
+ * página (acordeão) e pelo layout (JSON-LD FAQPage), para nunca divergirem.
+ */
+
+export const faqs = [
+  {
+    q: "Isto é legal em Portugal?",
+    a: "Sim. Mystery shopping é uma atividade legítima e regulada como qualquer outra prestação de serviços. As marcas pagam às plataformas para auditarem o seu próprio atendimento e tu prestas esse serviço como independente.",
+  },
+  {
+    q: "Preciso de experiência anterior?",
+    a: "Não. O curso foi desenhado para começar do zero. Se tens atenção ao detalhe e sabes escrever um parágrafo claro, tens o suficiente para começar.",
+  },
+  {
+    q: "Quanto tempo demora a fazer o curso?",
+    a: "Em média, cerca de 4 horas, distribuídas pelos 10 módulos. Podes fazê-lo num fim-de-semana ou ao longo de várias semanas — o acesso é vitalício.",
+  },
+  {
+    q: "Como recebo o pagamento das missões?",
+    a: "Diretamente da plataforma que te atribui a missão, normalmente por transferência bancária após aprovação do relatório. O módulo 10 explica como emitir recibos verdes.",
+  },
+  {
+    q: "É preciso ter carro?",
+    a: "Depende da tua zona. Em cidades como Lisboa ou Porto, transportes públicos chegam. Fora dos centros, carro alarga muito as missões disponíveis — mas não é obrigatório.",
+  },
+  {
+    q: "Há reembolso se não gostar?",
+    a: "Sim. Tens 14 dias para pedir reembolso integral, sem questões. Acreditamos no produto — só queremos que aprendas, não que pagues sem usar.",
+  },
+  {
+    q: "O certificado é reconhecido?",
+    a: "O certificado é emitido pelo Cliente Mistério e comprova as competências adquiridas. As plataformas em Portugal aceitam-no como prova de formação, mas o que conta sobretudo é o teu desempenho nas missões.",
+  },
+];

--- a/app/faq/layout.tsx
+++ b/app/faq/layout.tsx
@@ -1,4 +1,25 @@
 import type { Metadata } from "next";
+import { faqs } from "./faqData";
+import { siteUrl } from "../lib/site";
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map(({ q, a }) => ({
+    "@type": "Question",
+    name: q,
+    acceptedAnswer: { "@type": "Answer", text: a },
+  })),
+};
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Início", item: siteUrl },
+    { "@type": "ListItem", position: 2, name: "FAQ", item: `${siteUrl}/faq` },
+  ],
+};
 
 export const metadata: Metadata = {
   title: "Perguntas frequentes sobre ser cliente mistério em Portugal",
@@ -14,5 +35,17 @@ export const metadata: Metadata = {
 };
 
 export default function FaqLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      {children}
+    </>
+  );
 }

--- a/app/faq/page.module.css
+++ b/app/faq/page.module.css
@@ -114,6 +114,13 @@
   margin-top: 12px;
 }
 .faqItem { border-bottom: 1px solid var(--hairline); }
+.faqQHeading {
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+}
 .page .faqQ {
   display: flex;
   width: 100%;

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -7,6 +7,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import styles from "./page.module.css";
+import { faqs } from "./faqData";
 
 const ArrowIcon = ({ size = 16 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -15,43 +16,12 @@ const ArrowIcon = ({ size = 16 }: { size?: number }) => (
   </svg>
 );
 
-const faqs = [
-  {
-    q: "Isto é legal em Portugal?",
-    a: "Sim. Mystery shopping é uma atividade legítima e regulada como qualquer outra prestação de serviços. As marcas pagam às plataformas para auditarem o seu próprio atendimento e tu prestas esse serviço como independente.",
-  },
-  {
-    q: "Preciso de experiência anterior?",
-    a: "Não. O curso foi desenhado para começar do zero. Se tens atenção ao detalhe e sabes escrever um parágrafo claro, tens o suficiente para começar.",
-  },
-  {
-    q: "Quanto tempo demora a fazer o curso?",
-    a: "Em média, cerca de 4 horas, distribuídas pelos 10 módulos. Podes fazê-lo num fim-de-semana ou ao longo de várias semanas — o acesso é vitalício.",
-  },
-  {
-    q: "Como recebo o pagamento das missões?",
-    a: "Diretamente da plataforma que te atribui a missão, normalmente por transferência bancária após aprovação do relatório. O módulo 10 explica como emitir recibos verdes.",
-  },
-  {
-    q: "É preciso ter carro?",
-    a: "Depende da tua zona. Em cidades como Lisboa ou Porto, transportes públicos chegam. Fora dos centros, carro alarga muito as missões disponíveis — mas não é obrigatório.",
-  },
-  {
-    q: "Há reembolso se não gostar?",
-    a: "Sim. Tens 14 dias para pedir reembolso integral, sem questões. Acreditamos no produto — só queremos que aprendas, não que pagues sem usar.",
-  },
-  {
-    q: "O certificado é reconhecido?",
-    a: "O certificado é emitido pelo Cliente Mistério e comprova as competências adquiridas. As plataformas em Portugal aceitam-no como prova de formação, mas o que conta sobretudo é o teu desempenho nas missões.",
-  },
-];
-
 export default function FaqPage() {
   const [openFaq, setOpenFaq] = useState<number | null>(0);
 
   return (
     <div className={styles.page}>
-      <header className={`${styles.hero} full-section full-section-scroll`}>
+      <section className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.eyebrow}>Perguntas frequentes</div>
           <h1 className={styles.title}>Tudo o que precisas de saber.</h1>
@@ -60,24 +30,35 @@ export default function FaqPage() {
             tua resposta? <Link href="/contact" className={styles.subLink}>Fala connosco</Link>.
           </p>
         </div>
-      </header>
+      </section>
 
-      <main className={`${styles.wrap} ${styles.contentSection} full-section full-section-scroll`}>
+      <section className={`${styles.wrap} ${styles.contentSection} full-section full-section-scroll`}>
         <div className={styles.faq}>
           {faqs.map((f, i) => {
             const open = openFaq === i;
+            const questionId = `faq-question-${i}`;
+            const panelId = `faq-panel-${i}`;
             return (
               <div className={`${styles.faqItem} ${open ? styles.faqItemOpen : ""}`} key={f.q}>
-                <button
-                  type="button"
-                  className={styles.faqQ}
-                  onClick={() => setOpenFaq(open ? null : i)}
-                  aria-expanded={open}
+                <h2 className={styles.faqQHeading}>
+                  <button
+                    type="button"
+                    id={questionId}
+                    className={styles.faqQ}
+                    onClick={() => setOpenFaq(open ? null : i)}
+                    aria-expanded={open}
+                    aria-controls={panelId}
+                  >
+                    <span>{f.q}</span>
+                    <span className={styles.faqIcon} aria-hidden />
+                  </button>
+                </h2>
+                <div
+                  className={styles.faqA}
+                  id={panelId}
+                  role="region"
+                  aria-labelledby={questionId}
                 >
-                  <span>{f.q}</span>
-                  <span className={styles.faqIcon} aria-hidden />
-                </button>
-                <div className={styles.faqA}>
                   <div className={styles.faqAInner}>{f.a}</div>
                 </div>
               </div>
@@ -97,7 +78,7 @@ export default function FaqPage() {
             <ArrowIcon />
           </Link>
         </div>
-      </main>
+      </section>
     </div>
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,31 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Página de erro 500 personalizada em português.
+ * `global-error` substitui todo o layout raiz quando ocorre um erro não
+ * tratado, por isso precisa do próprio <html>/<body>.
+ */
+
+"use client";
+
+export default function GlobalError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html lang="pt-PT">
+      <body className="bg-[color:var(--background,#5a3dc7)] text-white antialiased">
+        <div className="flex min-h-dvh flex-col items-center justify-center gap-6 px-6 text-center">
+          <p className="text-label">Erro 500</p>
+          <h1 className="page-title">Algo correu mal.</h1>
+          <p className="text-body-lg max-w-[52ch]">
+            Ocorreu um erro inesperado. Podes tentar novamente ou voltar à página inicial.
+          </p>
+          <div className="hero-buttons">
+            <button type="button" className="button primary" onClick={() => reset()}>
+              Tentar novamente
+            </button>
+            <a href="/" className="button secondary">
+              Página inicial
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -187,6 +187,10 @@
   color-scheme: light;
 }
 
+html {
+  scroll-padding-top: var(--header-h);
+}
+
 /* -------------------------------------------------------------------
    PAINÉIS INVERTIDOS
    Aplicar `.on-light` a qualquer bloco branco: os tokens de texto e linha
@@ -571,6 +575,30 @@
     border-color: var(--ink);
     color: var(--ink);
     box-shadow: none;
+  }
+
+  /* Skip link — primeiro elemento focável da página, invisível até
+     receber foco por teclado. */
+  .skip-link {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 200;
+    transform: translateY(-150%);
+    padding: 12px 20px;
+    background: var(--color-white);
+    color: var(--color-red);
+    font-weight: 700;
+    font-size: 14px;
+    border-radius: 0 0 var(--radius-md) 0;
+    box-shadow: var(--shadow-md);
+    transition: transform 150ms ease;
+  }
+
+  .skip-link:focus-visible {
+    transform: translateY(0);
+    outline: 3px solid var(--color-red);
+    outline-offset: -3px;
   }
 
   /* Botão hamburguer — controlo estrutural, não é um CTA. */
@@ -2298,18 +2326,19 @@
     color: var(--color-red);
   }
 
-  /* FOCUS STATES */
+  /* FOCUS STATES
+     Sistema global: qualquer elemento focável recebe o mesmo anel de foco,
+     nunca `outline: none` sem substituto. `--focus-ring` já inverte por
+     painel (roxo sobre branco, branco sobre roxo — ver `.on-light`),
+     garantindo ≥3:1 contra o fundo em qualquer contexto. */
   *:focus {
     outline: none;
   }
 
-  a:focus-visible,
-  button:focus-visible,
-  input:focus-visible,
-  select:focus-visible,
-  textarea:focus-visible {
-    outline: 2px solid var(--focus-ring);
+  :focus-visible {
+    outline: 3px solid var(--focus-ring);
     outline-offset: 2px;
+    border-radius: inherit;
   }
 
   /* SMOOTH TRANSITIONS */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,14 +15,6 @@ export const metadata: Metadata = {
   },
   description: siteDescription,
   applicationName: siteName,
-  keywords: [
-    "cliente mistério",
-    "mystery shopper",
-    "curso",
-    "Portugal",
-    "avaliação de serviços",
-    "rendimento extra",
-  ],
   authors: [{ name: siteName }],
   alternates: {
     canonical: "/",
@@ -58,6 +50,22 @@ export const viewport: Viewport = {
   themeColor: "#7c5cff",
 };
 
+// TODO: acrescentar `logo` (URL de imagem real) e `sameAs` (redes sociais
+// reais) quando existirem — não inventar dados de marca não confirmados.
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: siteName,
+  url: siteUrl,
+};
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: siteName,
+  url: siteUrl,
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -66,6 +74,14 @@ export default function RootLayout({
   return (
     <html lang="pt-PT" className={creatoDisplay.variable}>
       <body className="bg-[color:var(--background)] text-[color:var(--foreground)] antialiased">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -122,30 +122,39 @@ export default function LoginPage() {
           <form onSubmit={handleSubmit}>
             <div className="input-group">
               <input
+                id="login-email"
                 name="email"
                 placeholder={t.auth.emailPlaceholder}
                 type="email"
+                inputMode="email"
+                autoComplete="email"
+                required
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
               />
-              <span className="label">{t.auth.emailLabel}</span>
+              <label className="label" htmlFor="login-email">{t.auth.emailLabel}</label>
             </div>
 
             <div className="input-group">
               <input
+                id="login-password"
                 name="password"
                 placeholder={t.auth.passwordPlaceholder}
                 type="password"
+                autoComplete="current-password"
+                required
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
               />
-              <span className="label">{t.auth.passwordLabel}</span>
+              <label className="label" htmlFor="login-password">{t.auth.passwordLabel}</label>
             </div>
 
-            {feedback && <p className="form-feedback">{feedback}</p>}
+            <div role="status" aria-live="polite">
+              {feedback && <p className="form-feedback">{feedback}</p>}
+            </div>
 
             <div className="mt-5 space-y-3">
-              <button className="submit" type="submit">
+              <button className="submit" type="submit" aria-busy={isSubmitting}>
                 {isSubmitting ? t.auth.loginSubmitting : t.auth.loginButton}
               </button>
               <div className="flex flex-wrap items-center justify-between gap-3">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,40 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Página 404 personalizada em português — mantém
+ * cabeçalho/rodapé (via RootLayout/AppShell) e sugere caminhos alternativos.
+ */
+
+import Link from "next/link";
+
+export const metadata = {
+  title: "Página não encontrada",
+  robots: { index: false, follow: false },
+};
+
+export default function NotFound() {
+  return (
+    <div className="full-section container-sm mx-auto flex flex-col items-center gap-6 px-6 py-24 text-center">
+      <p className="text-label">Erro 404</p>
+      <h1 className="page-title">Esta página não existe.</h1>
+      <p className="text-body-lg max-w-[52ch]">
+        O endereço que procuras pode ter mudado ou nunca ter existido. Aqui tens alguns
+        caminhos úteis para continuares.
+      </p>
+
+      <div className="hero-buttons">
+        <Link href="/o-curso" className="button primary">
+          Ver o curso
+        </Link>
+        <Link href="/faq" className="button secondary">
+          FAQ
+        </Link>
+        <Link href="/contact" className="button secondary">
+          Contactos
+        </Link>
+      </div>
+
+      <Link href="/" className="form-link mt-4">
+        Voltar à página inicial
+      </Link>
+    </div>
+  );
+}

--- a/app/o-curso/layout.tsx
+++ b/app/o-curso/layout.tsx
@@ -1,8 +1,42 @@
 import type { Metadata } from "next";
+import { siteUrl, siteName } from "../lib/site";
 
 const title = "O Curso: 10 módulos + certificado | Cliente Mistério — 24,99€";
 const description =
   "Curso completo de Cliente Mistério em Portugal: 10 módulos, casos reais, quiz por módulo e certificado de conclusão. Pagamento único de 24,99€, acesso vitalício.";
+
+const courseJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Course",
+  name: "Curso Cliente Mistério",
+  description,
+  provider: {
+    "@type": "Organization",
+    name: siteName,
+    sameAs: siteUrl,
+  },
+  offers: {
+    "@type": "Offer",
+    price: "24.99",
+    priceCurrency: "EUR",
+    availability: "https://schema.org/InStock",
+    url: `${siteUrl}/o-curso`,
+  },
+  hasCourseInstance: {
+    "@type": "CourseInstance",
+    courseMode: "online",
+    courseWorkload: "PT4H",
+  },
+};
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Início", item: siteUrl },
+    { "@type": "ListItem", position: 2, name: "O Curso", item: `${siteUrl}/o-curso` },
+  ],
+};
 
 export const metadata: Metadata = {
   title: { absolute: title },
@@ -16,5 +50,17 @@ export const metadata: Metadata = {
 };
 
 export default function OCursoLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(courseJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      {children}
+    </>
+  );
 }

--- a/app/privacidade/layout.tsx
+++ b/app/privacidade/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Política de Privacidade",
+  description: "Como o Cliente Mistério recolhe, usa e protege os teus dados pessoais, em conformidade com o RGPD.",
+  alternates: { canonical: "/privacidade" },
+};
+
+export default function PrivacidadeLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/privacidade/page.module.css
+++ b/app/privacidade/page.module.css
@@ -1,0 +1,135 @@
+/*
+ * Termos e Condições — sistema vermelho/branco.
+ * Documento longo: cada cláusula fica num bloco translúcido sobre o vermelho,
+ * com o número em caixa branca a servir de âncora de leitura.
+ */
+
+.page button { all: unset; cursor: pointer; font: inherit; }
+.page a { border-bottom: none !important; color: inherit; text-decoration: none; transition: color .2s; }
+
+/* ============================================================
+   LAYOUT PRIMITIVES
+   ============================================================ */
+.page {
+  background: var(--surface-brand);
+  color: var(--color-white);
+  font-size: 15px;
+  line-height: 1.65;
+  font-family: var(--font-body);
+}
+.wrap {
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+@media (min-width: 768px) { .wrap { padding: 0 40px; } }
+
+.section {
+  padding: clamp(28px, 8vh, 96px) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+@media (max-width: 720px) { .section { padding: clamp(20px, 6vh, 64px) 0; } }
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--on-brand-2);
+  margin-bottom: 20px;
+}
+.eyebrow::before {
+  content: "";
+  width: 34px; height: 2px;
+  background: currentColor;
+}
+
+.displayLg {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+  color: var(--color-white);
+  font-size: clamp(30px, 4.6vw, 62px);
+  margin: 0;
+}
+
+/* ============================================================
+   HERO
+   ============================================================ */
+.hero {
+  padding: clamp(28px, 8vh, 96px) 0;
+  border-bottom: 1px solid var(--hairline);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+@media (max-width: 720px) { .hero { padding: clamp(20px, 6vh, 64px) 0; } }
+.heroTitle { margin-bottom: 20px; }
+.heroDate {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--on-brand-2);
+  margin-top: 16px;
+}
+
+/* ============================================================
+   SECTIONS
+   ============================================================ */
+.sections { display: flex; flex-direction: column; gap: 12px; }
+.termSection {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-lg);
+  padding: 32px 36px;
+  transition: border-color .2s, background .2s;
+}
+.termSection:hover {
+  border-color: var(--color-white);
+  background: rgba(255, 255, 255, 0.11);
+}
+.termHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+.termNum {
+  flex-shrink: 0;
+  width: 44px; height: 44px;
+  border-radius: var(--radius-sm);
+  background: var(--color-white);
+  color: var(--color-red);
+  font-weight: 700;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.termTitle {
+  font-size: 21px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--color-white);
+  margin: 0;
+  padding-top: 9px;
+}
+.termContent {
+  font-size: 16px;
+  color: var(--on-brand-2);
+  line-height: 1.75;
+  margin: 0;
+  padding-left: 64px;
+}
+@media (max-width: 560px) {
+  .termContent { padding-left: 0; }
+  .termSection { padding: 24px; }
+}

--- a/app/privacidade/page.tsx
+++ b/app/privacidade/page.tsx
@@ -1,0 +1,90 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Política de privacidade (RGPD). Dados de
+ * identificação legal da empresa ainda não confirmados aparecem marcados
+ * com TODO — substituir assim que existirem valores reais.
+ */
+
+import styles from "./page.module.css";
+
+const sections = [
+  {
+    number: "01",
+    title: "Responsável pelo tratamento",
+    content:
+      "[TODO: denominação social], com sede em [TODO: morada legal da empresa] e contacto [TODO: email de contacto real], é responsável pelo tratamento dos dados pessoais recolhidos através deste site.",
+  },
+  {
+    number: "02",
+    title: "Que dados recolhemos",
+    content:
+      "Recolhemos os dados que fornece diretamente: nome, email e password (ao criar conta), dados de contacto submetidos no formulário de contacto, e dados de progresso no curso (módulos concluídos, resultados de quiz, certificado). Não recolhemos dados de pagamento — estes são processados diretamente pela Stripe.",
+  },
+  {
+    number: "03",
+    title: "Finalidades e bases legais",
+    content:
+      "Tratamos os seus dados para: (a) criar e gerir a sua conta e dar acesso ao curso — execução de contrato; (b) processar pagamentos através da Stripe — execução de contrato; (c) responder a pedidos de contacto — interesse legítimo; (d) cumprir obrigações legais e fiscais — obrigação legal.",
+  },
+  {
+    number: "04",
+    title: "Prazos de conservação",
+    content:
+      "Os dados da conta são conservados enquanto a conta estiver ativa. Dados de faturação são conservados pelo prazo legal aplicável em Portugal (geralmente 10 anos, nos termos do Código Comercial e legislação fiscal). Pode pedir a eliminação da sua conta a qualquer momento, sujeito às obrigações legais de conservação.",
+  },
+  {
+    number: "05",
+    title: "Subcontratantes",
+    content:
+      "Partilhamos dados estritamente necessários com: Stripe (processamento de pagamentos), o fornecedor de alojamento da aplicação, e o fornecedor de envio de emails transacionais. Todos os subcontratantes estão contratualmente obrigados a proteger os seus dados nos termos do RGPD.",
+  },
+  {
+    number: "06",
+    title: "Transferências internacionais",
+    content:
+      "Alguns subcontratantes (nomeadamente a Stripe) podem processar dados fora do Espaço Económico Europeu. Nesses casos, garantimos que a transferência assenta em mecanismos reconhecidos pelo RGPD, como Cláusulas Contratuais-Tipo aprovadas pela Comissão Europeia.",
+  },
+  {
+    number: "07",
+    title: "Os seus direitos",
+    content:
+      "Tem direito a aceder, retificar, apagar e portar os seus dados, a opor-se e a limitar o tratamento, e a retirar o consentimento a qualquer momento sem afetar a licitude do tratamento anterior. Para exercer estes direitos, contacte-nos através de [TODO: email de contacto real]. Tem também direito a apresentar reclamação junto da Comissão Nacional de Proteção de Dados (CNPD) — www.cnpd.pt.",
+  },
+  {
+    number: "08",
+    title: "Cookies",
+    content:
+      "Para informação sobre os cookies e chaves de armazenamento local utilizados neste site, consulte a nossa Política de Cookies.",
+  },
+];
+
+export default function PrivacidadePage() {
+  return (
+    <div className={styles.page}>
+      <header className={`${styles.hero} full-section full-section-scroll`}>
+        <div className={styles.wrap}>
+          <div className={styles.eyebrow}>Proteção de dados</div>
+          <h1 className={`${styles.displayLg} ${styles.heroTitle}`}>Política de Privacidade</h1>
+          <div className={styles.heroDate}>
+            Última atualização: {new Date().toLocaleDateString("pt-PT")}
+          </div>
+        </div>
+      </header>
+
+      <section className={`${styles.section} full-section full-section-scroll`}>
+        <div className={styles.wrap}>
+          <div className={styles.sections}>
+            {sections.map((section) => (
+              <div key={section.number} className={styles.termSection}>
+                <div className={styles.termHeader}>
+                  <div className={styles.termNum}>{section.number}</div>
+                  <h2 className={styles.termTitle}>{section.title}</h2>
+                </div>
+                <p className={styles.termContent}>{section.content}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,8 +9,8 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      allow: ["/", "/about", "/o-curso", "/contact", "/termos-e-condicoes", "/login", "/account"],
-      disallow: ["/api", "/api-docs", "/dashboard", "/curso", "/checkout", "/reset-password", "/forgot-password"],
+      allow: ["/", "/about", "/o-curso", "/contact", "/termos-e-condicoes", "/privacidade", "/login"],
+      disallow: ["/api", "/api-docs", "/dashboard", "/curso", "/account", "/checkout", "/reset-password", "/forgot-password"],
     },
     sitemap: `${siteUrl}/sitemap.xml`,
   };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,8 +12,8 @@ const publicPaths = [
   { path: "/about", priority: 0.7, changeFrequency: "monthly" as const },
   { path: "/contact", priority: 0.6, changeFrequency: "monthly" as const },
   { path: "/login", priority: 0.4, changeFrequency: "yearly" as const },
-  { path: "/account", priority: 0.4, changeFrequency: "yearly" as const },
   { path: "/termos-e-condicoes", priority: 0.3, changeFrequency: "yearly" as const },
+  { path: "/privacidade", priority: 0.3, changeFrequency: "yearly" as const },
 ];
 
 export default function sitemap(): MetadataRoute.Sitemap {


### PR DESCRIPTION
…gais

- Skip link "Saltar para o conteúdo" + sistema global de :focus-visible (3px, border-radius: inherit) em vez de outline:none sem substituto.
- Menu mobile: aria-controls, aria-label dinâmico, fecho com Escape, focus trap, devolução de foco ao botão, inert no resto do conteúdo.
- /faq: um único <main> por documento (header/main internos passam a section); acordeão com h2 no botão, aria-controls/role="region".
- Formulários de contacto, login e registo: label/id ligados, autocomplete correto, região aria-live para estado, aria-busy no submit.
- robots noindex em /dashboard, /curso e /account (rotas privadas); removidas do sitemap.
- JSON-LD: Organization/WebSite no layout raiz, Course+Offer e BreadcrumbList em /o-curso, FAQPage (7 perguntas reais) e BreadcrumbList em /faq.
- Página 404 e 500 (global-error) personalizadas em português.
- Nova página /privacidade (RGPD) com dados legais ainda por confirmar marcados como TODO explícito.
- Remove a meta keywords (obsoleta para SEO moderno).