### PR TITLE
Fase 5 (ponto 41): reestrutura a homepage segundo o funil do plano

### DIFF
--- a/app/lib/translations.ts
+++ b/app/lib/translations.ts
@@ -14,13 +14,14 @@ export const translations = {
       logout: "Terminar Sessão",
       dashboard: "Dashboard",
     },
-    // Home Page — ecrã único: proposta de valor + os três passos do processo.
+    // Home Page
     home: {
       badge: "Curso de Cliente Mistério em Portugal",
       titleLine1: "Avalia lojas.",
       titleLine2: "Recebe dinheiro",
       subtitle: "Transforma o teu tempo livre numa oportunidade real. Torna-te cliente mistério e começa hoje.",
       valueProp: "Ganha entre 5€ e 150€ por missão",
+      heroGuarantee: "24,99€ · pagamento único · 14 dias de reembolso",
       ctaPrimary: "Quero começar",
       ctaSecondary: "Saber mais",
       step1: "Inscreve-te no curso",
@@ -29,6 +30,27 @@ export const translations = {
       step2Desc: "Aprende o método ao teu ritmo, com casos reais, checklists e um quiz no fim de cada módulo.",
       step3: "Acesso a todas as missões das várias empresas em Portugal",
       step3Desc: "Candidata-te às missões disponíveis e recebe o pagamento assim que o relatório é aprovado.",
+
+      modulesEyebrow: "O que vais aprender",
+      modulesTitle: "10 módulos, do zero à primeira missão paga.",
+      modulesSub: "Teoria paginada, casos reais comentados e um quiz no fim de cada módulo.",
+      modulesCta: "Ver o programa completo",
+
+      socialProofEyebrow: "Quem já está a fazer isto",
+      socialProofTitle: "[TODO: prova social real — número de alunos, avaliações e testemunhos verificáveis]",
+      socialProofDesc: "[TODO: substituir por testemunhos reais, identificados e com indicação de como foram recolhidos]",
+
+      pricingEyebrow: "Preço",
+      pricingTitle: "Um pagamento. Acesso para sempre.",
+      pricingCta: "Quero começar",
+
+      faqEyebrow: "Perguntas frequentes",
+      faqTitle: "Ainda tens dúvidas?",
+      faqCta: "Ver todas as perguntas",
+
+      finalCtaTitle: "A tua primeira missão paga começa aqui.",
+      finalCtaDesc: "Compras uma vez, aprendes ao teu ritmo e candidatas-te às missões assim que estiveres pronto.",
+      finalCtaButton: "Quero começar",
     },
 
     // About Page
@@ -547,6 +569,7 @@ export const translations = {
       titleLine2: "Get paid",
       subtitle: "Turn your free time into a real opportunity. Become a mystery shopper and start today.",
       valueProp: "Earn between €5 and €150 per mission",
+      heroGuarantee: "€24.99 · one-time payment · 14-day refund",
       ctaPrimary: "Get started",
       ctaSecondary: "Learn more",
       step1: "Sign up for the course",
@@ -555,6 +578,27 @@ export const translations = {
       step2Desc: "Learn the method at your own pace, with real cases, checklists and a quiz after each module.",
       step3: "Access every mission from companies across Portugal",
       step3Desc: "Apply to available missions and get paid as soon as your report is approved.",
+
+      modulesEyebrow: "What you'll learn",
+      modulesTitle: "10 modules, from zero to your first paid mission.",
+      modulesSub: "Paginated theory, real cases and a quiz at the end of each module.",
+      modulesCta: "See the full program",
+
+      socialProofEyebrow: "Who's already doing this",
+      socialProofTitle: "[TODO: real social proof — student count, ratings and verifiable testimonials]",
+      socialProofDesc: "[TODO: replace with real testimonials, identified, with a note on how they were collected]",
+
+      pricingEyebrow: "Pricing",
+      pricingTitle: "One payment. Access forever.",
+      pricingCta: "Get started",
+
+      faqEyebrow: "Frequently asked questions",
+      faqTitle: "Still have questions?",
+      faqCta: "See all questions",
+
+      finalCtaTitle: "Your first paid mission starts here.",
+      finalCtaDesc: "Pay once, learn at your own pace, and apply to missions as soon as you're ready.",
+      finalCtaButton: "Get started",
     },
 
     // About Page

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -367,6 +367,266 @@
 }
 
 /* ============================================================
+   SECÇÕES ADICIONAIS DA HOMEPAGE (ponto 41)
+   O que aprendes · Prova social · Preço · FAQ curto · CTA final.
+   Reaproveitam os tokens e o ritmo `full-section` já usados no
+   resto do site (o-curso, faq, contactos).
+   ============================================================ */
+.section {
+  padding: clamp(20px, 6vh, 64px) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+@media (min-width: 768px) {
+  .section { padding: clamp(28px, 8vh, 96px) 0; }
+}
+
+.sectionInner {
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 var(--sp-md);
+}
+@media (min-width: 768px) {
+  .sectionInner { padding: 0 var(--sp-xl); }
+}
+
+.sectionHead {
+  max-width: 640px;
+  margin: 0 auto clamp(24px, 5vh, 48px);
+  text-align: center;
+}
+.sectionTitle {
+  font-family: var(--font-display);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--color-white);
+  font-size: clamp(24px, 3.4vw, 38px);
+  margin: 0 0 12px;
+}
+.sectionSub {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--on-brand-2);
+  margin: 0;
+}
+.sectionHead .eyebrow { justify-content: center; }
+.socialProofPlaceholder {
+  font-size: 13px;
+  font-style: italic;
+  line-height: 1.6;
+  color: var(--on-brand-3);
+  margin: 0 0 6px;
+}
+
+.sectionLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: clamp(20px, 4vh, 36px) auto 0;
+  color: var(--color-white);
+  font-weight: 700;
+  font-size: 15px;
+  text-decoration: none;
+  transition: opacity 200ms ease;
+}
+.sectionLink:hover { opacity: 0.75; }
+.sectionLink svg { width: 16px; height: 16px; }
+.section > .sectionInner > .sectionLink {
+  display: flex;
+  justify-content: center;
+}
+
+/* ---------- O que aprendes ---------- */
+.modulesGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+@media (min-width: 640px) {
+  .modulesGrid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .modulesGrid { grid-template-columns: repeat(2, 1fr); gap: 12px; }
+}
+.moduleCard {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+}
+.moduleCardNum {
+  flex-shrink: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--on-brand-3);
+}
+.moduleCardTitle {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--color-white);
+  line-height: 1.4;
+}
+
+/* ---------- Preço ---------- */
+.priceCard {
+  max-width: 480px;
+  margin: 0 auto;
+  background: var(--panel-invert-bg);
+  color: var(--on-invert);
+  border-radius: var(--radius-xl);
+  padding: 32px;
+  box-shadow: var(--shadow-lg);
+  text-align: center;
+}
+.priceEyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--link-accent);
+  margin: 0 0 8px;
+}
+.priceTitle {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--on-invert);
+  margin: 0 0 20px;
+}
+.priceRow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+.priceAmount {
+  font-family: var(--font-display);
+  font-size: 44px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--on-invert);
+}
+.priceMeta {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--on-invert-3);
+}
+.priceUrgency {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--link-accent);
+  margin: 0 0 20px;
+}
+.priceFeatures {
+  list-style: none;
+  margin: 0 0 24px;
+  padding: 20px 0 0;
+  border-top: 1px solid var(--hairline-invert);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-align: left;
+}
+.priceFeatures li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--on-invert-2);
+}
+.priceFeatures svg {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  padding: 3px;
+  border-radius: 50%;
+  background: var(--color-red);
+  color: var(--color-white);
+}
+.priceCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 48px;
+  padding: 14px 24px;
+  border-radius: var(--radius-md);
+  background: var(--color-red);
+  color: var(--color-white);
+  font-weight: 700;
+  font-size: 15px;
+  text-decoration: none;
+  box-shadow: 0 4px 14px rgba(124, 92, 255, 0.28);
+  transition: all 200ms ease;
+}
+.priceCta:hover { background: var(--color-red-2); transform: translateY(-2px); }
+.priceCta svg { width: 16px; height: 16px; }
+.priceSecure {
+  font-size: 11.5px;
+  color: var(--on-invert-3);
+  margin: 14px 0 0;
+}
+
+/* ---------- FAQ curto ---------- */
+.faqList {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin: 0;
+  max-width: 680px;
+  margin-inline: auto;
+}
+.faqItem {
+  border-bottom: 1px solid var(--hairline);
+  padding-bottom: 18px;
+}
+.faqQ {
+  font-size: 15.5px;
+  font-weight: 700;
+  color: var(--color-white);
+  margin: 0 0 6px;
+}
+.faqA {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--on-brand-2);
+  margin: 0;
+}
+
+/* ---------- CTA final ---------- */
+.finalCta {
+  max-width: 560px;
+  margin: 0 auto;
+  text-align: center;
+}
+.finalCtaTitle {
+  font-family: var(--font-display);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--color-white);
+  font-size: clamp(26px, 4vw, 42px);
+  margin: 0 0 14px;
+}
+.finalCtaDesc {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--on-brand-2);
+  margin: 0 0 28px;
+}
+
+/* ============================================================
    ECRÃS BAIXOS — telemóveis pequenos, em que o total ainda não
    coubesse com as regras acima; comprime mais um nível.
    ============================================================ */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,24 @@
 import Link from "next/link";
 import { useLanguage } from "@/app/context/LanguageContext";
 import { useCourseAccess } from "@/app/lib/useCourseAccess";
