### PR TITLE
Add recruiting companies list and new course content pages

### DIFF
--- a/app/curso/courseData.ts
+++ b/app/curso/courseData.ts
@@ -23,6 +23,17 @@ export type CoursePage = {
  blocks: string[];
 };
 
+export type RecruitingCompany = {
+ name: string;
+ description: string;
+ url: string;
+};
+
+export type RecruitingCompanyGroup = {
+ category: string;
+ companies: RecruitingCompany[];
+};
+
 export type CourseModule = {
  id: number;
  title: string;
@@ -35,6 +46,7 @@ export type CourseModule = {
  warning?: string;
  benefit?: string;
  evaluationExamples?: EvaluationExample[];
+ recruitingCompanies?: RecruitingCompanyGroup[];
 };
 
 // Forma pública do módulo, sem a resposta certa de cada pergunta — é o que
@@ -231,6 +243,15 @@ export const courseModules: CourseModule[] = [
      "Exemplo real: missão de 25 €, 40 minutos de carro (ida e volta), 30 minutos de visita, 40 minutos de relatório. São quase duas horas e uns 6 € de combustível: rende cerca de 10 €/hora. Agora agrupa três missões na mesma zona no mesmo dia e o valor por hora quase duplica — o segredo nunca foi a missão, foi a **rota**.",
     ],
    },
+   {
+    title: "Página 4 — Do primeiro registo à escolha estratégica",
+    blocks: [
+     "Este mercado não tem uma única porta de entrada. Se nunca fizeste nada parecido, o objetivo do primeiro mês é simples: fechar o ciclo completo em missões pequenas — candidatar, executar, documentar, submeter, ser aprovado. Não persigas o honorário mais alto; persegue a primeira aprovação limpa.",
+     "Se já vens de uma área próxima — atendimento ao público, receção de hotel, auditoria de qualidade, gestão de loja — já trazes o olho treinado para reparar no que a maioria demora meses a notar. Isso encurta a curva de **observação**. Não encurta, porém, a curva de **confiança**: nenhuma plataforma te dá uma missão de 150 € na primeira semana só porque o teu currículo é bom. A reputação constrói-se sempre com missões concluídas, não com experiência importada de outro lado.",
+     "A vantagem de quem já tem experiência é outra: sabe mais depressa em que setor quer especializar-se. Se já trabalhaste em concessionários, o automóvel é o teu atalho natural; se já trabalhaste em hotelaria, é aí que vais render mais rápido. Usa essa vantagem para escolher setor cedo — não para saltar etapas de confiança.",
+     "Seja qual for o ponto de partida, a fórmula para subir de nível é a mesma: perfil completo, resposta rápida a convites, prazos sempre cumpridos. Isso é o que as plataformas medem — e é sobre isso que voltamos a falar em detalhe no Módulo 10.",
+    ],
+   },
   ],
   evaluationExamples: [
    {
@@ -308,6 +329,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m2q6",
+    question: "Quem já tem experiência numa área próxima (hotelaria, atendimento, auditoria) pode saltar a fase de construir reputação nas plataformas?",
+    options: [
+     "Sim, a experiência substitui sempre as primeiras missões",
+     "Não — a experiência ajuda a observar melhor e a escolher setor mais depressa, mas a reputação constrói-se sempre com missões concluídas",
+     "Sim, desde que apresente o currículo à agência",
+     "Não, a experiência prévia não tem qualquer utilidade neste mercado",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -358,6 +390,15 @@ export const courseModules: CourseModule[] = [
      "**Fraude.** Inventar uma visita, reutilizar um talão antigo, copiar um relatório anterior ou pedir a outra pessoa que faça a missão por ti são motivos de exclusão imediata e, dependendo do caso, de responsabilidade civil. Vale sempre menos do que a missão que estavas a tentar salvar.",
      "**Dados pessoais.** Podes registar o nome próprio que consta do crachá e a descrição funcional (\"colaborador do balcão, cerca de 30 anos, camisa azul\"). Não recolhas dados de saúde, opiniões políticas, morada ou fotografias de rosto sem base para isso. O RGPD aplica-se a ti tal como a qualquer profissional.",
      "**Provocação.** Não crias cenários artificiais para \"apanhar\" alguém: não peças descontos ilegais, não simules conflitos, não insistas depois de um não. Avalias o serviço normal — não uma armadilha montada por ti.",
+    ],
+   },
+   {
+    title: "Página 4 — Calibrar a discrição consoante o contexto",
+    blocks: [
+     "Numa loja ou num café, aplicar as três regras de ouro é quase automático: entras, observas, sais, ninguém repara em ti. É por aí que todos começam, e é suficiente para 80% das missões do mercado.",
+     "Em missões mais longas — uma estadia de hotel de duas noites, um test-drive com follow-up, um processo de crédito com três contactos — o risco de exposição multiplica-se. Já não basta manter o cenário coerente durante 10 minutos; tens de o manter durante horas ou dias, perante várias pessoas que podem comparar notas entre si. Escreve o teu cenário antes de partires, exatamente como farias com um guião de teatro: quem és, porque estás ali, o que dizes se alguém repetir a pergunta no dia seguinte.",
+     "Há também um dilema que só aparece com a experiência: numa estadia longa, é fácil desenvolver simpatia genuína por um rececionista simpático que te ajudou várias vezes. É precisamente aí que a imparcialidade custa mais a manter — porque já não é uma pessoa desconhecida durante cinco minutos, é alguém com quem interagiste o fim de semana todo. A regra não muda: avalias o cumprimento dos critérios, não a relação que se criou.",
+     "Fica a ideia central deste módulo, para levares para todos os que se seguem: mais experiência não te dá licença para relaxar as três regras — dá-te apenas mais contextos onde as tens de aplicar com mais subtileza.",
     ],
    },
   ],
@@ -425,6 +466,17 @@ export const courseModules: CourseModule[] = [
      "Porque se as equipas souberem quando são avaliadas, o dado deixa de ser real",
      "Porque as marcas exigem sigilo por moda",
      "Porque evita que outros avaliadores concorram",
+    ],
+    correctIndex: 1,
+   },
+   {
+    id: "m3q6",
+    question: "Numa missão longa, como uma estadia de hotel de duas noites, o que muda em relação às três regras de ouro?",
+    options: [
+     "As regras deixam de se aplicar, porque já não é uma visita rápida",
+     "As regras mantêm-se, mas exigem mais cuidado a manter o cenário coerente ao longo do tempo",
+     "Só a confidencialidade continua a ser obrigatória",
+     "A simpatia genuína criada com a equipa passa a justificar avaliações mais brandas",
     ],
     correctIndex: 1,
    },
