### PR TITLE
Redesenha a homepage para um visual clean e claro

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,8 +1,13 @@
 /*
  * Cliente Mistério — Homepage.
- * Superfície roxa da marca (igual às restantes páginas), título de grande
- * escala com o segundo verso em destaque branco-sobre-roxo, ícone de
- * destaque em halo branco e três passos ligados por uma curva ascendente.
+ * Layout claro: fundo branco, texto quase-preto, roxo da marca como
+ * acento (eyebrow, botões, ícone do hero, cartão de preço). A raiz da
+ * página leva a classe `on-light` (globals.css) em page.tsx, que já
+ * remapeia os tokens genéricos --ink/--body/--muted/--brand/--surface*
+ * para a escala clara — por isso este ficheiro usa sempre esses tokens
+ * genéricos (nunca --color-white/--on-brand-2/--surface-brand a direito,
+ * exceto no cartão de preço e no CTA final, que são o único bloco roxo
+ * cheio da página e usam os tokens absolutos de propósito).
  * CSS Module ao lado de app/page.tsx.
  */
 
@@ -14,9 +19,9 @@
      cima, onde ficaria escondido atrás do cabeçalho fixo. */
   justify-content: flex-start;
   min-height: calc(100dvh - var(--header-h) - var(--footer-h));
-  padding: clamp(12px, 4vh, 48px) 0;
-  background: var(--surface-brand);
-  color: var(--color-white);
+  padding: clamp(12px, 4vh, 48px) 0 0;
+  background: var(--surface);
+  color: var(--ink);
   font-family: var(--font-body);
 }
 
@@ -38,180 +43,183 @@
   display: grid;
   grid-template-columns: 1fr;
   align-items: center;
-  gap: clamp(8px, 2vh, var(--sp-xl));
+  gap: clamp(32px, 5vh, var(--sp-xl));
 }
 @media (min-width: 768px) {
   .heroInner { padding: 0 var(--sp-xl); }
 }
 @media (min-width: 1024px) {
-  .heroInner { grid-template-columns: 1.15fr 0.85fr; gap: var(--sp-xl); }
+  .heroInner { grid-template-columns: 1.1fr 0.9fr; gap: var(--sp-xl); }
 }
 
 .intro { max-width: 640px; }
 
 .eyebrow {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 14px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0.24em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
-  margin: 0 0 clamp(8px, 1.6vh, var(--sp-md));
-}
-.eyebrow::before {
-  content: "";
-  width: 34px;
-  height: 2px;
-  background: currentColor;
-  flex-shrink: 0;
+  color: var(--brand);
+  margin: 0 0 clamp(10px, 1.8vh, var(--sp-md));
 }
 
 .title {
   font-family: var(--font-display);
-  font-size: clamp(26px, min(10vw, 8vh), 46px);
+  font-size: clamp(32px, min(8vw, 8vh), 56px);
   font-weight: 800;
-  letter-spacing: -0.04em;
-  line-height: 1.02;
-  text-transform: uppercase;
-  color: var(--color-white);
+  letter-spacing: -0.03em;
+  line-height: 1.06;
+  color: var(--ink);
   margin: 0;
   text-wrap: balance;
 }
-
-/* Realce do segundo verso: inversão do sistema — caixa branca, texto roxo. */
-.titleAccent {
-  color: var(--color-red);
-  background: var(--color-white);
-  padding: 0 0.1em;
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+@media (min-width: 1024px) {
+  .title { font-size: clamp(34px, min(4.4vw, 5.8vh), 58px); }
 }
-.dot { color: var(--color-red); }
 
 .subtitle {
-  margin: clamp(6px, 1.2vh, var(--sp-sm)) 0 0;
+  margin: clamp(10px, 1.6vh, var(--sp-md)) 0 0;
   font-size: 16px;
-  line-height: 1.45;
-  color: var(--on-brand-2);
+  line-height: 1.55;
+  color: var(--body);
   max-width: 46ch;
+}
+@media (min-width: 768px) {
+  .subtitle { font-size: 17px; }
 }
 
 .valueProp {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin: clamp(6px, 1.2vh, var(--sp-sm)) 0 0;
-  padding: 8px 14px;
-  border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.14);
-  color: var(--color-white);
-  font-size: 13px;
-  font-weight: 700;
+  margin: clamp(12px, 2vh, var(--sp-md)) 0 0;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--muted);
 }
