### PR TITLE
Fase 7 (pontos 59-62): testes E2E com Playwright + axe-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache
 
 # next.js
 /.next/

--- a/app/context/LanguageContext.tsx
+++ b/app/context/LanguageContext.tsx
@@ -15,26 +15,25 @@ const LanguageContext = createContext<LanguageContextType | undefined>(undefined
 const LANGUAGE_STORAGE_KEY = "clientemisterio_language";
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  // Começa sempre em "pt" — igual no servidor e no primeiro render do
+  // cliente, para não haver mismatch de hidratação. Se a preferência
+  // guardada for diferente, o efeito abaixo atualiza o estado depois do
+  // mount (um re-render normal, não uma trocas de tipo de elemento — o
+  // Provider é sempre o mesmo, para o React nunca desmontar/remontar
+  // cabeçalho, main e rodapé a cada carregamento de página).
   const [language, setLanguageState] = useState<Language>("pt");
-  const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY) as Language | null;
     if (stored && (stored === "pt" || stored === "en")) {
       setLanguageState(stored);
     }
-    setIsHydrated(true);
   }, []);
 
   const setLanguage = (lang: Language) => {
     setLanguageState(lang);
     localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
   };
-
-  // Avoid hydration issues by rendering nothing until client is hydrated
-  if (!isHydrated) {
-    return <>{children}</>;
-  }
 
   return (
     <LanguageContext.Provider value={{ language, setLanguage, t: getTranslation(language) }}>

--- a/app/cookies/page.module.css
+++ b/app/cookies/page.module.css
@@ -124,7 +124,7 @@
 }
 .termContent {
   font-size: 16px;
-  color: var(--on-brand-2);
+  color: var(--on-brand-3);
   line-height: 1.75;
   margin: 0;
   padding-left: 64px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,7 +26,9 @@
    =================================================================== */
 :root {
   /* --- Paleta base ------------------------------------------------ */
-  --color-red: #7c5cff;                /* Roxo vivo — acento sobre fundos claros/painéis, nunca superfície de página */
+  --color-red: #6a4ade;                /* Roxo — acento sobre fundos claros/painéis. ≥5,8:1 com branco/texto
+                                           em ambos os sentidos (WCAG AA) — mínimo recomendado no plano de
+                                           contraste; nunca superfície de página. */
   --color-red-2: #6d4ce6;              /* Roxo alternado — ritmo */
   --color-red-3: #5a3dc7;              /* Roxo profundo — pressed */
   --color-red-bright: #a78bfa;         /* Roxo vivo — acento sobre branco/preto */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,7 +47,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 5,
   userScalable: true,
-  themeColor: "#7c5cff",
+  themeColor: "#6a4ade",
 };
 
 // TODO: acrescentar `logo` (URL de imagem real) e `sameAs` (redes sociais

--- a/app/privacidade/page.module.css
+++ b/app/privacidade/page.module.css
@@ -124,7 +124,7 @@
 }
 .termContent {
   font-size: 16px;
-  color: var(--on-brand-2);
+  color: var(--on-brand-3);
   line-height: 1.75;
   margin: 0;
   padding-left: 64px;

--- a/app/sobre/page.module.css
+++ b/app/sobre/page.module.css
@@ -177,7 +177,7 @@
   border: 1px solid var(--hairline);
   border-radius: var(--radius-lg);
   font-size: 15px;
-  color: var(--on-brand-2);
+  color: var(--on-brand-3);
   line-height: 1.5;
   transition: border-color .2s, background .2s;
 }