@@ -882,6 +934,15 @@ export const courseModules: CourseModule[] = [
      "Respeita os limites: as evidências são para a missão e mais nada. Não as publiques, não as partilhes, não as reutilizes noutra missão. Passado o prazo de guarda, apaga o que contém dados pessoais — é a atitude correta e é o que o RGPD espera de ti.",
     ],
    },
+   {
+    title: "Página 4 — Sistema de evidências para quem já faz várias missões por semana",
+    blocks: [
+     "Enquanto fazes uma ou duas missões por mês, uma pasta no telemóvel chega perfeitamente. O problema aparece quando o volume cresce: a partir de quatro ou cinco missões por semana, o método manual começa a falhar — talões trocados, fotos sem nome, uma agência a perguntar por uma evidência que já não sabes onde está.",
+     "Nessa fase, vale a pena migrar para uma pasta na nuvem sincronizada automaticamente (Drive, iCloud ou equivalente), organizada sempre pela mesma convenção de nomes que já usas: data, marca, cidade, código da missão. O ganho não é só arrumação — é teres a evidência acessível mesmo se perderes o telemóvel a meio de uma semana cheia.",
+     "Junta o registo de evidências a uma folha de acompanhamento simples, com uma linha por missão: data, marca, honorário, reembolso, prazo de submissão, estado (submetida, aprovada, paga). É a mesma lógica de controlo que vais aprofundar no Módulo 9 para a parte financeira — aqui serve para nunca perderes o rasto de uma prova.",
+     "E mantém a disciplina de sempre: duas cópias de cada evidência importante (telemóvel + nuvem), respeito pelo prazo de guarda de cada plataforma, e uma limpeza periódica — trimestral, por exemplo — para apagar o que já passou do prazo e contém dados pessoais de terceiros.",
+    ],
+   },
   ],
   quiz: [
    {
@@ -939,6 +1000,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m7q6",
+    question: "A partir de que ponto compensa migrar de uma pasta manual no telemóvel para um sistema mais organizado de evidências?",
+    options: [
+     "Nunca — a pasta manual chega sempre, independentemente do volume",
+     "Quando o volume de missões sobe (por exemplo, quatro ou cinco por semana) e o método manual começa a falhar",
+     "Apenas se a agência o exigir por escrito",
+     "Só depois de a primeira evidência se perder",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -990,6 +1062,15 @@ export const courseModules: CourseModule[] = [
      "**3. Evidências.** Talão legível, fotografias exigidas anexadas, ficheiros com o nome certo e no formato pedido?",
      "**4. Língua.** Ortografia e pontuação revistas. Um relatório com erros grosseiros parece feito à pressa — e passa a ideia de que a observação também foi.",
      "**5. Prazo.** Submetido dentro do prazo. Muitas plataformas exigem 12 a 24 horas após a visita e cortam automaticamente o pagamento a quem chega atrasado. Se surgir um imprevisto, avisa antes de o prazo terminar, nunca depois.",
+    ],
+   },
+   {
+    title: "Página 4 — Do relatório único ao sistema de escrita",
+    blocks: [
+     "No início, cada relatório demora o que tem de demorar: tudo é novo, cada campo obriga a pensar duas vezes. É o preço normal de aprender e não há atalho honesto para o saltar.",
+     "Quem já escreveu vinte ou trinta relatórios do mesmo tipo de missão começa naturalmente a criar \"moldes\" mentais — a mesma ordem, os mesmos blocos, frases que já sabem funcionar. Isso é bom: acelera e reduz erros de estrutura.",
+     "O risco aparece quando o molde deixa de ser estrutura e passa a ser texto copiado. Um banco pessoal de frases para situações recorrentes (\"colaborador não ofereceu o cartão de cliente\", \"espera superior a 5 minutos com caixa livre\") é uma ferramenta legítima — desde que cada frase seja sempre reescrita com os factos específicos daquela visita: a hora certa, o crachá certo, o número certo.",
+     "As agências com mais experiência sabem identificar relatórios \"parecidos demais\" do mesmo avaliador em missões diferentes — é um dos sinais mais óbvios de texto reciclado, e levanta suspeita de fraude mesmo quando a visita foi real. A velocidade que a experiência traz nunca pode substituir a variação genuína dos factos observados: mais rápido a escrever, sim; mais descuidado a verificar, nunca.",
     ],
    },
   ],
@@ -1065,6 +1146,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 0,
    },