-.valueProp svg { width: 16px; height: 16px; flex-shrink: 0; }
+.valueProp svg { width: 15px; height: 15px; color: var(--brand); flex-shrink: 0; }
 
 .ctaRow {
   display: flex;
   align-items: center;
   gap: var(--sp-lg);
   flex-wrap: wrap;
-  margin-top: clamp(10px, 2vh, var(--sp-lg));
+  margin-top: clamp(18px, 3vh, var(--sp-xl));
 }
 
 .ctaPrimary {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 10px;
-  min-height: 48px;
-  padding: 15px 26px;
+  min-height: 50px;
+  padding: 15px 28px;
   border-radius: var(--radius-md);
-  background: var(--color-white);
-  color: var(--color-red);
-  font-size: 15px;
-  font-weight: 700;
-  text-decoration: none;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
-  transition: all 200ms ease;
-}
-.ctaPrimary:hover {
-  color: var(--color-red-3);
-  transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.22);
-}
-.ctaPrimary:active {
-  transform: translateY(0) scale(0.97);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
-}
-.ctaPrimary svg { width: 18px; height: 18px; }
-
-.ctaSecondary {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 48px;
+  background: var(--brand);
   color: var(--color-white);
   font-size: 15px;
   font-weight: 700;
   text-decoration: none;
-  transition: opacity 200ms ease, transform 150ms ease;
+  box-shadow: 0 10px 24px rgba(106, 74, 222, 0.26);
+  transition: all 200ms ease;
 }
-.ctaSecondary:hover { opacity: 0.7; }
-.ctaSecondary:active { transform: scale(0.97); }
-.ctaSecondary svg { width: 16px; height: 16px; }
+.ctaPrimary:hover {
+  background: var(--color-red-2);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(106, 74, 222, 0.32);
+}
+.ctaPrimary:active {
+  transform: translateY(0) scale(0.97);
+  box-shadow: 0 6px 16px rgba(106, 74, 222, 0.28);
+}
+.ctaPrimary svg { width: 18px; height: 18px; }
 
-/* ---------- Destaque visual do hero ----------
-   Escondido por omissão: em ecrãs baixos/estreitos o destaque decorativo
-   é o primeiro a ceder espaço ao conteúdo, para o texto nunca ficar
-   cortado. Só aparece a partir do breakpoint onde a coluna extra cabe. */
+/* ---------- Ilustração do hero ----------
+   Moldura tipo "dispositivo" com o olho da marca ao centro e um
+   mini-cartão de interface no canto — puramente decorativo, sem dados
+   nem screenshots reais. Escondida abaixo de 1024px para o texto nunca
+   perder espaço (mesmo critério que o resto do site). */
 .heroArt {
   display: none;
   position: relative;
   align-items: center;
   justify-content: center;
-  min-height: clamp(120px, 22vh, 280px);
+  padding: var(--sp-lg);
 }
 @media (min-width: 1024px) {
   .heroArt { display: flex; }
-  .title { font-size: clamp(28px, min(5vw, 5.6vh), 56px); }
 }
 
