### PR TITLE
Remove homepage social proof TODO placeholder section

### DIFF
--- a/app/lib/translations.ts
+++ b/app/lib/translations.ts
@@ -36,10 +36,6 @@ export const translations = {
       modulesSub: "Teoria paginada, casos reais comentados e um quiz no fim de cada módulo.",
       modulesCta: "Ver o programa completo",
 
-      socialProofEyebrow: "Quem já está a fazer isto",
-      socialProofTitle: "[TODO: prova social real — número de alunos, avaliações e testemunhos verificáveis]",
-      socialProofDesc: "[TODO: substituir por testemunhos reais, identificados e com indicação de como foram recolhidos]",
-
       pricingEyebrow: "Preço",
       pricingTitle: "Um pagamento. Acesso para sempre.",
       pricingCta: "Quero começar",
@@ -585,10 +581,6 @@ export const translations = {
       modulesTitle: "10 modules, from zero to your first paid mission.",
       modulesSub: "Paginated theory, real cases and a quiz at the end of each module.",
       modulesCta: "See the full program",
-
-      socialProofEyebrow: "Who's already doing this",
-      socialProofTitle: "[TODO: real social proof — student count, ratings and verifiable testimonials]",
-      socialProofDesc: "[TODO: replace with real testimonials, identified, with a note on how they were collected]",
 
       pricingEyebrow: "Pricing",
       pricingTitle: "One payment. Access forever.",

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -368,7 +368,7 @@
 
 /* ============================================================
    SECÇÕES ADICIONAIS DA HOMEPAGE (ponto 41)
-   O que aprendes · Prova social · Preço · FAQ curto · CTA final.
+   O que aprendes · Preço · FAQ curto · CTA final.
    Reaproveitam os tokens e o ritmo `full-section` já usados no
    resto do site (o-curso, faq, contactos).
    ============================================================ */
@@ -413,13 +413,6 @@
   margin: 0;
 }
 .sectionHead .eyebrow { justify-content: center; }
-.socialProofPlaceholder {
-  font-size: 13px;
-  font-style: italic;
-  line-height: 1.6;
-  color: var(--on-brand-3);
-  margin: 0 0 6px;
-}
 
 .sectionLink {
   display: inline-flex;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -187,21 +187,6 @@ export default function HomePage() {
       </section>
 
       {/* ----------------------------------------------------------
-          PROVA SOCIAL — por preencher com dados reais e verificáveis
-          (ponto 48/58 do plano: nunca inventar números de alunos ou
-          avaliações).
-          ---------------------------------------------------------- */}
-      <section className={`${styles.section} full-section full-section-scroll`}>
-        <div className={styles.sectionInner}>
-          <div className={styles.sectionHead}>
-            <p className={styles.eyebrow}>{t.home.socialProofEyebrow}</p>
-            <p className={styles.socialProofPlaceholder}>{t.home.socialProofTitle}</p>
-            <p className={styles.socialProofPlaceholder}>{t.home.socialProofDesc}</p>
-          </div>
-        </div>
-      </section>
-
-      {/* ----------------------------------------------------------
           PREÇO — reaproveita os valores já usados em /o-curso
           ---------------------------------------------------------- */}
       <section className={`${styles.section} full-section full-section-scroll`}>


### PR DESCRIPTION
The section only rendered unresolved [TODO] strings for student
counts/testimonials that were never backed by real, verifiable data.
Removed the section, its translations (pt/en), and the now-unused
socialProofPlaceholder CSS class per STYLEGUIDE.md's rule against
publishing invented marketing claims.