+   {
+    id: "m8q6",
+    question: "Um avaliador experiente usa um banco pessoal de frases-modelo para acelerar a escrita. O que é indispensável para que isso continue a ser uma boa prática?",
+    options: [
+     "Usar sempre a mesma frase, sem alterações, para poupar tempo",
+     "Reescrever cada frase com os factos específicos da visita em causa (hora, nome, número)",
+     "Só usar frases-modelo em missões de baixo valor",
+     "Pedir autorização da agência para cada frase reutilizada",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -1115,6 +1207,15 @@ export const courseModules: CourseModule[] = [
      "O que declaras é o **honorário**, o teu rendimento. Reembolsos de despesa devidamente documentados têm tratamento diferente — vale a pena confirmar com um contabilista logo no início, sobretudo se as missões passarem a ser regulares.",
      "Existe uma isenção de IVA para quem tem rendimento anual baixo (o limiar é revisto periodicamente). Enquanto estiveres abaixo desse valor, emites recibos sem IVA; ao ultrapassá-lo, passas ao regime normal. Confirma sempre o valor em vigor no ano em causa.",
      "**Guarda tudo.** Recibos emitidos, comprovativos de pagamento, faturas de combustível e talões. Se um dia esta atividade passar de complemento a profissão, vais querer ter os últimos dois anos organizados — e a tua futura contabilista vai adorar-te.",
+    ],
+   },
+   {
+    title: "Página 4 — De complemento a atividade séria",
+    blocks: [
+     "Nos primeiros meses, com uma missão ocasional aqui e ali, uma folha simples com data, honorário e reembolso chega perfeitamente. É o suficiente para saberes se compensa continuar.",
+     "Quando o ritmo sobe — 15, 20 missões por mês, várias plataformas em simultâneo — a contabilidade exige mais rigor: reconcilia todos os meses os honorários recebidos com os recibos verdes emitidos, e não deixes essa reconciliação acumular-se para o fim do ano.",
+     "Nessa fase, diversificar deixa de ser só uma tática de agenda (como vimos no Módulo 2) e passa a ser proteção de rendimento: trabalhar com três ou quatro agências ou plataformas diferentes evita que uma quebra sazonal de um único operador — um projeto que acaba, uma pausa de contrato — te deixe sem missões durante semanas.",
+     "E há um ponto de decisão real que só chega com o volume: quando o rendimento mensal desta atividade se torna relevante para o teu orçamento, vale a pena sentar com um contabilista e confirmar se o enquadramento atual (recibos verdes simples) continua a ser o mais adequado. Não é uma decisão para tomar sozinho, nem de véspera da entrega do IRS.",
     ],
    },
   ],
@@ -1189,6 +1290,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m9q6",
+    question: "Porque é que trabalhar com várias agências ou plataformas em simultâneo protege o rendimento, à medida que o volume de missões cresce?",
+    options: [
+     "Porque cada plataforma paga mais quando há concorrência entre avaliadores",
+     "Porque evita que a quebra sazonal de um único operador te deixe sem missões durante semanas",
+     "Porque reduz os impostos a pagar",
+     "Porque as plataformas exigem exclusividade a partir de certo volume",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -1239,6 +1351,15 @@ export const courseModules: CourseModule[] = [
      "**Especializa-te em dois ou três setores.** Quem repete o mesmo tipo de missão fica mais rápido, escreve melhores relatórios e sobe de classificação. Restauração e retalho são portas de entrada; banca, automóvel e hotelaria são onde está o dinheiro sério.",
      "**Constrói relação com as agências.** Responde rápido, cumpre prazos, avisa quando algo corre mal e sê educado com quem revê os teus relatórios. Passados alguns meses começam a chegar convites diretos — as missões que nunca chegam a ser publicadas.",
      "**Meta realista para os primeiros três meses:** 4 a 8 missões por mês, entre 80 € e 250 € de honorário mensal, e uma classificação acima da média. A partir daí, é escolher: manter como complemento ou empurrar para valores que já pagam contas.",
+    ],
+   },
+   {
+    title: "Página 4 — Depois dos 90 dias: o caminho sénior",
+    blocks: [
+     "Com os primeiros três meses cumpridos e uma boa classificação, abre-se um caminho que poucos avaliadores conhecem à partida: algumas agências convidam avaliadores fiáveis para funções de **revisor ou validador** dos relatórios de outros avaliadores — mais responsabilidade, e normalmente remuneração fixa ou por lote de relatórios revistos, em vez de por missão.",
+     "Quem já vem de outra área — atendimento, hotelaria, auditoria de qualidade — tende a chegar mais depressa a este ponto, porque já traz hábitos de rigor treinados noutro contexto. Mas só chega lá com histórico de missões cumpridas nesta atividade: currículo de fora abre portas, não substitui a confiança construída aqui dentro.",
+     "Outro caminho, mais comum, é a **especialização vertical**: concentrares-te num setor de alto valor — automóvel, banca, hotelaria — até te tornares o avaliador de referência de uma agência para essa categoria. É aí que aparecem os convites diretos para missões que nunca chegam a ser publicadas, o objetivo que persegues desde a Página 3 deste módulo.",
+     "Seja qual for o caminho que te atrair, o próximo passo é sempre o mesmo e é imediato: candidatares-te. No módulo seguinte — o do certificado — encontras uma lista concreta de empresas e plataformas onde podes começar a fazê-lo hoje mesmo.",
     ],
    },
   ],