+import { courseModules } from "./curso/courseData";
+import { faqs } from "./faq/faqData";
 import styles from "./page.module.css";
+
+const CheckIcon = ({ size = 11 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const ArrowIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <path d="M5 12h14M13 6l6 6-6 6" />
+  </svg>
+);
+
+/* As 4 perguntas mais representativas da FAQ, uma por tema. */
+const homeFaqSlugs = ["duracao", "pagamento", "legalidade", "certificado"];
 
 /* ---------- Ícones dos nós do processo ---------- */
 const StepIcons = [
@@ -66,6 +83,7 @@ export default function HomePage() {
               </span>
             </h1>
             <p className={styles.subtitle}>{t.home.subtitle}</p>
+            <p className={styles.valueProp}>{t.home.heroGuarantee}</p>
 
             <div className={styles.ctaRow}>
               <Link href={primaryCta.href} className={styles.ctaPrimary}>
@@ -138,6 +156,128 @@ export default function HomePage() {
               </li>
             ))}
           </ol>
+        </div>
+      </section>
+
+      {/* ----------------------------------------------------------
+          O QUE APRENDES — grelha resumida dos 10 módulos
+          ---------------------------------------------------------- */}
+      <section className={`${styles.section} full-section full-section-scroll`}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionHead}>
+            <p className={styles.eyebrow}>{t.home.modulesEyebrow}</p>
+            <h2 className={styles.sectionTitle}>{t.home.modulesTitle}</h2>
+            <p className={styles.sectionSub}>{t.home.modulesSub}</p>
+          </div>
+          <div className={styles.modulesGrid}>
+            {courseModules
+              .filter((m) => m.id <= 10)
+              .map((module) => (
+                <div key={module.id} className={styles.moduleCard}>
+                  <span className={styles.moduleCardNum}>{String(module.id).padStart(2, "0")}</span>
+                  <span className={styles.moduleCardTitle}>{module.title}</span>
+                </div>
+              ))}
+          </div>
+          <Link href="/o-curso" className={styles.sectionLink}>
+            {t.home.modulesCta}
+            <ArrowIcon />
+          </Link>
+        </div>
+      </section>
+
+      {/* ----------------------------------------------------------
+          PROVA SOCIAL — por preencher com dados reais e verificáveis
+          (ponto 48/58 do plano: nunca inventar números de alunos ou
+          avaliações).
+          ---------------------------------------------------------- */}
+      <section className={`${styles.section} full-section full-section-scroll`}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionHead}>
+            <p className={styles.eyebrow}>{t.home.socialProofEyebrow}</p>
+            <p className={styles.socialProofPlaceholder}>{t.home.socialProofTitle}</p>
+            <p className={styles.socialProofPlaceholder}>{t.home.socialProofDesc}</p>
+          </div>
+        </div>
+      </section>
+
+      {/* ----------------------------------------------------------
+          PREÇO — reaproveita os valores já usados em /o-curso
+          ---------------------------------------------------------- */}
+      <section className={`${styles.section} full-section full-section-scroll`}>
+        <div className={styles.sectionInner}>
+          <div className={styles.priceCard}>
+            <p className={styles.priceEyebrow}>{t.home.pricingEyebrow}</p>
+            <h2 className={styles.priceTitle}>{t.home.pricingTitle}</h2>
+            <div className={styles.priceRow}>
+              <span className={styles.priceAmount}>{t.coursePage.pricingPrice}</span>
+              <span className={styles.priceMeta}>
+                {t.coursePage.pricingPayment} · {t.coursePage.pricingLifetime}
+              </span>
+            </div>
+            <p className={styles.priceUrgency}>{t.coursePage.pricingUrgency}</p>
+            <ul className={styles.priceFeatures}>
+              {[
+                t.coursePage.pricingFeature1,
+                t.coursePage.pricingFeature2,
+                t.coursePage.pricingFeature3,
+              ].map((feature) => (
+                <li key={feature}>
+                  <CheckIcon />
+                  {feature}
+                </li>
+              ))}
+            </ul>
+            <Link href={primaryCta.href} className={styles.priceCta}>
+              {t.home.pricingCta}
+              <ArrowIcon />
+            </Link>
+            <p className={styles.priceSecure}>{t.coursePage.paymentSecure}</p>
+          </div>
+        </div>
+      </section>
+
+      {/* ----------------------------------------------------------
+          FAQ CURTO — 4 perguntas + link para a FAQ completa
+          ---------------------------------------------------------- */}
+      <section className={`${styles.section} full-section full-section-scroll`}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionHead}>
+            <p className={styles.eyebrow}>{t.home.faqEyebrow}</p>
+            <h2 className={styles.sectionTitle}>{t.home.faqTitle}</h2>
+          </div>
+          <dl className={styles.faqList}>
+            {homeFaqSlugs.map((slug) => {
+              const item = faqs.find((f) => f.slug === slug);
+              if (!item) return null;
+              return (
+                <div key={slug} className={styles.faqItem}>
+                  <dt className={styles.faqQ}>{item.q}</dt>
+                  <dd className={styles.faqA}>{item.a}</dd>
+                </div>
+              );
+            })}
+          </dl>
+          <Link href="/faq" className={styles.sectionLink}>
+            {t.home.faqCta}
+            <ArrowIcon />
+          </Link>
+        </div>
+      </section>
+
+      {/* ----------------------------------------------------------
+          CTA FINAL
+          ---------------------------------------------------------- */}
+      <section className={`${styles.section} full-section full-section-scroll`}>
+        <div className={styles.sectionInner}>
+          <div className={styles.finalCta}>
+            <h2 className={styles.finalCtaTitle}>{t.home.finalCtaTitle}</h2>
+            <p className={styles.finalCtaDesc}>{t.home.finalCtaDesc}</p>
+            <Link href={primaryCta.href} className={styles.ctaPrimary}>
+              {t.home.finalCtaButton}
+              <ArrowIcon />
+            </Link>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
A homepage era só hero + "como funciona" (decisão deliberada de ecrã único de uma sessão anterior). Estende-a com as secções que faltavam, na ordem pedida pelo plano, sem tocar no hero/processo existentes:

