### PR TITLE
Refactor email configuration to centralize validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,18 @@ SESSION_SECRET=troque-este-segredo-por-um-muito-longo-e-aleatorio
 # Conta com privilégios de administrador (fica com is_admin=true ao registar-se).
 ADMIN_EMAIL=admin@exemplo.com
 
-# Resend (envio de e-mails transacionais via HTTPS).
+# Resend (envio de e-mails transacionais via HTTPS). As quatro chaves abaixo
+# são obrigatórias — a app falha no arranque do fluxo de e-mail se faltar alguma.
 RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxx
-RESEND_FROM="Cliente Mistério <noreply@seudominio.com>"
+EMAIL_FROM="Cliente Mistério <noreply@seudominio.com>"
+EMAIL_REPLY_TO=suporte@exemplo.com
 
-# URL base absoluta usada em links de e-mails.
+# URL pública da app usada para construir links nos e-mails (ex.: reset de
+# password), sem barra final.
+APP_URL=http://localhost:3000
+
+# URL base absoluta antiga — ainda usada apenas como fallback de SEO
+# (canonical/sitemap) em app/lib/site.ts. Os links de e-mail usam APP_URL, acima.
 APP_BASE_URL=http://localhost:3000
 
 # URL pública e definitiva do site (com domínio próprio), usada em

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -122,8 +122,10 @@ export const POST = async (request: Request) => {
     const user = result.rows[0];
 
     if (user) {
-      const template = createEmailConfirmationTemplate(confirmationToken);
       try {
+        // Construção do template (inclui validação de APP_URL) entra no mesmo try do envio:
+        // falha de configuração de e-mail não deve impedir a criação da conta já persistida.
+        const template = createEmailConfirmationTemplate(confirmationToken);
         await sendEmail({
           to: user.email,
           subject: template.subject,

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -181,8 +181,10 @@ export const PUT = async (request: Request) => {
         ]
       );
 
-      const template = createEmailConfirmationTemplate(confirmationToken);
       try {
+        // Construção do template (inclui validação de APP_URL) entra no mesmo try do envio:
+        // falha de configuração de e-mail não deve impedir a atualização do perfil já guardada.
+        const template = createEmailConfirmationTemplate(confirmationToken);
         await sendEmail({ to: normalizedEmail, subject: template.subject, html: template.html });
       } catch (error) {
         // A atualização do perfil já foi guardada; a pessoa pode pedir reenvio do e-mail de confirmação.

--- a/lib/authEmail.ts
+++ b/lib/authEmail.ts
@@ -2,6 +2,8 @@
  * DESCRIÇÃO DO FICHEIRO: Este ficheiro implementa a lógica de `lib/authEmail.ts` no projeto, incluindo as responsabilidades principais desta unidade.
  */
 
+import { assertEmailEnv } from "./email";
+
 const normalizeBaseUrl = (rawUrl: string) => {
   // Remove espaços e barra final para evitar URLs duplicadas com "//" ao concatenar paths.
   const sanitizedUrl = rawUrl.trim().replace(/\/+$/, "");
@@ -15,17 +17,10 @@ const normalizeBaseUrl = (rawUrl: string) => {
 };
 
 const resolveAppBaseUrl = () => {
-  // Resolve a URL pública da aplicação com fallback entre variáveis comuns de deploy.
-  const rawBaseUrl =
-    process.env.APP_BASE_URL?.trim() ||
-    process.env.NEXT_PUBLIC_APP_URL?.trim() ||
-    process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim() ||
-    process.env.VERCEL_URL?.trim() ||
-    process.env.RAILWAY_PUBLIC_DOMAIN?.trim() ||
-    process.env.RENDER_EXTERNAL_URL?.trim() ||
-    "http://localhost:3000";
+  // Valida a configuração de e-mail (inclui APP_URL) antes de montar qualquer link.
+  assertEmailEnv();
 
-  return normalizeBaseUrl(rawBaseUrl);
+  return normalizeBaseUrl(process.env.APP_URL!);
 };
 
 const createLayout = (title: string, description: string, buttonLabel: string, buttonUrl: string) => {

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -12,21 +12,32 @@ type MailPayload = {
   replyTo?: string;
 };
 
+// As quatro variáveis exigidas pelo fluxo de e-mail transacional (Resend + link da app).
+// APP_URL não é lida diretamente aqui, mas valida-se em conjunto porque authEmail.ts
+// precisa dela para montar o link antes mesmo de chamar sendEmail().
+const REQUIRED_EMAIL_ENV_VARS = ["RESEND_API_KEY", "EMAIL_FROM", "EMAIL_REPLY_TO", "APP_URL"] as const;
+
+// Valida a configuração de e-mail assim que o fluxo arranca (construção de link ou envio),
+// falhando cedo e de forma explícita em vez de deixar o Resend responder 403 com um from inválido.
+export const assertEmailEnv = () => {
+  const missing = REQUIRED_EMAIL_ENV_VARS.filter((key) => !process.env[key]?.trim());
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Configuração de e-mail incompleta: defina ${missing.join(", ")} nas variáveis de ambiente.`
+    );
+  }
+};
+
 const getResendConfig = () => {
   // Lê configuração do Resend para envio de e-mails transacionais via API HTTPS.
-  const apiKey = process.env.RESEND_API_KEY?.trim() || "";
-  // Aceita RESEND_FROM (nome documentado no README/render.yaml) e RESEND_FROM_EMAIL (nome histórico) para evitar regressões no deploy.
-  const fromEmail = process.env.RESEND_FROM?.trim() || process.env.RESEND_FROM_EMAIL?.trim() || "";
+  assertEmailEnv();
 
-  if (!apiKey) {
-    throw new Error("RESEND_API_KEY não está definida para envio de e-mails transacionais.");
-  }
-
-  if (!fromEmail) {
-    throw new Error("RESEND_FROM não está definida para envio de e-mails transacionais.");
-  }
-
-  return { apiKey, fromEmail };
+  return {
+    apiKey: process.env.RESEND_API_KEY!.trim(),
+    fromEmail: process.env.EMAIL_FROM!.trim(),
+    replyTo: process.env.EMAIL_REPLY_TO!.trim(),
+  };
 };
 
 export const sendEmail = async (payload: MailPayload) => {
@@ -39,11 +50,15 @@ export const sendEmail = async (payload: MailPayload) => {
     to: payload.to,
     subject: payload.subject,
     html: payload.html,
+    // Mantém o Gmail de suporte como resposta por omissão; chamadas como o
+    // formulário de contacto podem substituir por replyTo explícito (ex.: responder ao visitante).
+    replyTo: payload.replyTo || config.replyTo,
     ...(payload.text ? { text: payload.text } : {}),
-    ...(payload.replyTo ? { replyTo: payload.replyTo } : {}),
   });
 
   if (error) {
+    // Log no servidor com o detalhe do provider — quem chama nunca deve repetir isto na resposta HTTP.
+    console.error("Falha ao enviar e-mail via Resend:", error);
     throw new Error(`Falha ao enviar e-mail via Resend: ${error.message}`);
   }
 

--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,11 @@ services:
         sync: false
       - key: RESEND_API_KEY
         sync: false
-      - key: RESEND_FROM
+      - key: EMAIL_FROM
+        sync: false
+      - key: EMAIL_REPLY_TO
+        sync: false
+      - key: APP_URL
         sync: false
       - key: APP_BASE_URL
         sync: false


### PR DESCRIPTION
## Summary
Consolidates email environment variable validation into a single `assertEmailEnv()` function that is called early in the email flow, replacing scattered validation logic and improving error handling consistency.

## Key Changes

- **Centralized validation**: Created `assertEmailEnv()` export in `lib/email.ts` that validates all required email environment variables (`RESEND_API_KEY`, `EMAIL_FROM`, `EMAIL_REPLY_TO`, `APP_URL`) upfront, failing fast with a clear error message instead of allowing the Resend API to respond with a 403.

- **Renamed environment variables**: 
  - `RESEND_FROM` → `EMAIL_FROM` (clearer naming, aligns with `EMAIL_REPLY_TO`)
  - Added new `EMAIL_REPLY_TO` variable for explicit reply-to address configuration
  - Consolidated `APP_URL` as the single source of truth for email links (replacing multiple fallback variables)

- **Simplified `getResendConfig()`**: Removed individual validation checks and now delegates to `assertEmailEnv()`, returning a config object that includes the new `replyTo` field.

- **Enhanced email sending**: Updated `sendEmail()` to use `payload.replyTo` with a fallback to `config.replyTo`, allowing callers to override the default support email when needed (e.g., contact forms replying to visitors).

- **Improved error logging**: Added explicit server-side logging of Resend errors before throwing, preventing duplicate error details in HTTP responses.

- **Updated `authEmail.ts`**: Calls `assertEmailEnv()` in `resolveAppBaseUrl()` to validate configuration before constructing email links, ensuring failures happen early and consistently.

- **Updated configuration files**: 
  - `.env.example`: Documented the four required email variables and clarified the distinction between `APP_URL` (for email links) and `APP_BASE_URL` (for SEO fallback)
  - `render.yaml`: Updated environment variable keys to match the new naming scheme

- **Moved template construction**: In `register/route.ts` and `user/route.ts`, moved email template creation inside the try block so configuration validation failures don't prevent account creation/profile updates that have already been persisted.

## Implementation Details

The validation is triggered at two entry points:
1. When sending email via `sendEmail()` → `getResendConfig()`
2. When building email links via `createEmailConfirmationTemplate()` → `resolveAppBaseUrl()`

This ensures configuration errors are caught early regardless of which part of the email flow is executed first, while allowing the database operations to complete before attempting email operations.

https://claude.ai/code/session_01P2ZgphewfeCxZxrcy7sJ4Q