@@ -1318,6 +1439,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m10q6",
+    question: "O que é necessário para uma agência convidar um avaliador para funções de revisor ou validador de relatórios?",
+    options: [
+     "Ter um currículo forte noutra área, independentemente do histórico na plataforma",
+     "Ter histórico de missões cumpridas e boa classificação nesta atividade",
+     "Pagar uma taxa de acesso ao nível seguinte",
+     "Completar apenas o certificado do curso",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -1348,6 +1480,93 @@ export const courseModules: CourseModule[] = [
      "Levas contigo o método completo: **enquadramento** do mercado, **ética** e conduta, **observação objetiva**, **preparação**, **execução**, **evidências**, **relatório**, **contas** e um **plano de 30 dias** para arrancar.",
      "O teu **certificado nominal em PDF** está disponível no botão abaixo. Anexa-o ao perfil em todas as plataformas: mostra que sabes o que é um briefing, um item de guião e um prazo — coisas que a maioria dos candidatos descobre a errar.",
      "Agora falta a única parte que não se aprende a ler: **a primeira missão**. Escolhe uma pequena, perto de casa, esta semana. O resto vem com quilómetros — e com talões bem fotografados.",
+    ],
+   },
+   {
+    title: "Página 2 — Onde te candidatares agora",
+    blocks: [
+     "O certificado prova que sabes preparar, executar e reportar uma missão com rigor. A parte que falta já não se aprende a ler: é candidatares-te. Tal como no Módulo 2, o mercado divide-se em dois tipos de operador — plataformas internacionais de autorregisto e agências ou institutos portugueses que publicam vagas com regularidade.",
+     "A lista abaixo não é exaustiva — o mercado muda, plataformas fecham e outras abrem — mas é um ponto de partida real e verificado. Regista-te em pelo menos cinco ou seis ao mesmo tempo, hoje, enquanto o método ainda está fresco, e preenche o perfil a 100% em cada uma: é o que separa quem começa a receber convites em duas semanas de quem espera meses (Módulo 10, Página 1).",
+     "E o aviso do costume, porque vale sempre a pena repetir: nenhuma empresa séria — nem nenhuma das que aqui estão — cobra para te registares, para te \"certificar\" ou para desbloquear missões. Se alguém pedir dinheiro, não é uma oportunidade, é um esquema. Ignora e segue para a próxima da lista.",
+    ],
+   },
+  ],
+  recruitingCompanies: [
+   {
+    category: "Plataformas internacionais de autorregisto",
+    companies: [
+     {
+      name: "BARE International",
+      description:
+       "A maior rede internacional de avaliadores de cliente mistério, com missões em dezenas de países e uma área própria dedicada a quem quer começar.",
+      url: "https://www.bareinternational.com/evaluators/",
+     },
+     {
+      name: "Secret View",
+      description:
+       "Plataforma global com mais de 75 mil avaliadores registados e missões ativas em Portugal, com registo direto online.",
+      url: "https://www.secretview.io/en",
+     },
+     {
+      name: "Globis Survey",
+      description:
+       "Rede internacional com uma página dedicada a \"tornares-te cliente mistério\", sem entrevista prévia.",
+      url: "https://www.globis-survey.com/en/become-a-mystery-shopper/",
+     },
+     {
+      name: "Ipsos",
+      description:
+       "Um dos maiores institutos de estudos de mercado do mundo, com uma prática dedicada a mystery shopping em vários setores.",
+      url: "https://www.ipsos.com/en-us/mystery-shopping-0",
+     },
+    ],
+   },
+   {
+    category: "Agências e institutos em Portugal",
+    companies: [
+     {
+      name: "SGS Portugal",
+      description:
+       "Multinacional de inspeção e certificação com missões de cliente mistério em retalho, banca, automóvel e restauração.",
+      url: "https://www.sgs.com/en-pt/services/mystery-shopping",
+     },
+     {
+      name: "DEKRA Portugal",
+      description:
+       "Auditorias e avaliações de cliente mistério em diversos setores, com plataforma própria de registo de avaliadores.",
+      url: "https://www.dekra.pt/pt/cliente-misterio-auditorias/",
+     },
+     {
+      name: "IMR — Instituto de Marketing Research",
+      description:
+       "Instituto português de estudos de mercado com ofertas regulares para avaliadores de cliente mistério em todo o país.",
+      url: "https://www.imr.pt/pt/ofertas-de-emprego/cliente-misterio",
+     },
+     {
+      name: "Intercampus",
+      description: "Agência portuguesa de investigação de mercado com painel próprio de clientes mistério.",
+      url: "https://intercampus.pt/clientes_misterio/",
+     },
+     {
+      name: "QSP Marketing",
+      description: "Consultora portuguesa de marketing e research que recruta avaliadores para estudos de mystery shopper.",
+      url: "https://qspmarketing.pt/research-tecnicas/mystery-shopper/",
+     },
+     {
+      name: "Consulmark",
+      description: "Empresa de estudos de mercado sediada em Lisboa, com serviço dedicado de mystery shopping.",
+      url: "https://www.consulmark.pt/?produtos=mystery-shopping",
+     },
+     {
+      name: "SmartSkills",
+      description: "A recrutar e formar avaliadores em Portugal desde 2006, com centenas de missões já realizadas.",
+      url: "https://smartskills.pt/en/servicos/8/Mystery-Shopping-Audit",
+     },
+     {
+      name: "Triangulu",
+      description: "Agência portuguesa de research com serviço de cliente mistério para marcas de retalho e serviços.",
+      url: "https://www.triangulu.pt/servicos/clientemisterio/",
+     },
     ],
    },
   ],

--- a/app/curso/courseDataEn.ts
+++ b/app/curso/courseDataEn.ts
@@ -24,6 +24,17 @@ export type CoursePage = {
  blocks: string[];
 };
 