1. Hero — acrescenta uma linha de reforço (24,99€ · pagamento único · 14 dias de reembolso) reaproveitando o pill ".valueProp" que já existia no CSS mas nunca chegou a ser usado.
2. Como funciona (inalterado).
3. O que aprendes — grelha resumida dos 10 módulos (só números e títulos, a partir de courseData — a mesma fonte de dados de /curso e /o-curso, nunca diverge).
4. Prova social — secção com placeholder `[TODO: ...]` explícito (título e descrição), como o resto do site já faz com dados que não posso inventar (contacto, legal). Estilo discreto de propósito — não é suposto parecer conteúdo publicado.
5. Preço — cartão reaproveitando os valores exatos já usados em /o-curso (24,99€, pagamento único, acesso vitalício, 14 dias de reembolso, Stripe), com CTA para o checkout/login.
6. FAQ curto — 4 perguntas (uma por tema) tiradas de faqData.ts, com link para a FAQ completa.
7. CTA final.

Nada de números novos inventados; tudo reaproveita factos já publicados noutras páginas do site.

Verificado com tsc --noEmit, build de produção, os 30 testes Playwright/axe-core (a suite mostrou instabilidade esporádica com 2 workers em paralelo neste sandbox por contenção de recursos — não regressão: --workers=1 fica sempre 30/30), uma verificação ad-hoc de axe-core com colorScheme:"dark" (0 violações — a primeira passagem apanhou 2, em .moduleCardNum e .priceEyebrow com var(--color-red)/ --color-red-bright em vez dos tokens já corrigidos --on-brand-3/ --link-accent) e screenshots de página inteira em claro, escuro e mobile (375px) para confirmar visualmente o layout.