--- a/app/termos-e-condicoes/page.module.css
+++ b/app/termos-e-condicoes/page.module.css
@@ -124,7 +124,7 @@
 }
 .termContent {
   font-size: 16px;
-  color: var(--on-brand-2);
+  color: var(--on-brand-3);
   line-height: 1.75;
   margin: 0;
   padding-left: 64px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "stripe": "^15.0.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -41,6 +43,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1232,6 +1247,22 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@react-email/render": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@react-email/render/-/render-2.0.7.tgz",
@@ -2417,9 +2448,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -3695,6 +3726,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -5548,6 +5594,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start -H 0.0.0.0 -p ${PORT:-3000}",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "^16.2.6",
@@ -18,6 +19,8 @@
     "stripe": "^15.0.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Configuração do Playwright para os testes E2E
+ * (Fase 7 do plano de acessibilidade/SEO). Sobe o servidor de produção
+ * (`npm run build && npm start`) e corre os testes contra localhost.
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+    // Evita que o axe-core capture cores a meio de transições/animações
+    // (ex.: fadeIn dos cartões de formulário) — o site já respeita
+    // prefers-reduced-motion nativamente (ver globals.css).
+    contextOptions: { reducedMotion: "reduce" },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH || "/opt/pw-browsers/chromium",
+        },
+      },
+    },
+  ],
+  webServer: {
+    command: "npm run start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Testes de acessibilidade (Fase 7, pontos 60-61):
+ * skip link, navegação por teclado no menu, e axe-core em todas as rotas
+ * públicas (zero violações críticas/sérias).
+ */
+
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+const publicRoutes = [
+  "/",
+  "/o-curso",
+  "/faq",
+  "/sobre",
+  "/contactos",
+  "/termos-e-condicoes",
+  "/privacidade",
+  "/cookies",
+  "/entrar",
+  "/criar-conta",
+];
+
+test.describe("Skip link", () => {
+  test("é o primeiro elemento focável e aponta para o conteúdo", async ({ page }) => {
+    await page.goto("/");
+    // Garante que é o documento (e não o browser) que tem o foco antes do
+    // primeiro Tab — evita falsos negativos em Chrome headless.
+    await page.evaluate(() => document.body.focus());
+    await page.keyboard.press("Tab");
+
+    const skipLink = page.locator(".skip-link");
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toHaveAttribute("href", "#conteudo");
+
+    await page.keyboard.press("Enter");
+    await expect(page.locator("#conteudo")).toBeVisible();
+  });
+});
+
+test.describe("Menu principal (mobile)", () => {
+  test.use({ viewport: { width: 375, height: 800 } });
+
+  test("abre com o botão, fecha com Escape e devolve o foco", async ({ page }) => {
+    await page.goto("/");
+
+    // Seletor estável: o aria-label muda dinamicamente ("Abrir" <-> "Fechar")
+    // consoante o estado, por desenho — não pode ser usado como localizador.
+    const toggle = page.locator(".menu-toggle-button");
+    await expect(toggle).toHaveAttribute("aria-label", "Abrir menu principal");
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByRole("navigation", { name: "Menu principal mobile" })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(toggle).toBeFocused();
+  });
+
+  test("fecha ao clicar fora", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Abrir menu principal" }).click();
+    await expect(page.getByRole("navigation", { name: "Menu principal mobile" })).toBeVisible();
+
+    await page.mouse.click(10, 10);
+
+    await expect(page.getByRole("navigation", { name: "Menu principal mobile" })).toBeHidden();
+  });
+});
+
+for (const route of publicRoutes) {
+  test(`axe: ${route} não tem violações críticas ou sérias`, async ({ page }) => {
+    await page.goto(route);
+
+    const results = await new AxeBuilder({ page })
+      .include("body")
+      .analyze();
+
+    const seriousOrCritical = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical"
+    );
+
+    expect(
+      seriousOrCritical,
+      seriousOrCritical.map((v) => `${v.id}: ${v.description}`).join("\n")
+    ).toEqual([]);
+  });
+}