-.heroArtGlow {
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  width: min(100%, 420px);
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle at 50% 45%,
-    rgba(255, 255, 255, 0.22) 0%,
-    rgba(255, 255, 255, 0.1) 45%,
-    rgba(255, 255, 255, 0) 72%
-  );
-}
-
-.heroArtRing {
+.heroArtFrame {
   position: relative;
+  width: 100%;
+  max-width: 420px;
+  aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 128px;
-  height: 128px;
+  border-radius: var(--radius-xl);
+  border: 3px solid var(--ink);
+  background: linear-gradient(155deg, var(--brand-soft) 0%, var(--surface) 65%);
+  box-shadow: var(--shadow-lg);
+}
+
+.heroArtIcon {
+  width: 38%;
+  height: 38%;
+  color: var(--brand);
+}
+
+.heroArtCard {
+  position: absolute;
+  right: -20px;
+  bottom: -22px;
+  width: 172px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  background: var(--color-white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.heroArtCardLine {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--panel-strong);
+}
+
+.heroArtCardToggle {
+  align-self: flex-end;
+  position: relative;
+  width: 30px;
+  height: 16px;
+  margin-top: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--color-success);
+}
+
+.heroArtCardDot {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   background: var(--color-white);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
-  color: var(--color-red);
 }
-.heroArtRing svg { width: 54px; height: 54px; }
 
 /* ============================================================
-   PROCESSO
+   PROCESSO — banda cinza-clara para separar da hero
    ============================================================ */
 .process {
   flex: 0 1 auto;
-  padding: clamp(8px, 2.5vh, var(--sp-xl)) 0 clamp(8px, 2.5vh, var(--sp-2xl));
+  padding: clamp(40px, 7vh, var(--sp-3xl)) 0;
+  background: var(--surface-raised);
 }
 
 .processInner {
@@ -228,9 +236,6 @@
 /* Curva ascendente que liga os três nós. Estica-se com o contentor
    (preserveAspectRatio="none"), por isso os centros dos nós estão nas
    mesmas percentagens usadas no path: 16,7% / 50% / 83,3%. */
-/* Mobile-first: por omissão é uma lista vertical sem a curva (ver bloco
-   "MOBILE" mais abaixo, que era a base antes da normalização de
-   breakpoints); a partir de 1024px passa a curva horizontal com os 3 nós. */
 .track {
   display: none;
   position: absolute;
@@ -248,7 +253,7 @@
 .steps {
   display: grid;
   grid-template-columns: 1fr;
-  gap: clamp(8px, 2.4vh, var(--sp-xl));
+  gap: clamp(28px, 4vh, var(--sp-xl));
   list-style: none;
   margin: 0;
   padding: 0;
@@ -282,17 +287,14 @@
   left: 21px;
   bottom: clamp(-28px, -3vh, -12px);
   width: 2px;
-  background: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.4) 0%,
-    rgba(255, 255, 255, 0.08) 100%
-  );
+  background: linear-gradient(180deg, var(--line-strong) 0%, transparent 100%);
 }
 @media (min-width: 1024px) {
   .step:not(:last-child)::before { content: none; }
 }
 
-/* Nó: círculo claro com contorno roxo; o terceiro nó vem preenchido. */
+/* Nó: círculo branco com contorno subtil e ícone roxo; o terceiro nó
+   vem preenchido a roxo, como marcador de chegada. */
 .node {
   position: absolute;
   top: 0;
@@ -305,8 +307,9 @@
   height: 44px;
   border-radius: 50%;
   background: var(--color-white);
-  color: var(--color-red);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  color: var(--brand);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow-sm);
 }
 @media (min-width: 1024px) {
   .node { position: relative; top: auto; left: auto; width: 48px; height: 48px; }
@@ -317,9 +320,10 @@
 }
 
 .nodeFilled {
-  background: var(--color-black);
+  background: var(--brand);
   color: var(--color-white);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.32);
+  border-color: transparent;
+  box-shadow: 0 10px 24px rgba(106, 74, 222, 0.32);
 }
 
 .stepIndex {
@@ -331,7 +335,11 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--color-white);
+  /* `--muted` (#74747e) só está verificado para 4,5:1 sobre branco puro;
+     esta secção assenta em `--surface-raised` (#f6f6f8), que o baixa
+     para 4,28:1 (axe-core apanhou isto) — `--body` é mais escuro e
+     mantém a folga em qualquer um dos dois fundos. */
+  color: var(--body);
 }
 @media (min-width: 1024px) {
   .stepIndex { margin-top: clamp(6px, 1.2vh, var(--sp-sm)); }
@@ -341,11 +349,11 @@
   position: relative;
   z-index: 1;
   margin: 6px 0 2px;
-  font-size: clamp(15px, 4vw, 21px);
+  font-size: clamp(16px, 4vw, 21px);
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1.25;
-  color: var(--color-white);
+  color: var(--ink);
   max-width: none;
   text-wrap: pretty;
 }
@@ -358,28 +366,30 @@
   z-index: 1;
   margin: 0;
   font-size: 14px;
