### PR TITLE
Corrige problemas de responsividade mobile: cabeçalho, lista de módulos e overflow

### DIFF
--- a/app/contactos/page.module.css
+++ b/app/contactos/page.module.css
@@ -119,6 +119,7 @@
   align-items: center;
   justify-content: center;
 }
+.infoText { min-width: 0; }
 .infoLabel {
   font-size: 11px;
   font-weight: 700;
@@ -127,7 +128,7 @@
   color: var(--on-brand-2);
   margin-bottom: 4px;
 }
-.infoValue { font-size: 16px; color: var(--color-white); line-height: 1.4; }
+.infoValue { font-size: 16px; color: var(--color-white); line-height: 1.4; overflow-wrap: anywhere; }
 .infoValue a { color: var(--color-white) !important; border-bottom: 1px solid rgba(255, 255, 255, 0.5); }
 .infoValue a:hover { opacity: .8; }
 

--- a/app/contactos/page.tsx
+++ b/app/contactos/page.tsx
@@ -150,7 +150,7 @@ export default function ContactPage() {
                       <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/>
                     </svg>
                   </div>
-                  <div>
+                  <div className={styles.infoText}>
                     <div className={styles.infoLabel}>{t.contact.emailLabel}</div>
                     <div className={styles.infoValue}>
                       <a href={`mailto:${t.contact.email}`}>{t.contact.email}</a>

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -311,9 +311,13 @@
 }
 .mod {
   display: grid;
-  grid-template-columns: 56px 1fr auto;
-  gap: 24px;
-  padding: 26px 0;
+  grid-template-columns: 40px 1fr;
+  grid-template-areas:
+    "num  body"
+    "meta meta";
+  column-gap: 14px;
+  row-gap: 10px;
+  padding: 18px 0;
   align-items: start;
   border-top: 1px solid var(--hairline);
   transition: background .25s, padding .25s;
@@ -321,6 +325,15 @@
   position: relative;
   width: 100%;
   text-align: left;
+}
+@media (min-width: 640px) {
+  .mod {
+    grid-template-columns: 56px 1fr auto;
+    grid-template-areas: "num body meta";
+    column-gap: 24px;
+    row-gap: 0;
+    padding: 26px 0;
+  }
 }
 .mod:last-of-type { border-bottom: 1px solid var(--hairline); }
 .mod:not(:disabled):hover { background: rgba(255, 255, 255, 0.08); padding-left: 16px; }
@@ -333,6 +346,7 @@
 .modLocked:hover { background: transparent; padding-left: 0; }
 
 .modNum {
+  grid-area: num;
   font-family: var(--font-display);
   font-weight: 700;
   font-size: 24px;
@@ -342,13 +356,14 @@
 }
 .modDone .modNum { color: var(--color-white); }
 .modCurrent .modNum { color: var(--color-white); }
-.modBody { min-width: 0; }
+.modBody { grid-area: body; min-width: 0; }
 .modTitle {
   font-size: clamp(15px, 1.4vw, 18px);
   font-weight: 700;
   letter-spacing: -0.025em;
   color: var(--color-white);
   margin: 0 0 5px;
+  overflow-wrap: break-word;
 }
 .modDesc {
   font-size: 14px;
@@ -357,12 +372,19 @@
   margin: 0;
   max-width: 68ch;
   text-wrap: pretty;
+  overflow-wrap: break-word;
 }
 .modMeta {
+  grid-area: meta;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 14px;
   padding-top: 2px;
+  padding-left: 54px;
+}
+@media (min-width: 640px) {
+  .modMeta { padding-left: 0; }
 }
 .modBadge {
   display: inline-flex;

--- a/app/globals.css
+++ b/app/globals.css
@@ -310,6 +310,19 @@ html {
     --color-gray-light: #383359;
     --color-bg-light: #221f38;
   }
+
+  /* O cabeçalho é o chrome fixo da marca, não um cartão de conteúdo — ao
+     contrário dos formulários/painéis acima, mantém-se sempre uma barra
+     branca nítida, para não ficar com um tom escurecido e dessaturado
+     desencontrado do roxo vivo do resto do site em modo escuro. */
+  .site-header.on-light {
+    --ink: #141416;
+    --muted: #74747e;
+    --line: #e7e7ea;
+    --line-strong: #cfcfd5;
+    --surface: var(--color-white);
+    --panel-strong: #ededf1;
+  }
 }
 
 @theme inline {


### PR DESCRIPTION
- Lista de módulos do curso (/curso): o badge de pontuação e a seta ficavam
  sobrepostos ao título em ecrãs estreitos, porque a grelha de 3 colunas
  espremia a coluna do título/descrição até a descrição quebrar palavra a
  palavra. Passa a empilhar em 2 linhas em mobile (número+título por cima,
  badge por baixo) e volta à grelha de 3 colunas original a partir dos 640px.
- Contactos: o endereço de email deixava a caixa branca e saía do ecrã em
  telemóveis pequenos, por o contentor flex não poder encolher abaixo do
  texto (sem espaços) do email. Agora encolhe e quebra normalmente.
- Cabeçalho: em modo escuro (comum em telemóveis), a barra de navegação
  herdava os tokens de painel escurecido e ficava com um tom dessaturado
  destoante do roxo vivo do resto do site. Fixa-se sempre como uma barra
  branca nítida, já que é chrome fixo da marca e não um cartão de conteúdo.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018hhzjdqzdniuJ4jZnewB6F