+export type RecruitingCompany = {
+ name: string;
+ description: string;
+ url: string;
+};
+
+export type RecruitingCompanyGroup = {
+ category: string;
+ companies: RecruitingCompany[];
+};
+
 export type CourseModule = {
  id: number;
  title: string;
@@ -36,6 +47,7 @@ export type CourseModule = {
  warning?: string;
  benefit?: string;
  evaluationExamples?: EvaluationExample[];
+ recruitingCompanies?: RecruitingCompanyGroup[];
 };
 
 export const courseModules: CourseModule[] = [
@@ -226,6 +238,15 @@ export const courseModules: CourseModule[] = [
      "A real example: €25 mission, 40 minutes driving round trip, 30 minutes on site, 40 minutes writing. That's almost two hours and about €6 of fuel: roughly €10/hour. Now group three missions in the same area on the same day and the hourly rate almost doubles — the secret was never the mission, it was the **route**.",
     ],
    },
+   {
+    title: "Page 4 — From first sign-up to a real strategy",
+    blocks: [
+     "This market doesn't have a single entry point. If you've never done anything like this, the goal of month one is simple: close the full cycle on small missions — apply, execute, document, submit, get approved. Don't chase the highest fee; chase the first clean approval.",
+     "If you already come from an adjacent field — customer service, hotel reception, quality auditing, store management — you already bring a trained eye for what most people take months to notice. That shortens the **observation** curve. It does not shorten the **trust** curve: no platform hands you a €150 mission in week one just because your CV looks good. Reputation is always built with completed missions, not with experience imported from elsewhere.",
+     "The real advantage of prior experience is different: you know faster which sector to specialise in. If you've worked at a car dealership, automotive is your natural shortcut; if you've worked in hospitality, that's where you'll ramp up fastest. Use that advantage to pick a sector early — not to skip trust-building steps.",
+     "Whatever your starting point, the formula for levelling up is the same: a complete profile, fast responses to invitations, deadlines always met. That's what platforms actually measure — and we come back to it in detail in Module 10.",
+    ],
+   },
   ],
   evaluationExamples: [
    {
@@ -303,6 +324,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m2q6",
+    question: "Can someone with experience in an adjacent field (hospitality, customer service, auditing) skip the phase of building platform reputation?",
+    options: [
+     "Yes, experience always replaces the first missions",
+     "No — experience helps you observe better and pick a sector faster, but reputation is always built with completed missions",
+     "Yes, as long as they submit their CV to the agency",
+     "No, prior experience is of no use at all in this market",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -353,6 +385,15 @@ export const courseModules: CourseModule[] = [
      "**Fraud.** Inventing a visit, reusing an old receipt, copying a previous report or asking someone else to run the mission for you all mean immediate exclusion and, in some cases, civil liability. It's always worth less than the mission you were trying to save.",
      "**Personal data.** You may record the first name shown on a badge and a functional description (\"counter assistant, around 30, blue shirt\"). Don't collect health data, political opinions, addresses or facial photographs without a basis for it. GDPR applies to you like any other professional.",
      "**Entrapment.** Don't build artificial scenarios to catch people out: don't request illegal discounts, don't stage conflicts, don't push after a no. You're evaluating normal service — not a trap you set yourself.",
+    ],
+   },
+   {
+    title: "Page 4 — Calibrating discretion to the context",
+    blocks: [
+     "In a shop or a café, applying the three golden rules is almost automatic: you walk in, observe, leave, and nobody notices you. That's how everyone starts, and it's enough for 80% of the missions on the market.",
+     "On longer missions — a two-night hotel stay, a test drive with follow-up, a credit application with three separate contacts — the risk of exposure multiplies. It's no longer enough to keep your scenario coherent for 10 minutes; you have to hold it for hours or days, in front of several people who may compare notes with each other. Write your scenario down before you leave, exactly as you would a stage script: who you are, why you're there, what you say if someone repeats the question the next day.",
+     "There's also a dilemma that only shows up with experience: on a long stay, it's easy to develop genuine warmth towards a receptionist who's helped you several times. That's precisely where impartiality is hardest to hold onto — because it's no longer a stranger for five minutes, it's someone you interacted with all weekend. The rule doesn't change: you evaluate whether the criteria were met, not the relationship that formed.",
+     "Take this core idea into every module that follows: more experience doesn't give you licence to relax the three rules — it just gives you more contexts in which to apply them with more subtlety.",
     ],
    },
   ],
@@ -420,6 +461,17 @@ export const courseModules: CourseModule[] = [
      "Because if teams know when they're evaluated, the data stops being real",
      "Because brands demand secrecy as a fashion",
      "Because it stops other evaluators competing",
+    ],
+    correctIndex: 1,
+   },
+   {
+    id: "m3q6",
+    question: "On a long mission, such as a two-night hotel stay, what changes about the three golden rules?",
+    options: [
+     "The rules no longer apply, because it isn't a quick visit anymore",
+     "The rules still apply, but require more care to keep the scenario coherent over time",
+     "Only confidentiality remains mandatory",
+     "Genuine warmth built up with staff justifies softer evaluations",
     ],
     correctIndex: 1,
    },
@@ -877,6 +929,15 @@ export const courseModules: CourseModule[] = [
      "Respect the limits: evidence belongs to the mission and nothing else. Don't publish it, don't share it, don't reuse it in another mission. Once the retention period is over, delete anything containing personal data — it's the right thing to do and it's what GDPR expects of you.",
     ],
    },
