### PR TITLE
Link authenticated user ID to Stripe checkout payments

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -31,27 +31,51 @@ const getPaymentIntentId = (paymentIntent: string | Stripe.PaymentIntent | null)
 
 type GrantResult = "granted" | "user_not_found";
 
-const grantCourseAccessByEmail = async (payload: {
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const findUserIdForPayment = async (
+  clientReferenceId: string | null,
+  customerEmail: string
+): Promise<string | null> => {
+  // client_reference_id é o identificador fiável (o próprio ID da conta, anexado ao link
+  // de pagamento no momento da compra) — o e-mail escrito no checkout do Stripe pode não
+  // coincidir com o da conta, por isso só serve como reserva para pagamentos antigos/manuais.
+  if (clientReferenceId && uuidPattern.test(clientReferenceId)) {
+    const byId = await query<{ id: string }>("select id from users where id = $1 limit 1", [
+      clientReferenceId,
+    ]);
+
+    if (byId.rows[0]?.id) {
+      return byId.rows[0].id;
+    }
+  }
+
+  const byEmail = await query<{ id: string }>(
+    "select id from users where lower(email) = $1 limit 1",
+    [customerEmail.toLowerCase()]
+  );
+
+  return byEmail.rows[0]?.id ?? null;
+};
+
+const grantCourseAccess = async (payload: {
   eventId: string;
   checkoutSessionId: string;
   paymentIntentId: string | null;
+  clientReferenceId: string | null;
   customerEmail: string;
   amountTotal: number;
   currency: string;
 }): Promise<GrantResult> => {
   // Atualiza o utilizador e regista a compra de forma idempotente para evitar duplicações.
-  const userResult = await query<{ id: string }>(
-    "select id from users where lower(email) = $1 limit 1",
-    [payload.customerEmail.toLowerCase()]
-  );
-
-  const userId = userResult.rows[0]?.id;
+  const userId = await findUserIdForPayment(payload.clientReferenceId, payload.customerEmail);
 
   if (!userId) {
     // Sem conta associada no momento do pagamento; regista alerta e confirma recepção ao Stripe.
     console.warn("STRIPE_WEBHOOK_USER_NOT_FOUND", {
       eventId: payload.eventId,
       checkoutSessionId: payload.checkoutSessionId,
+      clientReferenceId: payload.clientReferenceId,
       customerEmail: payload.customerEmail,
     });
     return "user_not_found";
@@ -132,10 +156,11 @@ export const POST = async (request: Request) => {
       }
 
       try {
-        const outcome = await grantCourseAccessByEmail({
+        const outcome = await grantCourseAccess({
           eventId: event.id,
           checkoutSessionId: session.id,
           paymentIntentId: getPaymentIntentId(session.payment_intent),
+          clientReferenceId: session.client_reference_id ?? null,
           customerEmail,
           amountTotal,
           currency,

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -4,26 +4,59 @@
 
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+
+import { buildCheckoutUrl } from "@/app/lib/checkoutLink";
+
+type SessionResponse = {
+  authenticated: boolean;
+  user?: { id: string; email: string };
+};
 
 export default function CheckoutPage() {
   const paymentLink = process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK;
+  const [checkoutUrl, setCheckoutUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    if (paymentLink) {
-      // Redireciona automaticamente para o Stripe Payment Link
-      window.location.href = paymentLink;
-    }
+    if (!paymentLink) return;
+
+    let isCancelled = false;
+
+    const redirectToCheckout = async () => {
+      // Liga o pagamento à conta autenticada (client_reference_id) antes de redirecionar.
+      let url = paymentLink;
+      try {
+        const response = await fetch("/api/auth/session", { cache: "no-store" });
+        const data = response.ok ? ((await response.json()) as SessionResponse) : { authenticated: false };
+        if (data.authenticated && data.user) {
+          url = buildCheckoutUrl(paymentLink, data.user);
+        }
+      } catch {
+        // Mantém o link base do Stripe se a sessão não puder ser confirmada.
+      }
+
+      if (isCancelled) return;
+      setCheckoutUrl(url);
+      window.location.href = url;
+    };
+
+    redirectToCheckout();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [paymentLink]);
+
+  const fallbackHref = checkoutUrl ?? paymentLink;
 
   return (
     <div className="full-section flex items-center justify-center">
       <div className="text-center space-y-4">
         <h1 className="text-xl font-semibold home-title-highlight-text">Redirecionando para pagamento...</h1>
         <p className="text-sm sm:text-base leading-6 sm:leading-7">Se não for redirecionado automaticamente,</p>
-        {paymentLink && (
+        {fallbackHref && (
           <a
-            href={paymentLink}
+            href={fallbackHref}
             className="submit inline-block max-w-sm text-center !no-underline"
           >
             clique aqui

--- a/app/components/CheckoutButton.tsx
+++ b/app/components/CheckoutButton.tsx
@@ -7,11 +7,18 @@
 import { useRouter } from "next/navigation";
 import React from "react";
 
+import { buildCheckoutUrl } from "@/app/lib/checkoutLink";
+
 interface CheckoutButtonProps {
   label?: React.ReactNode;
   className?: string;
   variant?: "primary" | "secondary";
 }
+
+type SessionResponse = {
+  authenticated: boolean;
+  user?: { id: string; email: string };
+};
 
 export default function CheckoutButton({
   label = "Comprar Curso",
@@ -34,9 +41,9 @@ export default function CheckoutButton({
     // decidir entre ir para o Stripe ou pedir login.
     try {
       const response = await fetch("/api/auth/session", { cache: "no-store" });
-      const data = response.ok ? ((await response.json()) as { authenticated: boolean }) : { authenticated: false };
-      if (data.authenticated) {
-        window.location.href = paymentLink;
+      const data = response.ok ? ((await response.json()) as SessionResponse) : { authenticated: false };
+      if (data.authenticated && data.user) {
+        window.location.href = buildCheckoutUrl(paymentLink, data.user);
       } else {
         router.push("/entrar?checkout=1");
       }

--- a/app/lib/checkoutLink.ts
+++ b/app/lib/checkoutLink.ts
@@ -1,0 +1,17 @@
+/*
+ * DESCRIÇÃO DO FICHEIRO: Constrói o URL do Payment Link do Stripe já associado à conta autenticada.
+ */
+
+type CheckoutUser = {
+  id: string;
+  email: string;
+};
+
+export const buildCheckoutUrl = (paymentLink: string, user: CheckoutUser): string => {
+  // client_reference_id liga o pagamento à conta de forma fiável no webhook — o e-mail
+  // escrito no checkout do Stripe pode ser diferente do e-mail da conta.
+  const url = new URL(paymentLink);
+  url.searchParams.set("client_reference_id", user.id);
+  url.searchParams.set("prefilled_email", user.email);
+  return url.toString();
+};

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -7,7 +7,13 @@ import { useRouter } from "next/navigation";
 import { courseModules as courseData } from "../curso/courseData";
 import { expandedModuleData } from "../curso/courseDataExpanded";
 import { useCourseAccess } from "@/app/lib/useCourseAccess";
+import { buildCheckoutUrl } from "@/app/lib/checkoutLink";
 import styles from "./page.module.css";
+
+type SessionResponse = {
+  authenticated: boolean;
+  user?: { id: string; email: string };
+};
 
 const CheckIcon = ({ size = 11 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -38,8 +44,8 @@ function BuyButton({ children, className }: { children: React.ReactNode; classNa
     // decidir entre ir para o Stripe ou pedir login.
     try {
       const response = await fetch("/api/auth/session", { cache: "no-store" });
-      const data = response.ok ? ((await response.json()) as { authenticated: boolean }) : { authenticated: false };
-      if (data.authenticated) { window.location.href = paymentLink; }
+      const data = response.ok ? ((await response.json()) as SessionResponse) : { authenticated: false };
+      if (data.authenticated && data.user) { window.location.href = buildCheckoutUrl(paymentLink, data.user); }
       else { router.push("/entrar?checkout=1"); }
     } catch {
       router.push("/entrar?checkout=1");


### PR DESCRIPTION
## Summary
This PR enhances the checkout flow to reliably associate payments with authenticated user accounts by passing the user ID as `client_reference_id` to Stripe, enabling proper access grant logic in the webhook handler.

## Key Changes

- **New utility module** (`app/lib/checkoutLink.ts`): Created `buildCheckoutUrl()` function that constructs Stripe Payment Link URLs with `client_reference_id` (user ID) and `prefilled_email` query parameters
  
- **Checkout page refactor** (`app/checkout/page.tsx`): 
  - Added session fetching to retrieve authenticated user data before redirecting to Stripe
  - Builds checkout URL with user context when available
  - Implements cleanup logic to prevent state updates after unmount
  
- **Webhook handler enhancement** (`app/stripe/webhook/route.ts`):
  - Introduced `findUserIdForPayment()` function that prioritizes `client_reference_id` (reliable user ID) over email lookup
  - Renamed `grantCourseAccessByEmail()` to `grantCourseAccess()` to reflect broader lookup strategy
  - Added UUID validation pattern to ensure `client_reference_id` is a valid user ID
  - Includes `clientReferenceId` in warning logs for debugging
  
- **Checkout button updates** (`CheckoutButton.tsx`, `o-curso/page.tsx`):
  - Updated to use `buildCheckoutUrl()` when user is authenticated
  - Consistent session response typing across components

## Implementation Details

The solution implements a two-tier user identification strategy in the webhook:
1. **Primary**: Uses `client_reference_id` (the authenticated user's ID attached at checkout time) - most reliable
2. **Fallback**: Looks up user by email from Stripe checkout - handles legacy/manual payments

This approach ensures that even if a user enters a different email during Stripe checkout, the payment is correctly attributed to their account via the `client_reference_id` parameter.

https://claude.ai/code/session_018QPxbcF8W8D31dq5KZDrKx