--- a/tests/e2e/forms.spec.ts
+++ b/tests/e2e/forms.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Testes do formulário de contacto (Fase 7, ponto
+ * 60): validação nativa, envio com sucesso e com erro, e anúncio por
+ * aria-live. Intercepta /api/contact para não depender de base de dados.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Formulário de contacto", () => {
+  test("impede o envio com campos obrigatórios vazios (validação nativa)", async ({ page }) => {
+    await page.goto("/contactos");
+
+    const emailInput = page.locator("#contact-email");
+    await page.locator("#contact-name").fill("Ana Teste");
+    // Deixa o email vazio propositadamente.
+    await page.getByRole("button", { name: /enviar mensagem/i }).click();
+
+    const isValid = await emailInput.evaluate((el: HTMLInputElement) => el.checkValidity());
+    expect(isValid).toBe(false);
+  });
+
+  test("mostra mensagem de sucesso numa região aria-live", async ({ page }) => {
+    await page.route("**/api/contact", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Mensagem enviada com sucesso!", reference: "TEST-1" }),
+      });
+    });
+
+    await page.goto("/contactos");
+    await page.locator("#contact-name").fill("Ana Teste");
+    await page.locator("#contact-email").fill("ana@example.com");
+    await page.locator("#contact-subject").fill("Dúvida sobre o curso");
+    await page.locator("#contact-message").fill("Mensagem de teste automatizado.");
+
+    const statusRegion = page.locator('[role="status"][aria-live="polite"]');
+    await page.getByRole("button", { name: /enviar mensagem/i }).click();
+
+    await expect(statusRegion).toContainText("Mensagem enviada com sucesso!");
+  });
+
+  test("mostra erro sem perder o texto escrito", async ({ page }) => {
+    await page.route("**/api/contact", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Não foi possível enviar a sua mensagem." }),
+      });
+    });
+
+    await page.goto("/contactos");
+    await page.locator("#contact-name").fill("Ana Teste");
+    await page.locator("#contact-email").fill("ana@example.com");
+    await page.locator("#contact-subject").fill("Dúvida sobre o curso");
+    await page.locator("#contact-message").fill("Mensagem que não se pode perder.");
+
+    await page.getByRole("button", { name: /enviar mensagem/i }).click();
+
+    await expect(page.locator('[role="status"][aria-live="polite"]')).toContainText(
+      "Não foi possível enviar a sua mensagem."
+    );
+    // O texto escrito continua no formulário — não há reset em caso de erro.
+    await expect(page.locator("#contact-message")).toHaveValue("Mensagem que não se pode perder.");
+  });
+});
+
+test.describe("Acordeão da FAQ", () => {
+  test("aria-expanded e aria-controls ligam pergunta e painel", async ({ page }) => {
+    await page.goto("/faq");
+
+    const firstButton = page.locator('[id^="faq-question-"]').first();
+    const panelId = await firstButton.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+
+    await expect(firstButton).toHaveAttribute("aria-expanded", "true");
+    await firstButton.click();
+    await expect(firstButton).toHaveAttribute("aria-expanded", "false");
+
+    const panel = page.locator(`#${panelId}`);
+    await expect(panel).toHaveAttribute("role", "region");
+  });
+});

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Teste de regressão do bug de layout da Fase 0
+ * (ponto 3): garante que nenhum texto fica cortado pelo rodapé e que não
+ * existe scrollbar interna, em três resoluções de referência.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const viewports = [
+  { name: "mobile", width: 360, height: 640 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1440, height: 900 },
+];
+
+const routes = ["/", "/o-curso", "/faq", "/contactos"];
+
+for (const viewport of viewports) {
+  for (const route of routes) {
+    test(`${route} @ ${viewport.name} (${viewport.width}x${viewport.height}): rodapé só aparece no fim, sem scroll interno`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(route);
+
+      // O rodapé é um elemento normal do fluxo (não fixed/sticky) e tem de
+      // estar visível ao fazer scroll até ao fim do documento. Espera a
+      // hidratação assentar antes de interagir, para não apanhar o
+      // elemento a meio de uma re-renderização.
+      const footer = page.locator("footer");
+      await expect(footer).toBeAttached();
+      await footer.scrollIntoViewIfNeeded();
+      await expect(footer).toBeVisible();
+
+      // Nenhum elemento interno (main, secções) deve ter a sua própria
+      // scrollbar vertical — o scroll é sempre da página.
+      const internalScrollers = await page.evaluate(() => {
+        const candidates = Array.from(document.querySelectorAll("main, main > *, section"));
+        return candidates
+          .filter((el) => {
+            const style = window.getComputedStyle(el);
+            return (
+              (style.overflowY === "auto" || style.overflowY === "scroll") &&
+              el.scrollHeight > el.clientHeight + 1
+            );
+          })
+          .map((el) => el.className);
+      });
+
+      expect(internalScrollers).toEqual([]);
+
+      // O rodapé tem de estar depois do último bloco de conteúdo do <main>,
+      // nunca sobreposto a ele.
+      const footerBox = await footer.boundingBox();
+      const mainBox = await page.locator("main").boundingBox();
+      expect(footerBox).not.toBeNull();
+      expect(mainBox).not.toBeNull();
+      if (footerBox && mainBox) {
+        expect(footerBox.y).toBeGreaterThanOrEqual(mainBox.y + mainBox.height - 1);
+      }
+    });
+  }
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@playwright/test", "node"]
+  },
+  "include": ["**/*.ts", "../playwright.config.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests/**", "playwright.config.ts"]
 }


### PR DESCRIPTION
- Adiciona @playwright/test e @axe-core/playwright (devDependencies) e tests/e2e/ com três suites:
  - accessibility.spec.ts: skip link, menu mobile (abrir/fechar com Escape, fechar ao clicar fora, foco devolvido ao botão) e axe-core em todas as rotas públicas (zero violações críticas/sérias).
  - forms.spec.ts: validação nativa do formulário de contacto, sucesso e erro sem perder o texto escrito (aria-live), acordeão da FAQ (aria-expanded/aria-controls/role=region).
  - layout.spec.ts: teste de regressão do bug da Fase 0 (rodapé nunca corta conteúdo, sem scroll interno) em 360x640/768x1024/1440x900.

Os testes apanharam três bugs reais, agora corrigidos:
- --color-red (#7c5cff) só atingia 4,34:1 como texto/fundo de botão em painéis brancos (ex. "Entrar", "Criar Conta") — abaixo do mínimo AA de 4,5:1. Escurecido para #6a4ade (o mínimo já recomendado no plano), que dá >=5,8:1 em ambos os sentidos.
- LanguageProvider trocava de <Fragment> para <Context.Provider> assim que a hidratação terminava — tipos de elemento diferentes na mesma posição da árvore forçam o React a desmontar e remontar TODA a página (cabeçalho, main, rodapé) a cada carregamento. Corrigido para renderizar sempre o mesmo Provider, só o valor muda.
- Texto de corpo (--on-brand-2) sobre painéis translúcidos (rgba(255,255,255,.07), usados em /termos-e-condicoes, /privacidade, /cookies e /sobre) ficava a 4,47:1 — o painel clareia o fundo efetivo o suficiente para cair abaixo de 4,5:1. Trocado para --on-brand-3 nesses blocos.