+   {
+    title: "Page 4 — An evidence system for higher volumes",
+    blocks: [
+     "While you're doing one or two missions a month, a folder on your phone is plenty. The problem shows up once volume grows: from around four or five missions a week, the manual method starts to fail — swapped receipts, unnamed photos, an agency asking for evidence you can no longer locate.",
+     "At that point, it's worth moving to a folder in the cloud, synced automatically (Drive, iCloud or equivalent), organised with the same naming convention you already use: date, brand, city, mission code. The gain isn't just tidiness — it's having your evidence accessible even if you lose your phone in the middle of a busy week.",
+     "Pair the evidence folder with a simple tracking sheet, one row per mission: date, brand, fee, reimbursement, submission deadline, status (submitted, approved, paid). It's the same logic you'll build on for the financial side in Module 9 — here it just keeps you from ever losing track of a piece of evidence.",
+     "And keep the same discipline as always: two copies of every important piece of evidence (phone + cloud), respect for each platform's retention period, and a periodic clean-up — quarterly, say — to delete anything past its retention window that contains other people's personal data.",
+    ],
+   },
   ],
   quiz: [
    {
@@ -934,6 +995,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m7q6",
+    question: "At what point does it pay off to move from a manual phone folder to a more organised evidence system?",
+    options: [
+     "Never — a manual folder is always enough, regardless of volume",
+     "When mission volume rises (for example, four or five a week) and the manual method starts to fail",
+     "Only if the agency requires it in writing",
+     "Only after the first piece of evidence is lost",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -985,6 +1057,15 @@ export const courseModules: CourseModule[] = [
      "**3. Evidence.** Legible receipt, required photographs attached, files correctly named and in the requested format?",
      "**4. Language.** Spelling and punctuation checked. A report full of errors looks rushed — and suggests the observation was too.",
      "**5. Deadline.** Submitted on time. Many platforms require 12 to 24 hours after the visit and automatically cut payment for late submissions. If something comes up, warn them before the deadline, never after.",
+    ],
+   },
+   {
+    title: "Page 4 — From a single report to a writing system",
+    blocks: [
+     "At the start, every report takes as long as it takes: everything is new, every field forces you to think twice. That's the normal cost of learning and there's no honest shortcut around it.",
+     "Anyone who's written twenty or thirty reports on the same type of mission naturally starts building mental \"templates\" — the same order, the same blocks, sentences that already work. That's a good thing: it speeds you up and cuts structural mistakes.",
+     "The risk appears when the template stops being structure and becomes copy-pasted text. A personal bank of phrases for recurring situations (\"employee did not offer the loyalty card\", \"wait over 5 minutes with a free till\") is a legitimate tool — as long as every phrase is rewritten with the specific facts of that visit: the right time, the right badge, the right number.",
+     "More experienced agencies know how to spot reports that are \"too similar\" from the same evaluator across different missions — it's one of the clearest signs of recycled text, and it raises suspicion of fraud even when the visit was real. The speed that experience brings can never replace genuine variation in the facts you observed: faster to write, yes; sloppier to check, never.",
     ],
    },
   ],
@@ -1060,6 +1141,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 0,
    },
+   {
+    id: "m8q6",
+    question: "An experienced evaluator uses a personal bank of template phrases to write faster. What's essential for that to remain good practice?",
+    options: [
+     "Always using the exact same phrase, unchanged, to save time",
+     "Rewriting each phrase with the specific facts of that visit (time, name, number)",
+     "Only using template phrases on low-value missions",
+     "Getting the agency's approval for each reused phrase",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -1110,6 +1202,15 @@ export const courseModules: CourseModule[] = [
      "What you declare is the **fee**, your income. Properly documented expense reimbursements are treated differently — worth confirming with an accountant early on, especially if missions become regular.",
      "There's a VAT exemption for low annual income (the threshold is revised periodically). While below it you issue receipts without VAT; once you exceed it you move to the standard regime. Always check the threshold in force for the year in question.",
      "**Keep everything.** Receipts issued, payment confirmations, fuel invoices and till receipts. If this ever moves from side income to profession, you'll want the last two years organised — and your future accountant will love you for it.",
+    ],
+   },
+   {
+    title: "Page 4 — From side income to a serious activity",
+    blocks: [
+     "In the first few months, with the odd mission here and there, a simple sheet with date, fee and reimbursement is plenty. It's enough to tell you whether it's worth continuing.",
+     "Once the pace picks up — 15, 20 missions a month, several platforms at once — bookkeeping needs more rigour: reconcile the fees received against the green receipts issued every single month, and don't let that reconciliation pile up until year-end.",
+     "At that stage, diversifying stops being just a scheduling tactic (as in Module 2) and becomes income protection: working with three or four different agencies or platforms stops a single operator's seasonal dip — a project ending, a contract pause — from leaving you without missions for weeks.",
+     "And there's a real decision point that only arrives with volume: once this activity's monthly income becomes meaningful to your budget, it's worth sitting down with an accountant to confirm whether your current setup (simple green receipts) is still the right one. That's not a decision to make alone, or the night before your tax return is due.",
     ],
    },
   ],
@@ -1184,6 +1285,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m9q6",
+    question: "Why does working with several agencies or platforms at once protect your income as mission volume grows?",
+    options: [
+     "Because each platform pays more when evaluators compete",
+     "Because it stops a single operator's seasonal dip from leaving you without missions for weeks",
+     "Because it reduces the taxes you owe",
+     "Because platforms require exclusivity past a certain volume",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -1234,6 +1346,15 @@ export const courseModules: CourseModule[] = [
      "**Specialise in two or three sectors.** Repeating the same type of mission makes you faster, sharpens your reports and lifts your rating. Restaurants and retail are the entry doors; banking, automotive and hospitality are where the serious money is.",
      "**Build a relationship with agencies.** Reply quickly, meet deadlines, flag problems early and be courteous with whoever reviews your reports. After a few months, direct invitations start arriving — the missions that never get published.",
      "**A realistic target for the first three months:** 4 to 8 missions a month, €80 to €250 in monthly fees, and an above-average rating. From there it's your choice: keep it as side income or push it towards figures that pay bills.",
+    ],
+   },
+   {
+    title: "Page 4 — Beyond 90 days: the senior path",
+    blocks: [
+     "Once your first three months are behind you with a good rating, a path opens up that few evaluators know about going in: some agencies invite reliable evaluators into **reviewer or validator** roles for other evaluators' reports — more responsibility, and usually a fixed rate or a per-batch fee rather than per mission.",
+     "Anyone coming from another field — customer service, hospitality, quality auditing — tends to reach this point faster, because they already bring habits of rigour trained elsewhere. But you only get there with a track record of completed missions in this activity: an outside CV opens doors, it doesn't replace the trust built here.",
+     "Another, more common path is **vertical specialisation**: focusing on one high-value sector — automotive, banking, hospitality — until you become an agency's go-to evaluator for that category. That's where the direct invitations for unpublished missions come from, the goal you've been working towards since Page 3 of this module.",
+     "Whichever path appeals to you, the next step is always the same, and it's immediate: apply. In the next module — the certificate one — you'll find a concrete list of companies and platforms where you can start doing exactly that today.",
     ],
    },
   ],