-  line-height: 1.5;
-  color: var(--on-brand-2);
+  line-height: 1.55;
+  color: var(--body);
   max-width: none;
 }
 @media (min-width: 1024px) {
-  .stepDesc { line-height: 1.55; max-width: 30ch; }
+  .stepDesc { line-height: 1.6; max-width: 30ch; }
 }
 
 /* ============================================================
-   SECÇÕES ADICIONAIS DA HOMEPAGE (ponto 41)
-   O que aprendes · Preço · FAQ curto · CTA final.
-   Reaproveitam os tokens e o ritmo `full-section` já usados no
-   resto do site (o-curso, faq, contactos).
+   SECÇÕES ADICIONAIS DA HOMEPAGE
+   O que aprendes · Preço · FAQ curto · CTA final. Alternam
+   branco/cinza-claro para dar ritmo, tal como o resto do site já
+   alterna --surface-brand/--surface-brand-alt.
    ============================================================ */
 .section {
-  padding: clamp(20px, 6vh, 64px) 0;
+  padding: clamp(40px, 8vh, 96px) 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
-@media (min-width: 768px) {
-  .section { padding: clamp(28px, 8vh, 96px) 0; }
+
+.sectionPrice,
+.sectionFinal {
+  background: var(--surface-raised);
 }
 
 .sectionInner {
@@ -401,25 +411,24 @@
   font-family: var(--font-display);
   font-weight: 800;
   letter-spacing: -0.03em;
-  line-height: 1.1;
-  color: var(--color-white);
+  line-height: 1.12;
+  color: var(--ink);
   font-size: clamp(24px, 3.4vw, 38px);
   margin: 0 0 12px;
 }
 .sectionSub {
   font-size: 15px;
   line-height: 1.6;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0;
 }
-.sectionHead .eyebrow { justify-content: center; }
 
 .sectionLink {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   margin: clamp(20px, 4vh, 36px) auto 0;
-  color: var(--color-white);
+  color: var(--brand);
   font-weight: 700;
   font-size: 15px;
   text-decoration: none;
@@ -449,30 +458,35 @@
   align-items: center;
   gap: 14px;
   padding: 14px 18px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--hairline);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
+  transition: border-color 200ms ease;
 }
+.moduleCard:hover { border-color: var(--line-strong); }
 .moduleCardNum {
   flex-shrink: 0;
   font-family: var(--font-display);
   font-weight: 700;
   font-size: 13px;
-  color: var(--on-brand-3);
+  color: var(--brand);
 }
 .moduleCardTitle {
   font-size: 14.5px;
   font-weight: 600;
-  color: var(--color-white);
+  color: var(--ink);
   line-height: 1.4;
 }
 
-/* ---------- Preço ---------- */
+/* ---------- Preço ----------
+   Único bloco roxo-cheio da página — usa os tokens absolutos da marca
+   de propósito, para se destacar como o momento de conversão (o mesmo
+   papel que os cartões de preço já têm nas outras páginas do site). */
 .priceCard {
   max-width: 480px;
   margin: 0 auto;
-  background: var(--panel-invert-bg);
-  color: var(--on-invert);
+  background: var(--surface-brand);
+  color: var(--color-white);
   border-radius: var(--radius-xl);
   padding: 32px;
   box-shadow: var(--shadow-lg);
@@ -483,14 +497,14 @@
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--link-accent);
+  color: var(--on-brand-3);
   margin: 0 0 8px;
 }
 .priceTitle {
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
-  color: var(--on-invert);
+  color: var(--color-white);
   margin: 0 0 20px;
 }
 .priceRow {
@@ -505,26 +519,26 @@
   font-size: 44px;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--on-invert);
+  color: var(--color-white);
 }
 .priceMeta {
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
 }
 .priceUrgency {
   font-size: 13px;
   font-weight: 700;
-  color: var(--link-accent);
+  color: var(--color-white);
   margin: 0 0 20px;
 }
 .priceFeatures {
   list-style: none;
   margin: 0 0 24px;
   padding: 20px 0 0;
-  border-top: 1px solid var(--hairline-invert);
+  border-top: 1px solid var(--hairline-soft);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -535,7 +549,7 @@
   align-items: center;
   gap: 10px;
   font-size: 14px;
-  color: var(--on-invert-2);
+  color: var(--on-brand-2);
 }
 .priceFeatures svg {
   flex-shrink: 0;
@@ -543,8 +557,8 @@
   height: 18px;
   padding: 3px;
   border-radius: 50%;
-  background: var(--color-red);
-  color: var(--color-white);
+  background: var(--color-white);
+  color: var(--surface-brand);
 }
 .priceCta {
   display: inline-flex;
@@ -555,19 +569,18 @@
   min-height: 48px;
   padding: 14px 24px;
   border-radius: var(--radius-md);
-  background: var(--color-red);
-  color: var(--color-white);
+  background: var(--color-white);
+  color: var(--surface-brand);
   font-weight: 700;
   font-size: 15px;
   text-decoration: none;
-  box-shadow: 0 4px 14px rgba(124, 92, 255, 0.28);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
   transition: all 200ms ease;
 }
