### PR TITLE
Adiciona verificação de propriedade da Google Search Console

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,6 +38,9 @@ export const metadata: Metadata = {
     follow: true,
     googleBot: { index: true, follow: true, "max-image-preview": "large", "max-snippet": -1 },
   },
+  verification: {
+    google: "946WmJk7qBDHfJStYqlqEyuY-Yj5zYnLHpuv0cKmxf4",
+  },
   icons: {
     icon: "/favicon.ico",
     apple: "/apple-touch-icon.png",


### PR DESCRIPTION
Tag de verificação via prefixo de URL (https://clientemisterio.com), já que o domínio foi comprado através do Railway e não há acesso direto ao registador subjacente (Name.com) para verificação por DNS.


Claude-Session: https://claude.ai/code/session_01QLEJKUmvNCTiPJekWup61P