@@ -1313,6 +1434,17 @@ export const courseModules: CourseModule[] = [
     ],
     correctIndex: 1,
    },
+   {
+    id: "m10q6",
+    question: "What does an agency need to see before inviting an evaluator to a reviewer or validator role?",
+    options: [
+     "A strong CV in another field, regardless of platform history",
+     "A track record of completed missions and a good rating in this activity",
+     "Payment of an access fee for the next level",
+     "Just finishing the course certificate",
+    ],
+    correctIndex: 1,
+   },
   ],
  },
 
@@ -1342,6 +1474,88 @@ export const courseModules: CourseModule[] = [
      "You're taking away the complete method: market **context**, **ethics** and conduct, **objective observation**, **preparation**, **execution**, **evidence**, **reporting**, **the maths**, and a **30-day plan** to get started.",
      "Your **personalised PDF certificate** is available from the button below. Attach it to your profile on every platform: it shows you know what a brief, a script item and a deadline are — things most applicants discover by getting them wrong.",
      "Now for the only part that can't be learned by reading: **the first mission**. Pick a small one, close to home, this week. The rest comes with mileage — and with well-photographed receipts.",
+    ],
+   },
+   {
+    title: "Page 2 — Where to apply now",
+    blocks: [
+     "The certificate proves you know how to prepare, execute and report a mission with rigour. The part that's missing can't be learned by reading anymore: it's applying. As in Module 2, the market splits into two types of operator — international self-registration platforms and Portuguese agencies or institutes that publish openings regularly.",
+     "The list below isn't exhaustive — the market shifts, platforms close and others open — but it's a real, checked starting point. Register on at least five or six of them at once, today, while the method is still fresh, and fill in your profile 100% on each: that's what separates people who start getting invitations within two weeks from those who wait months (Module 10, Page 1).",
+     "And the usual reminder, because it's always worth repeating: no serious company — none of the ones listed here included — charges you to register, to \"certify\" you, or to unlock missions. If anyone asks for money, it isn't an opportunity, it's a scam. Ignore it and move on to the next one on the list.",
+    ],
+   },
+  ],
+  recruitingCompanies: [
+   {
+    category: "International self-registration platforms",
+    companies: [
+     {
+      name: "BARE International",
+      description:
+       "The largest international network of mystery shopping evaluators, with missions in dozens of countries and a dedicated area for people getting started.",
+      url: "https://www.bareinternational.com/evaluators/",
+     },
+     {
+      name: "Secret View",
+      description:
+       "A global platform with over 75,000 registered evaluators and active missions in Portugal, with direct online sign-up.",
+      url: "https://www.secretview.io/en",
+     },
+     {
+      name: "Globis Survey",
+      description: "An international network with a dedicated \"become a mystery shopper\" page, no prior interview needed.",
+      url: "https://www.globis-survey.com/en/become-a-mystery-shopper/",
+     },
+     {
+      name: "Ipsos",
+      description: "One of the world's largest market research institutes, with a practice dedicated to mystery shopping across several sectors.",
+      url: "https://www.ipsos.com/en-us/mystery-shopping-0",
+     },
+    ],
+   },
+   {
+    category: "Agencies and institutes in Portugal",
+    companies: [
+     {
+      name: "SGS Portugal",
+      description: "A multinational inspection and certification company with mystery shopping missions in retail, banking, automotive and dining.",
+      url: "https://www.sgs.com/en-pt/services/mystery-shopping",
+     },
+     {
+      name: "DEKRA Portugal",
+      description: "Mystery shopping audits and evaluations across several sectors, with its own evaluator registration platform.",
+      url: "https://www.dekra.pt/pt/cliente-misterio-auditorias/",
+     },
+     {
+      name: "IMR — Instituto de Marketing Research",
+      description: "A Portuguese market research institute with regular openings for mystery shopping evaluators nationwide.",
+      url: "https://www.imr.pt/pt/ofertas-de-emprego/cliente-misterio",
+     },
+     {
+      name: "Intercampus",
+      description: "A Portuguese market research agency with its own mystery shopper panel.",
+      url: "https://intercampus.pt/clientes_misterio/",
+     },
+     {
+      name: "QSP Marketing",
+      description: "A Portuguese marketing and research consultancy that recruits evaluators for mystery shopper studies.",
+      url: "https://qspmarketing.pt/research-tecnicas/mystery-shopper/",
+     },
+     {
+      name: "Consulmark",
+      description: "A market research company based in Lisbon, with a dedicated mystery shopping service.",
+      url: "https://www.consulmark.pt/?produtos=mystery-shopping",
+     },
+     {
+      name: "SmartSkills",
+      description: "Recruiting and training evaluators in Portugal since 2006, with hundreds of missions already completed.",
+      url: "https://smartskills.pt/en/servicos/8/Mystery-Shopping-Audit",
+     },
+     {
+      name: "Triangulu",
+      description: "A Portuguese research agency offering mystery shopping for retail and service brands.",
+      url: "https://www.triangulu.pt/servicos/clientemisterio/",
+     },
     ],
    },
   ],

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -821,6 +821,60 @@
 .premGood .premList li::before { background: var(--color-success); }
 .premBad .premList li::before { background: var(--color-danger); }
 