-.priceCta:hover { background: var(--color-red-2); transform: translateY(-2px); }
-.priceCta svg { width: 16px; height: 16px; }
+.priceCta:hover { transform: translateY(-2px); box-shadow: 0 8px 22px rgba(0, 0, 0, 0.24); }
 .priceSecure {
   font-size: 11.5px;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
   margin: 14px 0 0;
 }
 
@@ -581,19 +594,19 @@
   margin-inline: auto;
 }
 .faqItem {
-  border-bottom: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--line);
   padding-bottom: 18px;
 }
 .faqQ {
   font-size: 15.5px;
   font-weight: 700;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 6px;
 }
 .faqA {
   font-size: 14px;
   line-height: 1.6;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0;
 }
 
@@ -607,15 +620,15 @@
   font-family: var(--font-display);
   font-weight: 800;
   letter-spacing: -0.03em;
-  line-height: 1.1;
-  color: var(--color-white);
+  line-height: 1.12;
+  color: var(--ink);
   font-size: clamp(26px, 4vw, 42px);
   margin: 0 0 14px;
 }
 .finalCtaDesc {
   font-size: 15px;
   line-height: 1.6;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0 0 28px;
 }
 
@@ -625,9 +638,9 @@
    ============================================================ */
 @media (max-width: 1023px) and (max-height: 760px) {
   .eyebrow { display: none; }
-  .title { font-size: clamp(22px, 8vw, 34px); line-height: 1.05; }
+  .title { font-size: clamp(24px, 8vw, 34px); line-height: 1.08; }
   .subtitle { font-size: 14px; line-height: 1.4; }
-  .ctaPrimary, .ctaSecondary { min-height: 40px; padding: 10px 18px; font-size: 14px; }
+  .ctaPrimary { min-height: 40px; padding: 10px 18px; font-size: 14px; }
   .node { width: 36px; height: 36px; }
   .node svg { width: 16px; height: 16px; }
   .step { padding-left: 50px; min-height: 36px; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,8 @@
 /*
  * DESCRIÇÃO DO FICHEIRO: Landing page principal.
- * Hero com proposta de valor à esquerda e ícone de destaque à direita,
- * seguido dos três passos do processo ligados por uma curva ascendente.
+ * Hero com proposta de valor à esquerda e moldura com o olho da marca à
+ * direita, sobre fundo claro (classe `on-light`), seguido dos três passos
+ * do processo ligados por uma curva ascendente.
  */
 
 "use client";
@@ -22,6 +23,19 @@ const CheckIcon = ({ size = 11 }: { size?: number }) => (
 const ArrowIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
     <path d="M5 12h14M13 6l6 6-6 6" />
+  </svg>
+);
+
+/* Ícone do olho da marca (mesma geometria do logo-mark.svg), recolorido
+   para se destacar sobre o painel claro da ilustração do hero. */
+const EyeMark = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 512 512" aria-hidden>
+    <path
+      d="M 48 256 C 48 256 160 146 256 146 C 352 146 464 256 464 256 C 464 256 352 366 256 366 C 160 366 48 256 48 256 Z"
+      fill="currentColor"
+    />
+    <circle cx="256" cy="230" r="64" fill="#ffffff" />
+    <rect x="222" y="270" width="68" height="66" rx="20" fill="#ffffff" />
   </svg>
 );
 
@@ -66,9 +80,9 @@ export default function HomePage() {
   ];
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       {/* ----------------------------------------------------------
-          HERO — proposta de valor à esquerda, destaque à direita
+          HERO — proposta de valor à esquerda, moldura com o olho à direita
           ---------------------------------------------------------- */}
       <section className={styles.hero}>
         <div className={styles.heroInner}>
@@ -77,32 +91,31 @@ export default function HomePage() {
             <h1 className={styles.title}>
               {t.home.titleLine1}
               <br />
-              <span className={styles.titleAccent}>
-                {t.home.titleLine2}
-                <span className={styles.dot}>.</span>
-              </span>
+              {t.home.titleLine2}.
             </h1>
             <p className={styles.subtitle}>{t.home.subtitle}</p>
-            <p className={styles.valueProp}>{t.home.heroGuarantee}</p>
+            <p className={styles.valueProp}>
+              <CheckIcon />
+              {t.home.heroGuarantee}
+            </p>
 
             <div className={styles.ctaRow}>
               <Link href={primaryCta.href} className={styles.ctaPrimary}>
                 {primaryCta.label}
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                  <path d="M5 12h14M13 6l6 6-6 6" />
-                </svg>
               </Link>
             </div>
           </div>
 
           <div className={styles.heroArt} aria-hidden>
-            <div className={styles.heroArtGlow} />
-            <div className={styles.heroArtRing}>
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                <path d="M6 7h12l1 13a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2L6 7Z" />
-                <path d="M9 7a3 3 0 0 1 6 0" />
-                <path d="m9.5 12.5 1.7 1.7L15 10.5" />
-              </svg>
+            <div className={styles.heroArtFrame}>
+              <EyeMark className={styles.heroArtIcon} />
+              <div className={styles.heroArtCard}>
+                <span className={styles.heroArtCardLine} style={{ width: "72%" }} />
+                <span className={styles.heroArtCardLine} style={{ width: "48%" }} />
+                <span className={styles.heroArtCardToggle}>
+                  <span className={styles.heroArtCardDot} />
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -121,9 +134,9 @@ export default function HomePage() {
           >
             <defs>
               <linearGradient id="cmTrack" x1="0" y1="1" x2="1" y2="0">
-                <stop offset="0%" stopColor="#ffffff" stopOpacity="0.18" />
-                <stop offset="45%" stopColor="#ffffff" stopOpacity="0.55" />
-                <stop offset="100%" stopColor="#ffffff" stopOpacity="1" />
+                <stop offset="0%" stopColor="#6a4ade" stopOpacity="0.12" />
+                <stop offset="45%" stopColor="#6a4ade" stopOpacity="0.4" />
+                <stop offset="100%" stopColor="#6a4ade" stopOpacity="0.85" />
               </linearGradient>
             </defs>
             <path
@@ -189,7 +202,7 @@ export default function HomePage() {
       {/* ----------------------------------------------------------
           PREÇO — reaproveita os valores já usados em /o-curso
           ---------------------------------------------------------- */}
-      <section className={`${styles.section} full-section full-section-scroll`}>
+      <section className={`${styles.section} ${styles.sectionPrice} full-section full-section-scroll`}>
         <div className={styles.sectionInner}>
           <div className={styles.priceCard}>
             <p className={styles.priceEyebrow}>{t.home.pricingEyebrow}</p>
@@ -215,7 +228,6 @@ export default function HomePage() {
             </ul>
             <Link href={primaryCta.href} className={styles.priceCta}>
               {t.home.pricingCta}
-              <ArrowIcon />
             </Link>
             <p className={styles.priceSecure}>{t.coursePage.paymentSecure}</p>
           </div>
@@ -253,14 +265,13 @@ export default function HomePage() {
       {/* ----------------------------------------------------------
           CTA FINAL
           ---------------------------------------------------------- */}
-      <section className={`${styles.section} full-section full-section-scroll`}>
+      <section className={`${styles.section} ${styles.sectionFinal} full-section full-section-scroll`}>
         <div className={styles.sectionInner}>
           <div className={styles.finalCta}>
             <h2 className={styles.finalCtaTitle}>{t.home.finalCtaTitle}</h2>
             <p className={styles.finalCtaDesc}>{t.home.finalCtaDesc}</p>
             <Link href={primaryCta.href} className={styles.ctaPrimary}>
               {t.home.finalCtaButton}
-              <ArrowIcon />
             </Link>
           </div>
         </div>


### PR DESCRIPTION
Troca o hero roxo cheio por um layout de fundo branco com o roxo da
marca só como acento (eyebrow, botão, ícone do olho, cartão de preço),
reaproveitando o sistema de tokens `on-light` já usado nos cartões
brancos do site. Inclui uma nova ilustração no hero (moldura com o
olho da marca + mini-cartão de UI decorativo) e alterna secções
brancas/cinza-claro para dar ritmo até ao CTA final.

Âmbito limitado à homepage (app/page.tsx e app/page.module.css) — as
restantes páginas mantêm o fundo roxo por agora.