+/* Empresas recrutadoras (módulo do certificado) */
+.companyGroup { margin: 0 0 32px; }
+.companyGroup:last-child { margin-bottom: 0; }
+.companyGroupTitle {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--link-accent);
+  margin: 0 0 16px;
+}
+.companyGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+@media (min-width: 640px) { .companyGrid { grid-template-columns: 1fr 1fr; } }
+.companyCard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--hairline-invert);
+  background: var(--input-bg);
+  padding: 22px;
+}
+.companyName {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--on-invert);
+  margin: 0;
+}
+.companyDesc {
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--on-invert-2);
+  margin: 0;
+  flex: 1;
+}
+a.companyLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--color-red);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  align-self: flex-start;
+}
+a.companyLink:hover { color: var(--color-red-2); }
+
 /* Exemplo de avaliação */
 .example {
   border-radius: var(--radius-lg);

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -701,6 +701,40 @@ function CursoPageContent() {
                   ))}
                 </div>
 
+                {/* Recruiting companies (certificate module, last page) */}
+                {isLastTheoryPage && activeModule.recruitingCompanies && activeModule.recruitingCompanies.length > 0 && (
+                  <>
+                    <div className={styles.readerBreak}>
+                      <span className={styles.readerBreakIcon}>§</span>
+                    </div>
+
+                    <h2 className={styles.readerH2}>{cp.recruitingCompaniesTitle}</h2>
+
+                    {activeModule.recruitingCompanies.map((group) => (
+                      <div key={group.category} className={styles.companyGroup}>
+                        <p className={styles.companyGroupTitle}>{group.category}</p>
+                        <div className={styles.companyGrid}>
+                          {group.companies.map((company) => (
+                            <div key={company.name} className={styles.companyCard}>
+                              <p className={styles.companyName}>{company.name}</p>
+                              <p className={styles.companyDesc}>{company.description}</p>
+                              <a
+                                href={company.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={styles.companyLink}
+                              >
+                                {cp.visitWebsite}
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6"/><path d="M10 14 21 3"/></svg>
+                              </a>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </>
+                )}
+
                 {/* Premium content on last page */}
                 {premiumTheoryPage && theoryPage === allTheoryPages.length - 1 && activeSupportContent && (
                   <>

--- a/app/lib/translations.ts
+++ b/app/lib/translations.ts
@@ -474,6 +474,8 @@ export const translations = {
       preparingCertificate: "A preparar certificado...",
       downloadCertificate: "Descarregar Certificado em PDF",
       startQuiz: "Iniciar Questionário",
+      recruitingCompaniesTitle: "Empresas que recrutam clientes mistério",
+      visitWebsite: "Visitar site",
     },
 
     // Catalog Page
@@ -1020,6 +1022,8 @@ export const translations = {
       preparingCertificate: "Preparing certificate...",
       downloadCertificate: "Download PDF Certificate",
       startQuiz: "Start Quiz",
+      recruitingCompaniesTitle: "Companies recruiting mystery shoppers",
+      visitWebsite: "Visit website",
     },
 
     // Catalog Page


### PR DESCRIPTION
## Summary
Expanded the course curriculum with new content pages across multiple modules and added a recruiting companies directory to the certificate module. This includes new types for company listings and corresponding UI components to display them.

## Key Changes

### Data Structure Enhancements
- Added `RecruitingCompany` and `RecruitingCompanyGroup` types to support company listings with name, description, and URL
- Extended `CourseModule` type with optional `recruitingCompanies` field to associate company groups with modules

### New Course Content
Added "Page 4" content to modules 2, 3, 7, 8, 9, and 10:
- **Module 2**: Strategic choice guidance for first registration and leveraging prior experience
- **Module 3**: Discretion calibration for longer-duration missions and maintaining impartiality
- **Module 7**: Evidence management system for higher mission volumes (cloud storage, tracking sheets)
- **Module 8**: Writing system and template phrase best practices to avoid plagiarism detection
- **Module 9**: Transition from side income to serious activity with accounting and diversification strategies
- **Module 10**: Senior paths (reviewer roles, vertical specialization) and next steps

### New Quiz Questions
Added 6th question to modules 2, 3, 7, 8, 9, and 10 to assess understanding of the new Page 4 content

### Certificate Module Recruiting Directory
- Added "Page 2 — Where to apply now" with guidance on registration
- Populated with 12 recruiting companies across two categories:
  - **International platforms**: BARE International, Secret View, Globis Survey, Ipsos
  - **Portuguese agencies**: SGS Portugal, DEKRA, IMR, Intercampus, QSP Marketing, Consulmark, SmartSkills, Triangulu

### UI Components
- New CSS styles for company cards, grid layout, and typography (`companyGroup`, `companyCard`, `companyName`, `companyDesc`, `companyLink`)
- Responsive grid (1 column on mobile, 2 columns on tablet+)
- Rendering logic in `page.tsx` to display recruiting companies on the last theory page of the certificate module

### Translations
- Added `recruitingCompaniesTitle` and `visitWebsite` translation keys for both Portuguese and English versions

## Implementation Details
- Company listings are conditionally rendered only on the last theory page of modules with `recruitingCompanies` data
- External links open in new tabs with security attributes (`noopener noreferrer`)
- Consistent styling with existing course design system (colors, spacing, typography)
- Both Portuguese (`courseData.ts`) and English (`courseDataEn.ts`) versions updated in parallel

https://claude.ai/code/session_01S6wUWyxw97NeTSTbXkLqvm