### PR TITLE
Migrate page color system from red/white to light theme

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -51,7 +51,7 @@ export default function CheckoutPage() {
 
   if (!paymentLink) {
     return (
-      <div className="full-section flex items-center justify-center">
+      <div className="full-section on-light bg-[color:var(--surface)] text-[color:var(--body)] flex items-center justify-center">
         <div className="text-center space-y-4 max-w-md px-4">
           <h1 className="text-xl font-semibold home-title-highlight-text">Pagamento indisponível de momento</h1>
           <p role="alert" className="text-sm sm:text-base leading-6 sm:leading-7">
@@ -63,7 +63,7 @@ export default function CheckoutPage() {
   }
 
   return (
-    <div className="full-section flex items-center justify-center">
+    <div className="full-section on-light bg-[color:var(--surface)] text-[color:var(--body)] flex items-center justify-center">
       <div className="text-center space-y-4">
         <h1 className="text-xl font-semibold home-title-highlight-text">Redirecionando para pagamento...</h1>
         <p className="text-sm sm:text-base leading-6 sm:leading-7">Se não for redirecionado automaticamente,</p>

--- a/app/contactos/page.module.css
+++ b/app/contactos/page.module.css
@@ -1,7 +1,9 @@
 /*
- * Página de contacto — sistema vermelho/branco.
- * Informação de contacto em texto branco sobre o vermelho; o formulário vive
- * num painel branco invertido, porque é onde o utilizador tem de escrever.
+ * Página de contacto — mesma linguagem clara da homepage.
+ * Informação de contacto em texto escuro sobre `--surface` (branco); o
+ * formulário continua num painel branco/elevado, como .login-form, porque é
+ * onde o utilizador tem de escrever — não inverte para roxo como os cartões
+ * de preço, é uma superfície funcional, não um acento de conversão.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -11,8 +13,8 @@
    LAYOUT PRIMITIVES
    ============================================================ */
 .page {
-  background: var(--surface-brand);
-  color: var(--color-white);
+  background: var(--surface);
+  color: var(--ink);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -41,7 +43,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 20px;
 }
 .eyebrow::before {
@@ -56,16 +58,16 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
-/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
+/* Realce do título: inversão do sistema — caixa roxa, texto branco. */
 .italic {
   font-style: normal;
   font-weight: 700;
-  color: var(--color-red);
-  background: var(--color-white);
+  color: var(--color-white);
+  background: var(--color-red);
   padding: 0 0.14em;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
@@ -73,7 +75,7 @@
 .lead {
   font-size: clamp(15px, 1.1vw, 18px);
   line-height: 1.7;
-  color: var(--on-brand-2);
+  color: var(--body);
   max-width: 56ch;
   margin: 0;
 }
@@ -104,7 +106,7 @@
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 18px;
 }
 .infoItems { display: flex; flex-direction: column; gap: 14px; }
@@ -113,8 +115,8 @@
   flex-shrink: 0;
   width: 40px; height: 40px;
   border-radius: var(--radius-md);
-  background: var(--color-white);
-  color: var(--color-red);
+  background: var(--color-red);
+  color: var(--color-white);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -125,11 +127,11 @@
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin-bottom: 4px;
 }
-.infoValue { font-size: 16px; color: var(--color-white); line-height: 1.4; overflow-wrap: anywhere; }
-.infoValue a { color: var(--color-white) !important; border-bottom: 1px solid rgba(255, 255, 255, 0.5); }
+.infoValue { font-size: 16px; color: var(--ink); line-height: 1.4; overflow-wrap: anywhere; }
+.infoValue a { color: var(--ink) !important; border-bottom: 1px solid var(--line-strong); }
 .infoValue a:hover { opacity: .8; }
 
 .badge {
@@ -138,10 +140,10 @@
   gap: 10px;
   padding: 13px 18px;
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.45);
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius-pill);
   font-size: 13px;
-  color: var(--color-white);
+  color: var(--ink);
   font-weight: 700;
   letter-spacing: 0.02em;
   margin-top: 18px;
@@ -149,12 +151,13 @@
 .badgeDot {
   width: 8px; height: 8px;
   border-radius: 50%;
-  background: var(--color-white);
-  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.22);
+  background: var(--color-red);
+  box-shadow: 0 0 0 4px rgba(124, 92, 255, 0.18);
 }
 
 /* ============================================================
-   FORM CARD — painel branco invertido
+   FORM CARD — painel branco elevado (como .login-form); fica igual mesmo
+   com a página agora clara, a sombra é que o separa do fundo.
    ============================================================ */
 .card {
   --muted: var(--on-invert-3);

--- a/app/contactos/page.tsx
+++ b/app/contactos/page.tsx
@@ -124,7 +124,7 @@ export default function ContactPage() {
   const hasErrors = Object.values(errors).some(Boolean) || Boolean(consentError);
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       {/* ============================================================
           CONTENT — título e informação de contacto à esquerda,
           formulário à direita, tudo num único ecrã sem scroll.

--- a/app/cookies/page.module.css
+++ b/app/cookies/page.module.css
@@ -1,7 +1,11 @@
 /*
- * Termos e Condições — sistema vermelho/branco.
- * Documento longo: cada cláusula fica num bloco translúcido sobre o vermelho,
- * com o número em caixa branca a servir de âncora de leitura.
+ * Política de Cookies / Termos / Privacidade — mesma linguagem clara da
+ * homepage (os três ficheiros são idênticos de propósito, ver STYLEGUIDE.md
+ * §3: copia este ficheiro para /privacidade e /termos-e-condicoes mantendo
+ * os nomes de classe iguais).
+ * Documento longo: cada cláusula fica num bloco elevado sobre `--surface`
+ * (branco), com o número em caixa roxa a servir de âncora de leitura. Raiz
+ * com `on-light` em page.tsx.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -12,8 +16,8 @@
    escala para cima. Breakpoints únicos do site: 640 / 768 / 1024 / 1280.
    ============================================================ */
 .page {
-  background: var(--surface-brand);
-  color: var(--color-white);
+  background: var(--surface);
+  color: var(--ink);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -42,7 +46,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 20px;
 }
 .eyebrow::before {
@@ -56,7 +60,7 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
@@ -66,7 +70,7 @@
    ============================================================ */
 .hero {
   padding: clamp(20px, 6vh, 64px) 0;
-  border-bottom: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--line);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -78,7 +82,7 @@
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin-top: 16px;
 }
 
@@ -87,16 +91,16 @@
    ============================================================ */
 .sections { display: flex; flex-direction: column; gap: 12px; }
 .termSection {
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid var(--hairline);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   padding: 24px;
   transition: border-color .2s, background .2s;
 }
 @media (min-width: 640px) { .termSection { padding: 32px 36px; } }
 .termSection:hover {
-  border-color: var(--color-white);
-  background: rgba(255, 255, 255, 0.11);
+  border-color: var(--line-strong);
+  background: var(--panel-strong);
 }
 .termHeader {
   display: flex;
@@ -108,8 +112,8 @@
   flex-shrink: 0;
   width: 44px; height: 44px;
   border-radius: var(--radius-sm);
-  background: var(--color-white);
-  color: var(--color-red);
+  background: var(--color-red);
+  color: var(--color-white);
   font-weight: 700;
   font-size: 18px;
   display: flex;
@@ -120,13 +124,17 @@
   font-size: 21px;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0;
   padding-top: 9px;
 }
 .termContent {
   font-size: 16px;
-  color: var(--on-brand-3);
+  /* `--muted` (#74747e) só está verificado para 4,5:1 sobre branco puro;
+     este bloco assenta em `--surface-raised` (#f6f6f8, ver .termSection),
+     que o baixa para 4,28:1 (axe-core apanhou isto) — `--body` é mais
+     escuro e mantém a folga (mesmo caso do .stepIndex na homepage). */
+  color: var(--body);
   line-height: 1.75;
   margin: 0;
   padding-left: 0;

--- a/app/cookies/page.tsx
+++ b/app/cookies/page.tsx
@@ -43,7 +43,7 @@ const sections = [
 
 export default function CookiesPage() {
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       <header className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.eyebrow}>Armazenamento local</div>

--- a/app/criar-conta/page.tsx
+++ b/app/criar-conta/page.tsx
@@ -87,7 +87,7 @@ export default function AccountPage() {
   };
 
   return (
-    <section className="full-section full-section-scroll w-full space-y-8">
+    <section className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form max-w-[620px]">
           <h1 className="form-heading">{t.auth.registerTitle}</h1>

--- a/app/curso/page.module.css
+++ b/app/curso/page.module.css
@@ -2,10 +2,15 @@
  * DESCRIÇÃO DO FICHEIRO: Estilos scoped da página /curso, sistema vermelho/branco.
  * Convenção: classes camelCase para acesso direto via styles.xxx
  *
- * A capa do curso (cabeçalho + lista de módulos) vive sobre o vermelho da
- * marca. O leitor é um overlay com chrome vermelho e corpo branco: são
- * milhares de palavras por módulo, e o branco é a superfície onde o texto
- * longo se lê sem cansar. O quiz e o resultado vivem dentro desse corpo.
+ * A capa do curso (cabeçalho + lista de módulos) vive sobre `--surface`
+ * (branco, como o resto do site — raiz com `on-light` em page.tsx). O
+ * leitor é um overlay com chrome vermelho e corpo branco: são milhares de
+ * palavras por módulo, e o branco é a superfície onde o texto longo se lê
+ * sem cansar — já usava os tokens `--on-invert*`/`--panel-invert-bg`, por
+ * isso não muda com esta conversão. O quiz e o resultado vivem dentro
+ * desse corpo. O cartão de progresso e os distintivos "atual"/"concluído"
+ * continuam a inverter para o roxo cheio da marca, como o cartão de preço
+ * da homepage.
  */
 
 /* Reset das regras globais que entram nesta página.
@@ -48,8 +53,8 @@
    PRIMITIVAS DE LAYOUT
    ============================================================ */
 .page {
-  background: var(--surface-brand);
-  color: var(--on-brand-2);
+  background: var(--surface);
+  color: var(--body);
   font-size: 15px;
   line-height: 1.7;
   font-family: var(--font-body);
@@ -71,7 +76,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 18px;
 }
 .eyebrow::before {
@@ -80,14 +85,14 @@
   background: currentColor;
   flex-shrink: 0;
 }
-.eyebrowAccent { color: var(--color-white); }
+.eyebrowAccent { color: var(--color-red); }
 
 .display {
   font-family: var(--font-display);
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0;
 }
 .displayXl { font-size: clamp(30px, 4.2vw, 58px); }
@@ -95,7 +100,7 @@
 .lead {
   font-size: 16px;
   line-height: 1.7;
-  color: var(--on-brand-2);
+  color: var(--body);
   max-width: 56ch;
   margin: 0;
 }
@@ -122,26 +127,28 @@
 .page .btn:hover:not(:disabled) { transform: translateY(-2px); }
 .page .btn:active:not(:disabled) { transform: translateY(0); }
 
-/* Principal sobre vermelho: branco cheio. */
+/* Principal sobre branco: roxo cheio (como .ctaPrimary da homepage). Dentro
+   do leitor/quiz, os overrides mais abaixo (.quiz, .readerTop/.readerBottom)
+   tomam prioridade e continuam vermelho-sobre-branco / branco-sobre-vermelho. */
 .page .btnPrimary {
-  background: var(--color-white);
-  color: var(--color-red);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.16);
+  background: var(--color-red);
+  color: var(--color-white);
+  box-shadow: 0 4px 14px rgba(124, 92, 255, 0.28);
 }
 .page .btnPrimary:hover:not(:disabled) {
-  background: var(--color-white);
-  color: var(--color-red-3);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.22);
+  background: var(--color-red-2);
+  color: var(--color-white);
+  box-shadow: 0 8px 22px rgba(124, 92, 255, 0.34);
 }
 .page .btnGhost {
   background: transparent;
-  color: var(--color-white);
-  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  color: var(--ink);
+  border: 1.5px solid var(--line-strong);
   padding: 14.5px 30.5px;
 }
 .page .btnGhost:hover:not(:disabled) {
-  border-color: var(--color-white);
-  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--ink);
+  background: var(--panel-strong);
 }
 .page .btnAccent {
   background: transparent;
@@ -189,11 +196,11 @@
 .courseHeadTitle {
   margin: 0 0 20px;
 }
-/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
+/* Realce do título: inversão do sistema — caixa roxa, texto branco. */
 .courseHeadTitle em {
   font-style: normal;
-  color: var(--color-red);
-  background: var(--color-white);
+  color: var(--color-white);
+  background: var(--color-red);
   padding: 0 0.14em;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
@@ -201,18 +208,20 @@
 .courseHeadSub {
   font-size: 15px;
   line-height: 1.75;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0;
   max-width: 48ch;
   text-wrap: pretty;
 }
 
-/* Cartão de progresso — painel branco invertido. */
+/* Cartão de progresso — painel roxo cheio, o único acento forte da capa
+   (mesmo papel que .priceCard na homepage). */
 .progressCard {
-  --muted: var(--on-invert-3);
+  --muted: var(--on-brand-3);
+  --body: var(--on-brand-2);
 
-  background: var(--panel-invert-bg);
-  color: var(--on-invert);
+  background: var(--surface-brand);
+  color: var(--color-white);
   border: none;
   border-radius: var(--radius-xl);
   padding: 28px;
@@ -225,7 +234,7 @@
   position: absolute;
   top: 0; left: var(--radius-xl);
   width: 56px; height: 4px;
-  background: var(--color-red);
+  background: var(--color-white);
 }
 .progressCardRow {
   display: flex;
@@ -239,16 +248,16 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1;
-  color: var(--on-invert);
+  color: var(--color-white);
 }
 .progressCardCount em {
   font-style: normal;
-  color: var(--link-accent);
+  color: var(--color-white);
 }
 .progressCardCount span {
   font-size: 16px;
   font-weight: 600;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
   margin-left: 6px;
 }
 .progressCardPct {
@@ -256,28 +265,28 @@
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--link-accent);
+  color: var(--on-brand-3);
   text-align: right;
 }
 .progressBar {
   height: 5px;
-  background: var(--track-invert);
+  background: rgba(255, 255, 255, 0.22);
   border-radius: var(--radius-pill);
   overflow: hidden;
   position: relative;
 }
 .progressBarFill {
   height: 100%;
-  background: var(--color-red);
+  background: var(--color-white);
   transition: width .6s cubic-bezier(0.23, 1, 0.32, 1);
 }
 .progressCardLabel {
   margin-top: 16px;
   font-size: 13.5px;
-  color: var(--on-invert-3);
+  color: var(--on-brand-2);
   line-height: 1.6;
 }
-.progressCardLabel strong { color: var(--on-invert); font-weight: 700; }
+.progressCardLabel strong { color: var(--color-white); font-weight: 700; }
 
 /* ============================================================
    LISTA DE MÓDULOS
@@ -296,7 +305,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 28px 0 14px;
-  border-top: 1px solid var(--hairline);
+  border-top: 1px solid var(--line);
   margin-top: 28px;
   flex-wrap: wrap;
   gap: 16px;
@@ -306,7 +315,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0;
 }
 .mod {
@@ -319,7 +328,7 @@
   row-gap: 10px;
   padding: 18px 0;
   align-items: start;
-  border-top: 1px solid var(--hairline);
+  border-top: 1px solid var(--line);
   transition: background .25s, padding .25s;
   cursor: pointer;
   position: relative;
@@ -335,8 +344,8 @@
     padding: 26px 0;
   }
 }
-.mod:last-of-type { border-bottom: 1px solid var(--hairline); }
-.mod:not(:disabled):hover { background: rgba(255, 255, 255, 0.08); padding-left: 16px; }
+.mod:last-of-type { border-bottom: 1px solid var(--line); }
+.mod:not(:disabled):hover { background: var(--surface-raised); padding-left: 16px; }
 .mod:disabled,
 .modLocked {
   opacity: .4;
@@ -352,22 +361,22 @@
   font-size: 24px;
   letter-spacing: -0.04em;
   line-height: 1.15;
-  color: var(--on-brand-2);
+  color: var(--body);
 }
-.modDone .modNum { color: var(--color-white); }
-.modCurrent .modNum { color: var(--color-white); }
+.modDone .modNum { color: var(--color-red); }
+.modCurrent .modNum { color: var(--color-red); }
 .modBody { grid-area: body; min-width: 0; }
 .modTitle {
   font-size: clamp(15px, 1.4vw, 18px);
   font-weight: 700;
   letter-spacing: -0.025em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 5px;
   overflow-wrap: break-word;
 }
 .modDesc {
   font-size: 14px;
-  color: var(--on-brand-2);
+  color: var(--body);
   line-height: 1.7;
   margin: 0;
   max-width: 68ch;
@@ -397,19 +406,19 @@
   padding: 6px 11px;
   border-radius: var(--radius-pill);
   background: transparent;
-  color: var(--on-brand-2);
-  border: 1px solid var(--hairline-strong);
+  color: var(--body);
+  border: 1px solid var(--line-strong);
   white-space: nowrap;
 }
 .modBadgeCurrent {
-  background: var(--color-white);
-  color: var(--color-red);
-  border-color: var(--color-white);
+  background: var(--color-red);
+  color: var(--color-white);
+  border-color: var(--color-red);
 }
 .modBadgeLocked {
   background: transparent;
-  color: var(--on-brand-2);
-  border-color: var(--hairline);
+  color: var(--muted);
+  border-color: var(--line);
 }
 .modBadgeDone {
   background: var(--color-success);
@@ -418,18 +427,18 @@
 }
 .modArrow {
   width: 28px; height: 28px;
-  border: 1px solid var(--hairline-strong);
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-white);
+  color: var(--ink);
   transition: background .2s, color .2s, border-color .2s;
 }
 .mod:not(:disabled):hover .modArrow {
-  background: var(--color-white);
-  color: var(--color-red);
-  border-color: var(--color-white);
+  background: var(--color-red);
+  color: var(--color-white);
+  border-color: var(--color-red);
 }
 
 /* ============================================================

--- a/app/curso/page.tsx
+++ b/app/curso/page.tsx
@@ -393,7 +393,7 @@ function CursoPageContent() {
 
   if (progressLoadError) {
     return (
-      <div className={styles.page}>
+      <div className={`${styles.page} on-light`}>
         <div className={styles.wrap} style={{ padding: "80px 28px", textAlign: "center" }}>
           <p role="alert" className={styles.lead} style={{ marginBottom: 24 }}>{progressLoadError}</p>
           <button type="button" className={`${styles.btn} ${styles.btnPrimary}`} onClick={() => loadProgress()}>
@@ -406,7 +406,7 @@ function CursoPageContent() {
 
   if (!isAuthenticated && !accessDenied) {
     return (
-      <div className={styles.page} aria-busy="true" aria-label={cp.verifyingSession}>
+      <div className={`${styles.page} on-light`} aria-busy="true" aria-label={cp.verifyingSession}>
         <div className={styles.wrap} style={{ padding: "80px 28px" }}>
           <div
             className={`${styles.progressCard} animate-pulse`}
@@ -419,7 +419,7 @@ function CursoPageContent() {
 
   if (accessDenied) {
     return (
-      <div className={styles.page}>
+      <div className={`${styles.page} on-light`}>
         <div className={styles.wrap} style={{ padding: "80px 28px" }}>
           <div className={styles.eyebrow}>Acesso restrito</div>
           <h1 className={`${styles.display} ${styles.displayLg}`} style={{ marginBottom: 16 }}>
@@ -441,7 +441,7 @@ function CursoPageContent() {
 
   if (modulesLoadError) {
     return (
-      <div className={styles.page}>
+      <div className={`${styles.page} on-light`}>
         <div className={styles.wrap} style={{ padding: "80px 28px", textAlign: "center" }}>
           <p role="alert" className={styles.lead} style={{ marginBottom: 24 }}>{modulesLoadError}</p>
           <button type="button" className={`${styles.btn} ${styles.btnPrimary}`} onClick={() => loadModules()}>
@@ -454,7 +454,7 @@ function CursoPageContent() {
 
   if (!modules) {
     return (
-      <div className={styles.page} aria-busy="true" aria-label={cp.verifyingSession}>
+      <div className={`${styles.page} on-light`} aria-busy="true" aria-label={cp.verifyingSession}>
         <div className={styles.wrap} style={{ padding: "80px 28px" }}>
           <div
             className={`${styles.progressCard} animate-pulse`}
@@ -494,7 +494,7 @@ function CursoPageContent() {
     : null;
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       {/* ============================================================
           STATE 1 — Module index
           ============================================================ */}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -418,7 +418,7 @@ function DashboardPageContent() {
 
   if (!profile && profileLoadError) {
     return (
-      <section className="full-section full-section-scroll w-full px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
+      <section className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <div className="mx-auto flex w-full max-w-md flex-col items-center gap-4 text-center">
           <p role="alert" className="text-sm text-[color:var(--muted)]">{profileLoadError}</p>
           <button
@@ -439,7 +439,7 @@ function DashboardPageContent() {
   if (!profile) {
     return (
       <section
-        className="full-section full-section-scroll w-full space-y-4 px-3 py-4 sm:px-6 sm:py-5 md:px-8 md:py-6"
+        className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full space-y-4 px-3 py-4 sm:px-6 sm:py-5 md:px-8 md:py-6"
         aria-busy="true"
         aria-label={d.loading}
       >
@@ -455,7 +455,7 @@ function DashboardPageContent() {
   }
 
   return (
-    <section className="full-section full-section-scroll w-full space-y-2 px-3 py-3 sm:px-5 sm:py-4 md:px-6 md:py-4">
+    <section className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full space-y-2 px-3 py-3 sm:px-5 sm:py-4 md:px-6 md:py-4">
       {mustCompleteProfile && (
         <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/70 p-4">
           <div className="login-form w-full max-w-2xl">

--- a/app/entrar/page.tsx
+++ b/app/entrar/page.tsx
@@ -107,7 +107,7 @@ export default function LoginPage() {
   };
 
   return (
-    <section className="full-section full-section-scroll w-full space-y-8">
+    <section className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <h1 className="form-heading">{t.auth.loginTitle}</h1>

--- a/app/faq/page.module.css
+++ b/app/faq/page.module.css
@@ -1,7 +1,9 @@
 /*
- * Cliente Mistério — Página FAQ, sistema vermelho/branco.
- * Acordeão tipográfico sobre o vermelho da marca: as respostas são separadas
- * por filetes brancos finos, sem cartões, para manter a leitura calma.
+ * Cliente Mistério — Página FAQ, mesma linguagem clara da homepage.
+ * Acordeão tipográfico sobre `--surface` (branco): as respostas são
+ * separadas por filetes finos, sem cartões, para manter a leitura calma. O
+ * CTA final inverte para o roxo cheio da marca, como o cartão de preço da
+ * homepage. Raiz com `on-light` em page.tsx.
  */
 
 /* Reset das regras globais de <button> dentro desta página. */
@@ -29,8 +31,8 @@
 .page button::after { content: none; }
 
 .page {
-  background: var(--surface-brand);
-  color: var(--on-brand-2);
+  background: var(--surface);
+  color: var(--body);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -72,7 +74,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 22px;
 }
 .eyebrow::before {
@@ -86,27 +88,27 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(32px, 4.6vw, 60px);
   margin: 0 0 18px;
 }
 .sub {
   font-size: clamp(15px, 1.15vw, 18px);
   line-height: 1.65;
-  color: var(--on-brand-2);
+  color: var(--body);
   max-width: 52ch;
   margin: 0 auto;
   text-wrap: pretty;
   font-weight: 400;
 }
 .subLink {
-  color: var(--color-white);
+  color: var(--color-red);
   font-weight: 700;
   text-decoration: none;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+  border-bottom: 1px solid rgba(106, 74, 222, 0.4);
   transition: border-color .2s;
 }
-.subLink:hover { border-color: var(--color-white); }
+.subLink:hover { border-color: var(--color-red); }
 
 /* ---------- Pesquisa ---------- */
 .searchWrap {
@@ -115,7 +117,7 @@
   margin: clamp(20px, 4vh, 36px) auto 0;
   display: flex;
   align-items: center;
-  color: var(--on-brand-2);
+  color: var(--body);
 }
 .searchWrap svg {
   position: absolute;
@@ -127,26 +129,29 @@
   width: 100%;
   height: 52px;
   padding: 0 18px 0 50px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid var(--hairline);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-pill);
-  color: var(--color-white);
+  color: var(--ink);
   font-size: 16px;
   font-family: inherit;
   outline: none;
   transition: border-color .2s, background .2s;
 }
-.searchInput::placeholder { color: var(--on-brand-3); }
+/* `--muted` só está verificado para 4,5:1 sobre branco puro; este campo
+   assenta em `--surface-raised` (#f6f6f8), que o baixa para 4,28:1 —
+   `--body` mantém a folga (mesmo caso do .termContent nas páginas legais). */
+.searchInput::placeholder { color: var(--body); }
 .searchInput:focus {
-  border-color: var(--color-white);
-  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--color-red);
+  background: var(--panel-strong);
 }
 .searchInput::-webkit-search-cancel-button { cursor: pointer; }
 
 .noResults {
   font-size: 16px;
   line-height: 1.7;
-  color: var(--on-brand-2);
+  color: var(--body);
   text-align: center;
   padding: 32px 0;
 }
@@ -159,24 +164,24 @@
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--on-brand-3);
+  color: var(--muted);
   margin: 40px 0 4px;
   scroll-margin-top: var(--header-h);
 }
 .group:first-child .groupTitle { margin-top: 0; }
 .groupCta {
   font-size: 13.5px;
-  color: var(--on-brand-3);
+  color: var(--muted);
   margin: 16px 0 0;
   padding-bottom: 8px;
 }
 
 /* ---------- Accordion ---------- */
 .faq {
-  border-top: 1px solid var(--hairline);
+  border-top: 1px solid var(--line);
   margin-top: 12px;
 }
-.faqItem { border-bottom: 1px solid var(--hairline); scroll-margin-top: var(--header-h); }
+.faqItem { border-bottom: 1px solid var(--line); scroll-margin-top: var(--header-h); }
 .faqQHeading {
   margin: 0;
   font-size: inherit;
@@ -195,7 +200,7 @@
   font-size: clamp(16px, 1.4vw, 19px);
   font-weight: 700;
   letter-spacing: -0.025em;
-  color: var(--color-white);
+  color: var(--ink);
   background: transparent;
   border: 0;
   cursor: pointer;
@@ -206,7 +211,7 @@
 .faqIcon {
   flex-shrink: 0;
   width: 34px; height: 34px;
-  border: 1px solid var(--hairline-strong);
+  border: 1px solid var(--line-strong);
   border-radius: 50%;
   position: relative;
   transition: all .3s cubic-bezier(0.23, 1, 0.320, 1);
@@ -214,18 +219,18 @@
 .faqIcon::before, .faqIcon::after {
   content: "";
   position: absolute;
-  background: var(--color-white);
+  background: var(--ink);
   top: 50%; left: 50%;
   transition: all .3s cubic-bezier(0.23, 1, 0.320, 1);
 }
 .faqIcon::before { width: 12px; height: 2px; transform: translate(-50%,-50%); }
 .faqIcon::after { width: 2px; height: 12px; transform: translate(-50%,-50%); }
 .faqItemOpen .faqIcon {
-  background: var(--color-white);
-  border-color: var(--color-white);
+  background: var(--color-red);
+  border-color: var(--color-red);
 }
 .faqItemOpen .faqIcon::before,
-.faqItemOpen .faqIcon::after { background: var(--color-red); }
+.faqItemOpen .faqIcon::after { background: var(--color-white); }
 .faqItemOpen .faqIcon::after { transform: translate(-50%,-50%) rotate(90deg); }
 
 .faqA {
@@ -236,7 +241,7 @@
 .faqAInner {
   padding: 0 0 24px;
   max-width: 68ch;
-  color: var(--on-brand-2);
+  color: var(--body);
   font-size: 16px;
   line-height: 1.75;
   text-wrap: pretty;
@@ -244,10 +249,11 @@
 }
 .faqItemOpen .faqA { max-height: 400px; }
 
-/* ---------- CTA — painel branco a fechar a página ---------- */
+/* ---------- CTA — painel roxo cheio a fechar a página, o momento de
+   conversão (mesmo papel que .priceCard na homepage). ---------- */
 .cta {
   margin-top: 56px;
-  background: var(--panel-invert-bg);
+  background: var(--surface-brand);
   border-radius: var(--radius-xl);
   padding: 36px 32px;
   display: flex;
@@ -255,7 +261,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  color: var(--on-invert);
+  color: var(--color-white);
   box-shadow: var(--shadow-lg);
   position: relative;
   overflow: hidden;
@@ -265,22 +271,22 @@
   position: absolute;
   inset: 0 0 auto 0;
   height: 4px;
-  background: var(--color-red);
+  background: var(--color-white);
 }
 .ctaTitle {
   font-size: clamp(21px, 2.4vw, 30px);
   font-weight: 700;
   letter-spacing: -0.035em;
-  color: var(--on-invert);
+  color: var(--color-white);
   margin: 0 0 6px;
 }
 .ctaSub {
   font-size: 15px;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
   margin: 0;
   font-weight: 400;
 }
-/* CTA sólido vermelho sobre o painel branco. */
+/* CTA sólido branco sobre o painel roxo (como .priceCta na homepage). */
 .ctaBtn {
   display: inline-flex;
   align-items: center;
@@ -294,15 +300,15 @@
   white-space: nowrap;
   text-decoration: none;
   border: none !important;
-  background: var(--color-red);
-  color: var(--color-white) !important;
-  box-shadow: 0 4px 14px rgba(124, 92, 255, 0.28);
+  background: var(--color-white);
+  color: var(--surface-brand) !important;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
   transition: all 200ms ease;
 }
 .ctaBtn:hover {
   transform: translateY(-2px);
-  background: var(--color-red-2);
-  box-shadow: 0 8px 22px rgba(124, 92, 255, 0.34);
+  background: var(--color-white);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.24);
 }
 .ctaBtn:active { transform: translateY(0); }
 .ctaBtn svg { transition: transform 200ms ease; }

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -90,7 +90,7 @@ function FaqPageContent() {
   }, []);
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       <section className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.eyebrow}>Perguntas frequentes</div>

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -44,7 +44,7 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <section className="full-section full-section-scroll w-full space-y-8">
+    <section className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <h1 className="form-heading">{t.auth.forgotPasswordTitle}</h1>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -9,7 +9,7 @@
 export default function GlobalError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <html lang="pt-PT">
-      <body className="bg-[color:var(--background,#5a3dc7)] text-white antialiased">
+      <body className="on-light bg-[color:var(--surface,#ffffff)] text-[color:var(--ink,#141416)] antialiased">
         <div className="flex min-h-dvh flex-col items-center justify-center gap-6 px-6 text-center">
           <p className="text-label">Erro 500</p>
           <h1 className="page-title">Algo correu mal.</h1>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,29 +12,31 @@ export const metadata = {
 
 export default function NotFound() {
   return (
-    <div className="full-section container-sm mx-auto flex flex-col items-center gap-6 px-6 py-24 text-center">
-      <p className="text-label">Erro 404</p>
-      <h1 className="page-title">Esta página não existe.</h1>
-      <p className="text-body-lg max-w-[52ch]">
-        O endereço que procuras pode ter mudado ou nunca ter existido. Aqui tens alguns
-        caminhos úteis para continuares.
-      </p>
+    <div className="full-section on-light bg-[color:var(--surface)] flex flex-col items-center justify-center">
+      <div className="container-sm mx-auto flex flex-col items-center gap-6 px-6 py-24 text-center">
+        <p className="text-label">Erro 404</p>
+        <h1 className="page-title">Esta página não existe.</h1>
+        <p className="text-body-lg max-w-[52ch]">
+          O endereço que procuras pode ter mudado ou nunca ter existido. Aqui tens alguns
+          caminhos úteis para continuares.
+        </p>
 
-      <div className="hero-buttons">
-        <Link href="/o-curso" className="button primary">
-          Ver o curso
-        </Link>
-        <Link href="/faq" className="button secondary">
-          FAQ
-        </Link>
-        <Link href="/contactos" className="button secondary">
-          Contactos
+        <div className="hero-buttons">
+          <Link href="/o-curso" className="button primary">
+            Ver o curso
+          </Link>
+          <Link href="/faq" className="button secondary">
+            FAQ
+          </Link>
+          <Link href="/contactos" className="button secondary">
+            Contactos
+          </Link>
+        </div>
+
+        <Link href="/" className="form-link mt-4">
+          Voltar à página inicial
         </Link>
       </div>
-
-      <Link href="/" className="form-link mt-4">
-        Voltar à página inicial
-      </Link>
     </div>
   );
 }

--- a/app/o-curso/page.module.css
+++ b/app/o-curso/page.module.css
@@ -1,8 +1,10 @@
 /*
- * O-curso — página de venda do curso, sistema vermelho/branco.
- * Vermelho de base, painéis brancos onde é preciso foco (cartão de preço,
- * primeiro benefício) e um bloco preto para o currículo, que ancora a
- * página a meio antes do CTA final.
+ * O-curso — página de venda do curso, mesma linguagem clara da homepage.
+ * Base branca, painéis roxo cheio onde é preciso o momento de conversão
+ * (cartão de preço no hero, CTA final) e um bloco preto para o currículo,
+ * que ancora a página a meio — os três blocos fortes continuam a dar ritmo,
+ * só a base é que deixou de ser vermelha. A raiz da página leva `on-light`
+ * em page.tsx.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -12,8 +14,8 @@
    LAYOUT PRIMITIVES
    ============================================================ */
 .page {
-  background: var(--surface-brand);
-  color: var(--on-brand-2);
+  background: var(--surface);
+  color: var(--body);
   font-size: 15px;
   line-height: 1.7;
   font-family: var(--font-body);
@@ -56,7 +58,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 20px;
 }
 .eyebrow::before {
@@ -72,7 +74,7 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(32px, 4.8vw, 64px);
   margin: 0;
 }
@@ -81,15 +83,15 @@
   font-weight: 700;
   letter-spacing: -0.035em;
   line-height: 1.08;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(24px, 3.2vw, 42px);
   margin: 0;
 }
-/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
+/* Realce do título: inversão do sistema — caixa roxa, texto branco. */
 .italic {
   font-style: normal;
-  color: var(--color-red);
-  background: var(--color-white);
+  color: var(--color-white);
+  background: var(--color-red);
   padding: 0 0.14em;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
@@ -97,7 +99,7 @@
 .lead {
   font-size: clamp(15px, 1.1vw, 18px);
   line-height: 1.7;
-  color: var(--on-brand-2);
+  color: var(--body);
   max-width: 56ch;
   margin: 0;
 }
@@ -124,7 +126,7 @@
 .page .btn:hover { transform: translateY(-2px); }
 .page .btn:active { transform: translateY(0); }
 
-/* Sólido — CTA principal. Vive dentro do cartão branco, logo vermelho. */
+/* Sólido — CTA principal, roxo sobre branco. */
 .page .btnDark {
   background: var(--color-red);
   color: var(--color-white);
@@ -135,7 +137,8 @@
   box-shadow: 0 8px 22px rgba(124, 92, 255, 0.34);
 }
 
-/* Vazado branco — ação secundária sobre superfícies vermelhas/pretas. */
+/* Vazado branco — ação secundária sobre superfícies roxas/pretas
+   (cartão de preço, CTA final, currículo). */
 .page .btnAccent {
   background: transparent;
   border: 1.5px solid rgba(255, 255, 255, 0.5);
@@ -182,7 +185,7 @@
   display: flex;
   gap: 40px;
   padding-top: 30px;
-  border-top: 1px solid var(--hairline);
+  border-top: 1px solid var(--line);
   flex-wrap: wrap;
 }
 .statNum {
@@ -190,30 +193,31 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1;
-  color: var(--color-white);
+  color: var(--ink);
 }
 .statNum em {
   font-style: normal;
-  color: var(--color-white);
+  color: var(--ink);
 }
 .statLabel {
   font-size: 11px;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin-top: 10px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.2em;
 }
 
-/* Cartão de preço (no hero) — painel branco invertido. */
+/* Cartão de preço (no hero) — painel roxo cheio, o momento de conversão
+   (mesmo papel que .priceCard na homepage). */
 .card {
-  --line: var(--hairline-invert);
-  --muted: var(--on-invert-3);
-  --body: var(--on-invert-2);
+  --line: var(--hairline-soft);
+  --muted: var(--on-brand-3);
+  --body: var(--on-brand-2);
 
   position: relative;
-  background: var(--panel-invert-bg);
-  color: var(--on-invert);
+  background: var(--surface-brand);
+  color: var(--color-white);
   border: none;
   border-radius: var(--radius-xl);
   padding: 24px 30px;
@@ -227,7 +231,7 @@
   left: var(--radius-xl);
   width: 72px;
   height: 4px;
-  background: var(--color-red);
+  background: var(--color-white);
 }
 .cardBadge {
   display: inline-flex;
@@ -237,20 +241,20 @@
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--link-accent);
-  border: 1px solid rgba(124, 92, 255, 0.35);
+  color: var(--color-white);
+  border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: var(--radius-pill);
   padding: 6px 12px;
   margin-bottom: 14px;
 }
-.cardTitle { font-size: 14px; font-weight: 600; color: var(--on-invert); margin: 0 0 8px; }
+.cardTitle { font-size: 14px; font-weight: 600; color: var(--color-white); margin: 0 0 8px; }
 .cardPriceRow { display: flex; align-items: baseline; gap: 12px; margin-bottom: 4px; flex-wrap: wrap; }
-.cardOrig { font-size: 17px; color: var(--on-invert-3); text-decoration: line-through; }
+.cardOrig { font-size: 17px; color: var(--on-brand-3); text-decoration: line-through; }
 .cardPrice {
   font-size: 36px;
   font-weight: 700;
   letter-spacing: -0.04em;
-  color: var(--on-invert);
+  color: var(--color-white);
   line-height: 1;
 }
 .discountBadge {
@@ -259,8 +263,8 @@
   align-self: center;
   padding: 4px 10px;
   border-radius: var(--radius-pill);
-  background: rgba(18, 160, 109, 0.12);
-  color: var(--color-success);
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--color-white);
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
@@ -272,7 +276,7 @@
   flex-wrap: wrap;
   gap: 8px;
   font-size: 11px;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
   margin: 0 0 10px;
   text-transform: uppercase;
   letter-spacing: 0.18em;
@@ -284,14 +288,14 @@
   gap: 5px;
   padding: 3px 10px;
   border-radius: var(--radius-pill);
-  background: rgba(124, 92, 255, 0.1);
-  color: var(--link-accent);
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--color-white);
   letter-spacing: 0.04em;
 }
 .urgencyNote {
   font-size: 12.5px;
   font-weight: 700;
-  color: var(--link-accent);
+  color: var(--color-white);
   margin: 0 0 14px;
   line-height: 1.4;
 }
@@ -300,8 +304,8 @@
   flex-direction: column;
   gap: 8px;
   padding: 14px 0;
-  border-top: 1px solid var(--hairline-invert);
-  border-bottom: 1px solid var(--hairline-invert);
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
   margin-bottom: 16px;
 }
 .featureItem {
@@ -309,14 +313,14 @@
   align-items: center;
   gap: 12px;
   font-size: 13px;
-  color: var(--on-invert-2);
+  color: var(--on-brand-2);
 }
 .check {
   flex-shrink: 0;
   width: 20px; height: 20px;
   border-radius: var(--radius-sm);
-  background: var(--color-red);
-  color: var(--color-white);
+  background: var(--color-white);
+  color: var(--surface-brand);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -324,15 +328,27 @@
 .secureNote {
   text-align: center;
   font-size: 11px;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
   margin-top: 10px;
   text-transform: uppercase;
   letter-spacing: 0.16em;
   font-weight: 700;
 }
+/* Dentro do cartão de preço (já roxo cheio) o CTA principal inverte para
+   branco, como na homepage. */
+.card .btnDark {
+  background: var(--color-white);
+  color: var(--surface-brand);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+}
+.card .btnDark:hover {
+  background: var(--color-white);
+  color: var(--color-red-3);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.24);
+}
 
 /* ============================================================
-   CONFIANÇA
+   CONFIANÇA (não usado atualmente — mantido pronto a reativar)
    ============================================================ */
 .trustBar {
   display: flex;
@@ -340,9 +356,9 @@
   align-items: center;
   gap: 20px;
   padding: 24px;
-  border: 1px solid var(--hairline);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-raised);
 }
 @media (min-width: 768px) {
   .trustBar { gap: 32px; padding: 28px 32px; }
@@ -353,8 +369,8 @@
   gap: 8px;
   padding: 10px 16px;
   border-radius: var(--radius-pill);
-  background: var(--color-white);
-  color: var(--color-red);
+  background: var(--color-red);
+  color: var(--color-white);
   font-size: 12px;
   font-weight: 700;
   text-transform: uppercase;
@@ -365,18 +381,19 @@
   font-size: clamp(22px, 2.4vw, 30px);
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-white);
+  color: var(--ink);
   line-height: 1;
 }
 .trustStatLabel {
   font-size: 12px;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin-top: 6px;
   font-weight: 600;
   line-height: 1.4;
 }
 /* ============================================================
-   TESTEMUNHOS — carrossel horizontal com scroll-snap (sem JS)
+   TESTEMUNHOS — carrossel horizontal com scroll-snap (não usado
+   atualmente — ver nota em page.tsx; mantido pronto a reativar)
    ============================================================ */
 .testimonialsTitle { margin-bottom: 28px; }
 .testimonials {
@@ -391,21 +408,21 @@
 .testimonial {
   flex: 0 0 min(320px, 88vw);
   scroll-snap-align: start;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--hairline);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   padding: 28px;
 }
-.testimonialStars { display: flex; gap: 4px; color: var(--color-white); margin-bottom: 16px; }
+.testimonialStars { display: flex; gap: 4px; color: var(--color-red); margin-bottom: 16px; }
 .testimonialStars svg { width: 14px; height: 14px; }
 .testimonialQuote {
   font-size: 15px;
   line-height: 1.7;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0 0 20px;
 }
-.testimonialName { font-size: 14px; font-weight: 700; color: var(--color-white); }
-.testimonialRole { font-size: 12px; color: var(--on-brand-2); margin-top: 2px; }
+.testimonialName { font-size: 14px; font-weight: 700; color: var(--ink); }
+.testimonialRole { font-size: 12px; color: var(--body); margin-top: 2px; }
 
 /* ============================================================
    VANTAGENS
@@ -420,7 +437,7 @@
 @media (min-width: 1024px) {
   .head { grid-template-columns: 1.3fr 1fr; gap: 64px; }
 }
-.headSub { font-size: 15px; line-height: 1.8; color: var(--on-brand-2); max-width: 44ch; margin: 0; }
+.headSub { font-size: 15px; line-height: 1.8; color: var(--body); max-width: 44ch; margin: 0; }
 
 .benefits {
   display: grid;
@@ -432,8 +449,8 @@
 
 .benefit {
   position: relative;
-  background: transparent;
-  border: 1px solid var(--hairline);
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   padding: 32px 28px 36px;
   transition: all 300ms ease;
@@ -441,30 +458,30 @@
 }
 .benefit:hover {
   transform: translateY(-8px);
-  background: rgba(255, 255, 255, 0.07);
-  border-color: var(--color-white);
+  background: var(--surface-raised);
+  border-color: var(--line-strong);
 }
-/* O primeiro benefício inverte-se — painel branco a abrir a grelha. */
+/* O primeiro benefício inverte-se — painel roxo cheio a abrir a grelha. */
 .benefit:first-child {
-  background: var(--panel-invert-bg);
-  border-color: var(--panel-invert-bg);
+  background: var(--surface-brand);
+  border-color: var(--surface-brand);
   box-shadow: var(--shadow-md);
 }
-.benefit:first-child:hover { background: var(--panel-invert-bg); }
+.benefit:first-child:hover { background: var(--surface-brand); }
 .benefitIcon {
   width: 30px; height: 30px;
-  color: var(--color-white);
+  color: var(--color-red);
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 24px;
 }
-.benefit:first-child .benefitIcon { color: var(--link-accent); }
+.benefit:first-child .benefitIcon { color: var(--color-white); }
 .benefitTitle {
   font-size: 19px;
   font-weight: 700;
   letter-spacing: -0.025em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 14px;
   padding-bottom: 14px;
   position: relative;
@@ -476,15 +493,16 @@
   bottom: 0;
   width: 34px;
   height: 2px;
-  background: var(--color-white);
+  background: var(--color-red);
 }
-.benefit:first-child .benefitTitle { color: var(--on-invert); }
-.benefit:first-child .benefitTitle::after { background: var(--color-red); }
-.benefitDesc { font-size: 14px; color: var(--on-brand-2); line-height: 1.75; margin: 0; }
-.benefit:first-child .benefitDesc { color: var(--on-invert-2); }
+.benefit:first-child .benefitTitle { color: var(--color-white); }
+.benefit:first-child .benefitTitle::after { background: var(--color-white); }
+.benefitDesc { font-size: 14px; color: var(--body); line-height: 1.75; margin: 0; }
+.benefit:first-child .benefitDesc { color: var(--on-brand-2); }
 
 /* ============================================================
-   CURRÍCULO — bloco preto
+   CURRÍCULO — bloco preto (âncora escura intencional, independente
+   do tema claro do resto da página — como a faixa .strip em /sobre).
    ============================================================ */
 .curr {
   position: relative;
@@ -573,11 +591,11 @@
 }
 
 /* ============================================================
-   CTA FINAL — painel branco, o momento mais claro da página
+   CTA FINAL — painel roxo cheio, o segundo momento de conversão
    ============================================================ */
 .final {
-  background: var(--panel-invert-bg);
-  color: var(--on-invert);
+  background: var(--surface-brand);
+  color: var(--color-white);
   border-radius: var(--radius-xl);
   padding: 64px 28px;
   position: relative;
@@ -591,53 +609,43 @@
   position: absolute;
   inset: 0 0 auto 0;
   height: 4px;
-  background: var(--color-red);
+  background: var(--color-white);
   pointer-events: none;
 }
 .finalInner { position: relative; max-width: 640px; margin: 0 auto; }
-.finalEyebrow { color: var(--link-accent); justify-content: center; }
+.finalEyebrow { color: var(--color-white); justify-content: center; }
 .finalTitle {
   font-size: clamp(30px, 3.8vw, 50px);
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.04;
-  color: var(--on-invert);
+  color: var(--color-white);
   margin: 0 0 20px;
 }
 .finalTitle em {
   font-style: normal;
-  color: var(--link-accent);
+  color: var(--color-white);
 }
 .finalSub {
   font-size: 16px;
   line-height: 1.7;
-  color: var(--on-invert-2);
+  color: var(--on-brand-2);
   margin: 0 0 34px;
 }
 .finalCta { display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; }
 .page .btnBlock { width: 100%; max-width: 340px; }
-/* É o CTA principal da página: dentro do painel branco fica sólido vermelho. */
-.page .final .btnAccent {
-  background: var(--color-red);
-  border-color: var(--color-red);
-  color: var(--color-white);
-  box-shadow: 0 4px 14px rgba(124, 92, 255, 0.28);
-}
-.page .final .btnAccent:hover {
-  background: var(--color-red-2);
-  border-color: var(--color-red-2);
-  color: var(--color-white);
-  box-shadow: 0 8px 22px rgba(124, 92, 255, 0.34);
-}
+/* O CTA principal do bloco final usa a variante vazada branca (.btnAccent),
+   já preparada para superfícies roxas/pretas — não precisa de mais nenhuma
+   substituição aqui. */
 
 /* ============================================================
    COMO FUNCIONA — secção vinda da antiga página inicial
    ============================================================ */
 .sectionSteps {
   padding: clamp(20px, 6vh, 64px) 0;
-  background: var(--surface-brand-alt);
-  border-top: 1px solid var(--hairline-soft);
-  border-bottom: 1px solid var(--hairline-soft);
+  background: var(--surface-raised);
+  border-top: 1px solid var(--line-light);
+  border-bottom: 1px solid var(--line-light);
 }
 @media (min-width: 768px) { .sectionSteps { padding: clamp(28px, 8vh, 96px) 0; } }
 
@@ -646,7 +654,7 @@
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 16px 0 0;
 }
 
@@ -659,35 +667,35 @@
 @media (min-width: 1024px) { .steps { grid-template-columns: repeat(4, 1fr); } }
 
 .step {
-  background: transparent;
-  border: 1px solid var(--hairline);
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   padding: 32px 28px;
   transition: all 300ms ease;
 }
 .step:hover {
   transform: translateY(-4px);
-  background: rgba(255, 255, 255, 0.07);
-  border-color: var(--color-white);
+  background: var(--panel-strong);
+  border-color: var(--line-strong);
 }
 .stepNum {
   font-weight: 700;
   font-size: 11px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin-bottom: 16px;
 }
 .stepTitle {
   font-size: 21px;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 12px;
 }
 .stepDesc {
   font-size: 15px;
-  color: var(--on-brand-2);
+  color: var(--body);
   line-height: 1.65;
   margin: 0;
   text-wrap: pretty;

--- a/app/o-curso/page.tsx
+++ b/app/o-curso/page.tsx
@@ -152,7 +152,7 @@ export default function CoursePage() {
   ];
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       {/* ============================================================
           HERO
           ============================================================ */}

--- a/app/pagamento-confirmado/page.tsx
+++ b/app/pagamento-confirmado/page.tsx
@@ -80,7 +80,7 @@ export default function PagamentoConfirmadoPage() {
 
   if (state === "confirmed") {
     return (
-      <div className="full-section flex items-center justify-center">
+      <div className="full-section on-light bg-[color:var(--surface)] text-[color:var(--body)] flex items-center justify-center">
         <div className="text-center space-y-4 max-w-md px-4">
           <h1 className="text-xl font-semibold home-title-highlight-text">Pagamento confirmado!</h1>
           <p className="text-sm sm:text-base leading-6 sm:leading-7">
@@ -96,7 +96,7 @@ export default function PagamentoConfirmadoPage() {
 
   if (state === "pending") {
     return (
-      <div className="full-section flex items-center justify-center">
+      <div className="full-section on-light bg-[color:var(--surface)] text-[color:var(--body)] flex items-center justify-center">
         <div className="text-center space-y-4 max-w-md px-4">
           <h1 className="text-xl font-semibold home-title-highlight-text">A confirmação está a demorar mais do que o normal</h1>
           <p className="text-sm sm:text-base leading-6 sm:leading-7">
@@ -126,7 +126,7 @@ export default function PagamentoConfirmadoPage() {
   }
 
   return (
-    <div className="full-section flex items-center justify-center" aria-busy="true" aria-label="A confirmar o pagamento">
+    <div className="full-section on-light bg-[color:var(--surface)] text-[color:var(--body)] flex items-center justify-center" aria-busy="true" aria-label="A confirmar o pagamento">
       <div className="text-center space-y-4">
         <h1 className="text-xl font-semibold home-title-highlight-text">A confirmar o teu pagamento...</h1>
         <p className="text-sm sm:text-base leading-6 sm:leading-7">Isto demora só alguns segundos.</p>

--- a/app/privacidade/page.module.css
+++ b/app/privacidade/page.module.css
@@ -1,7 +1,11 @@
 /*
- * Termos e Condições — sistema vermelho/branco.
- * Documento longo: cada cláusula fica num bloco translúcido sobre o vermelho,
- * com o número em caixa branca a servir de âncora de leitura.
+ * Política de Cookies / Termos / Privacidade — mesma linguagem clara da
+ * homepage (os três ficheiros são idênticos de propósito, ver STYLEGUIDE.md
+ * §3: copia este ficheiro para /privacidade e /termos-e-condicoes mantendo
+ * os nomes de classe iguais).
+ * Documento longo: cada cláusula fica num bloco elevado sobre `--surface`
+ * (branco), com o número em caixa roxa a servir de âncora de leitura. Raiz
+ * com `on-light` em page.tsx.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -12,8 +16,8 @@
    escala para cima. Breakpoints únicos do site: 640 / 768 / 1024 / 1280.
    ============================================================ */
 .page {
-  background: var(--surface-brand);
-  color: var(--color-white);
+  background: var(--surface);
+  color: var(--ink);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -42,7 +46,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 20px;
 }
 .eyebrow::before {
@@ -56,7 +60,7 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
@@ -66,7 +70,7 @@
    ============================================================ */
 .hero {
   padding: clamp(20px, 6vh, 64px) 0;
-  border-bottom: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--line);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -78,7 +82,7 @@
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin-top: 16px;
 }
 
@@ -87,16 +91,16 @@
    ============================================================ */
 .sections { display: flex; flex-direction: column; gap: 12px; }
 .termSection {
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid var(--hairline);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   padding: 24px;
   transition: border-color .2s, background .2s;
 }
 @media (min-width: 640px) { .termSection { padding: 32px 36px; } }
 .termSection:hover {
-  border-color: var(--color-white);
-  background: rgba(255, 255, 255, 0.11);
+  border-color: var(--line-strong);
+  background: var(--panel-strong);
 }
 .termHeader {
   display: flex;
@@ -108,8 +112,8 @@
   flex-shrink: 0;
   width: 44px; height: 44px;
   border-radius: var(--radius-sm);
-  background: var(--color-white);
-  color: var(--color-red);
+  background: var(--color-red);
+  color: var(--color-white);
   font-weight: 700;
   font-size: 18px;
   display: flex;
@@ -120,13 +124,17 @@
   font-size: 21px;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0;
   padding-top: 9px;
 }
 .termContent {
   font-size: 16px;
-  color: var(--on-brand-3);
+  /* `--muted` (#74747e) só está verificado para 4,5:1 sobre branco puro;
+     este bloco assenta em `--surface-raised` (#f6f6f8, ver .termSection),
+     que o baixa para 4,28:1 (axe-core apanhou isto) — `--body` é mais
+     escuro e mantém a folga (mesmo caso do .stepIndex na homepage). */
+  color: var(--body);
   line-height: 1.75;
   margin: 0;
   padding-left: 0;

--- a/app/privacidade/page.tsx
+++ b/app/privacidade/page.tsx
@@ -57,7 +57,7 @@ const sections = [
 
 export default function PrivacidadePage() {
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       <header className={`${styles.hero} full-section full-section-scroll`}>
         <div className={styles.wrap}>
           <div className={styles.eyebrow}>Proteção de dados</div>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -20,7 +20,7 @@ export default function ResetPasswordPage() {
 function ResetPasswordLoadingState() {
   const { t } = useLanguage();
   return (
-    <section className="full-section full-section-scroll w-full space-y-8">
+    <section className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <p className="text-center text-sm">{t.auth.loadingRecoveryForm}</p>
@@ -82,7 +82,7 @@ function ResetPasswordContent() {
   };
 
   return (
-    <section className="full-section full-section-scroll w-full space-y-8">
+    <section className="full-section full-section-scroll on-light bg-[color:var(--surface)] w-full space-y-8">
       <div className="mx-auto flex w-full max-w-6xl justify-center px-3 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10">
         <article className="login-form">
           <h1 className="form-heading">{t.auth.resetPasswordTitle}</h1>

--- a/app/sobre/page.module.css
+++ b/app/sobre/page.module.css
@@ -1,8 +1,12 @@
 /*
- * Página "Sobre" — sistema vermelho/branco.
- * A página inteira assenta no vermelho da marca; os blocos de foco (cartão de
- * preço) invertem-se para painel branco. As secções alternam entre o vermelho
- * base e o vermelho profundo para dar ritmo sem sair da paleta.
+ * Página "Sobre" — mesma linguagem clara da homepage.
+ * A página assenta em `--surface` (branco), texto quase-preto; os blocos de
+ * destaque (cartão de preço, pilar em foco, faixa de números) invertem-se
+ * para o roxo cheio da marca ou para preto, tal como o cartão de preço da
+ * homepage. A raiz da página leva a classe `on-light` (globals.css) em
+ * page.tsx — este ficheiro usa sempre os tokens genéricos (nunca
+ * --color-white/--on-brand-2/--surface-brand a direito, exceto nos blocos
+ * intencionalmente invertidos abaixo).
  */
 
 /* Reset global button/link styles inside this page */
@@ -13,8 +17,8 @@
    LAYOUT PRIMITIVES
    ============================================================ */
 .page {
-  background: var(--surface-brand);
-  color: var(--color-white);
+  background: var(--surface);
+  color: var(--ink);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -43,7 +47,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 20px;
 }
 .eyebrow::before {
@@ -58,16 +62,16 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
-/* Realce do título: inversão do sistema — caixa branca, texto vermelho. */
+/* Realce do título: inversão do sistema — caixa roxa, texto branco. */
 .italic {
   font-style: normal;
   font-weight: 700;
-  color: var(--color-red);
-  background: var(--color-white);
+  color: var(--color-white);
+  background: var(--color-red);
   padding: 0 0.14em;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
@@ -75,7 +79,7 @@
 .lead {
   font-size: clamp(15px, 1.1vw, 18px);
   line-height: 1.7;
-  color: var(--on-brand-2);
+  color: var(--body);
   max-width: 56ch;
   margin: 0;
 }
@@ -83,7 +87,7 @@
 /* ============================================================
    BUTTONS
    ============================================================ */
-/* CTA vazado a branco; enche no hover. */
+/* CTA vazado; enche no hover. */
 .page .btn {
   display: inline-flex;
   align-items: center;
@@ -94,23 +98,22 @@
   font-weight: 700;
   font-size: 16px;
   line-height: 1.2;
-  border: 1.5px solid rgba(255, 255, 255, 0.5);
+  border: 1.5px solid var(--line-strong);
   background: transparent;
-  color: var(--color-white);
+  color: var(--ink);
   transition: all 200ms ease;
   white-space: nowrap;
   cursor: pointer;
   font-family: var(--font-body);
 }
 .page .btn:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: var(--color-white);
+  background: var(--panel-strong);
+  border-color: var(--ink);
   transform: translateY(-2px);
 }
 .page .btn:active { transform: translateY(0); }
 
-/* Variante sólida — CTA principal. Dentro do cartão branco fica vermelho
-   sobre branco; sobre o vermelho da página fica branco sobre vermelho. */
+/* Variante sólida — CTA principal: roxo sobre branco. */
 .page .btnDark {
   background: var(--color-red);
   border-color: var(--color-red);
@@ -123,13 +126,26 @@
   color: var(--color-white);
   box-shadow: 0 8px 22px rgba(124, 92, 255, 0.34);
 }
+/* Dentro do cartão de preço (já roxo cheio) o botão inverte para branco. */
+.card .btnDark {
+  background: var(--color-white);
+  border-color: var(--color-white);
+  color: var(--surface-brand);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+}
+.card .btnDark:hover {
+  background: var(--color-white);
+  border-color: var(--color-white);
+  color: var(--color-red-3);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.24);
+}
 
 /* ============================================================
    HERO
    ============================================================ */
 .hero {
   padding: clamp(20px, 6vh, 64px) 0;
-  border-bottom: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--line);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -158,12 +174,12 @@
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.14;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 16px;
 }
 .advDesc {
   font-size: 15px;
-  color: var(--on-brand-2);
+  color: var(--body);
   line-height: 1.6;
   margin: 0 0 32px;
 }
@@ -173,24 +189,24 @@
   align-items: flex-start;
   gap: 16px;
   padding: 20px 24px;
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid var(--hairline);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   font-size: 15px;
-  color: var(--on-brand-3);
+  color: var(--body);
   line-height: 1.5;
   transition: border-color .2s, background .2s;
 }
 .adv:hover {
-  border-color: var(--color-white);
-  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--line-strong);
+  background: var(--panel-strong);
 }
 .advNum {
   flex-shrink: 0;
   width: 28px; height: 28px;
   border-radius: var(--radius-sm);
-  background: var(--color-white);
-  color: var(--color-red);
+  background: var(--color-red);
+  color: var(--color-white);
   font-weight: 700;
   font-size: 13px;
   display: inline-flex;
@@ -199,23 +215,18 @@
 }
 .bodyText {
   font-size: 16px;
-  color: var(--on-brand-2);
+  color: var(--body);
   line-height: 1.7;
   margin: 24px 0 0;
 }
 
 /* ============================================================
-   PRICING CARD — painel branco invertido
+   PRICING CARD — bloco roxo cheio, único acento forte da página
+   (mesmo papel que .priceCard na homepage).
    ============================================================ */
 .card {
-  /* Vira os tokens herdados para a escala escura: tudo o que está dentro
-     do cartão passa a ler-se sobre branco sem declarações extra. */
-  --line: var(--hairline-invert);
-  --muted: var(--on-invert-3);
-  --body: var(--on-invert-2);
-
-  background: var(--panel-invert-bg);
-  color: var(--on-invert);
+  background: var(--surface-brand);
+  color: var(--color-white);
   border: none;
   border-radius: var(--radius-xl);
   padding: 40px;
@@ -226,36 +237,36 @@
 @media (min-width: 1024px) {
   .card { position: sticky; top: 100px; }
 }
-/* Régua vermelha no topo, assinatura dos painéis brancos. */
+/* Régua branca no topo, assinatura dos painéis de destaque. */
 .card::before {
   content: "";
   position: absolute;
   top: 0; left: var(--radius-xl);
   width: 72px; height: 4px;
-  background: var(--color-red);
+  background: var(--color-white);
 }
 .cardEyebrow {
   margin-bottom: 16px;
-  color: var(--link-accent);
+  color: var(--on-brand-3);
 }
 .price {
   font-size: 44px;
   font-weight: 700;
   letter-spacing: -0.04em;
-  color: var(--on-invert);
+  color: var(--color-white);
   line-height: 1;
   margin: 0 0 4px;
 }
 .priceOriginal {
   font-size: 18px;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
   text-decoration: line-through;
   margin-right: 8px;
   font-weight: 500;
 }
 .priceNote {
   font-size: 13px;
-  color: var(--on-invert-3);
+  color: var(--on-brand-3);
   margin: 0 0 28px;
 }
 .featureList {
@@ -263,8 +274,8 @@
   flex-direction: column;
   gap: 14px;
   padding: 24px 0;
-  border-top: 1px solid var(--hairline-invert);
-  border-bottom: 1px solid var(--hairline-invert);
+  border-top: 1px solid var(--hairline-soft);
+  border-bottom: 1px solid var(--hairline-soft);
   margin-bottom: 28px;
 }
 .featureItem {
@@ -272,14 +283,14 @@
   align-items: center;
   gap: 12px;
   font-size: 15px;
-  color: var(--on-invert-2);
+  color: var(--on-brand-2);
 }
 .check {
   flex-shrink: 0;
   width: 20px; height: 20px;
   border-radius: var(--radius-sm);
-  background: var(--color-red);
-  color: var(--color-white);
+  background: var(--color-white);
+  color: var(--surface-brand);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -290,15 +301,15 @@
    ============================================================ */
 .sectionAlt {
   padding: clamp(20px, 6vh, 64px) 0;
-  background: var(--surface-brand-alt);
-  border-top: 1px solid var(--hairline-soft);
+  background: var(--surface-raised);
+  border-top: 1px solid var(--line-light);
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
 @media (min-width: 768px) { .sectionAlt { padding: clamp(28px, 8vh, 96px) 0; } }
 
-.dot { color: var(--on-brand-2); }
+.dot { color: var(--muted); }
 
 .head {
   display: grid;
@@ -313,7 +324,7 @@
 .headSub {
   font-size: 16px;
   line-height: 1.7;
-  color: var(--on-brand-2);
+  color: var(--body);
   max-width: 46ch;
   margin: 0;
   text-wrap: pretty;
@@ -323,11 +334,12 @@
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: var(--sp-sm) 0 0;
 }
 
-/* Pilares */
+/* Pilares — os dois normais ficam claros; o pilar em destaque inverte
+   para o roxo cheio da marca, como o cartão de preço. */
 .pillars {
   display: grid;
   grid-template-columns: 1fr;
@@ -337,59 +349,59 @@
   .pillars { grid-template-columns: repeat(3, 1fr); }
 }
 .pillar {
-  background: transparent;
-  border: 1px solid var(--hairline);
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   padding: var(--sp-lg);
   transition: all 300ms ease;
 }
 .pillar:hover {
   transform: translateY(-4px);
-  border-color: var(--color-white);
-  background: rgba(255, 255, 255, 0.07);
+  border-color: var(--line-strong);
+  background: var(--panel-strong);
 }
-/* O pilar em destaque inverte-se: branco sobre o vermelho da secção. */
+/* O pilar em destaque inverte-se: roxo cheio, texto branco. */
 .pillarAccent {
-  background: var(--panel-invert-bg);
-  border-color: var(--panel-invert-bg);
+  background: var(--surface-brand);
+  border-color: var(--surface-brand);
   box-shadow: var(--shadow-md);
 }
 .pillarAccent:hover {
-  background: var(--panel-invert-bg);
-  border-color: var(--panel-invert-bg);
+  background: var(--surface-brand);
+  border-color: var(--surface-brand);
 }
 .pillarIcon {
   display: block;
   width: 32px;
   height: 32px;
-  color: var(--color-white);
+  color: var(--color-red);
   margin-bottom: var(--sp-md);
 }
 .pillarIcon svg { width: 100%; height: 100%; }
-.pillarAccent .pillarIcon { color: var(--link-accent); }
+.pillarAccent .pillarIcon { color: var(--color-white); }
 .pillarTitle {
   font-size: 23px;
   font-weight: 700;
   letter-spacing: -0.025em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 12px;
 }
-.pillarAccent .pillarTitle { color: var(--on-invert); }
+.pillarAccent .pillarTitle { color: var(--color-white); }
 .pillarRule {
   width: 34px;
   height: 3px;
-  background: var(--color-white);
+  background: var(--color-red);
   margin-bottom: var(--sp-sm);
 }
-.pillarAccent .pillarRule { background: var(--color-red); }
+.pillarAccent .pillarRule { background: var(--color-white); }
 .pillarDesc {
   font-size: 15px;
   line-height: 1.65;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0;
   text-wrap: pretty;
 }
-.pillarAccent .pillarDesc { color: var(--on-invert-2); }
+.pillarAccent .pillarDesc { color: var(--on-brand-2); }
 
 /* Setores */
 .cats {
@@ -404,9 +416,9 @@
   .cats { grid-template-columns: repeat(3, 1fr); }
 }
 .cat {
-  background: transparent;
-  border: 1px solid var(--hairline);
-  border-top: 3px solid var(--color-white);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-top: 3px solid var(--color-red);
   border-radius: var(--radius-lg);
   padding: var(--sp-md);
   display: flex;
@@ -416,14 +428,14 @@
 }
 .cat:hover {
   transform: translateY(-4px);
-  background: rgba(255, 255, 255, 0.07);
-  border-color: var(--hairline-strong);
-  border-top-color: var(--color-white);
+  background: var(--surface-raised);
+  border-color: var(--line-strong);
+  border-top-color: var(--color-red);
 }
 .catIcon {
   width: 26px;
   height: 26px;
-  color: var(--color-white);
+  color: var(--color-red);
   flex-shrink: 0;
 }
 .catBody { flex: 1; min-width: 0; }
@@ -431,21 +443,22 @@
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.025em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0 0 4px;
 }
 .catPay {
   font-size: 14px;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin: 0;
 }
 .catPay strong {
-  color: var(--color-white);
+  color: var(--ink);
   font-weight: 700;
   font-size: 16px;
 }
 
-/* Faixa de números — preto, para ancorar o fim da página. */
+/* Faixa de números — preto, para ancorar o fim da página (bloco
+   intencionalmente escuro, independente do tema claro/roxo do resto). */
 .strip {
   background: var(--color-black);
   border-top: none;

--- a/app/sobre/page.tsx
+++ b/app/sobre/page.tsx
@@ -169,7 +169,7 @@ export default function AboutPage() {
   ];
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       {/* ============================================================
           HERO
           ============================================================ */}

--- a/app/termos-e-condicoes/page.module.css
+++ b/app/termos-e-condicoes/page.module.css
@@ -1,7 +1,11 @@
 /*
- * Termos e Condições — sistema vermelho/branco.
- * Documento longo: cada cláusula fica num bloco translúcido sobre o vermelho,
- * com o número em caixa branca a servir de âncora de leitura.
+ * Política de Cookies / Termos / Privacidade — mesma linguagem clara da
+ * homepage (os três ficheiros são idênticos de propósito, ver STYLEGUIDE.md
+ * §3: copia este ficheiro para /privacidade e /termos-e-condicoes mantendo
+ * os nomes de classe iguais).
+ * Documento longo: cada cláusula fica num bloco elevado sobre `--surface`
+ * (branco), com o número em caixa roxa a servir de âncora de leitura. Raiz
+ * com `on-light` em page.tsx.
  */
 
 .page button { all: unset; cursor: pointer; font: inherit; }
@@ -12,8 +16,8 @@
    escala para cima. Breakpoints únicos do site: 640 / 768 / 1024 / 1280.
    ============================================================ */
 .page {
-  background: var(--surface-brand);
-  color: var(--color-white);
+  background: var(--surface);
+  color: var(--ink);
   font-size: 15px;
   line-height: 1.65;
   font-family: var(--font-body);
@@ -42,7 +46,7 @@
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--brand);
   margin-bottom: 20px;
 }
 .eyebrow::before {
@@ -56,7 +60,7 @@
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.02;
-  color: var(--color-white);
+  color: var(--ink);
   font-size: clamp(30px, 4.6vw, 62px);
   margin: 0;
 }
@@ -66,7 +70,7 @@
    ============================================================ */
 .hero {
   padding: clamp(20px, 6vh, 64px) 0;
-  border-bottom: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--line);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -78,7 +82,7 @@
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--on-brand-2);
+  color: var(--body);
   margin-top: 16px;
 }
 
@@ -87,16 +91,16 @@
    ============================================================ */
 .sections { display: flex; flex-direction: column; gap: 12px; }
 .termSection {
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid var(--hairline);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   padding: 24px;
   transition: border-color .2s, background .2s;
 }
 @media (min-width: 640px) { .termSection { padding: 32px 36px; } }
 .termSection:hover {
-  border-color: var(--color-white);
-  background: rgba(255, 255, 255, 0.11);
+  border-color: var(--line-strong);
+  background: var(--panel-strong);
 }
 .termHeader {
   display: flex;
@@ -108,8 +112,8 @@
   flex-shrink: 0;
   width: 44px; height: 44px;
   border-radius: var(--radius-sm);
-  background: var(--color-white);
-  color: var(--color-red);
+  background: var(--color-red);
+  color: var(--color-white);
   font-weight: 700;
   font-size: 18px;
   display: flex;
@@ -120,13 +124,17 @@
   font-size: 21px;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-white);
+  color: var(--ink);
   margin: 0;
   padding-top: 9px;
 }
 .termContent {
   font-size: 16px;
-  color: var(--on-brand-3);
+  /* `--muted` (#74747e) só está verificado para 4,5:1 sobre branco puro;
+     este bloco assenta em `--surface-raised` (#f6f6f8, ver .termSection),
+     que o baixa para 4,28:1 (axe-core apanhou isto) — `--body` é mais
+     escuro e mantém a folga (mesmo caso do .stepIndex na homepage). */
+  color: var(--body);
   line-height: 1.75;
   margin: 0;
   padding-left: 0;

--- a/app/termos-e-condicoes/page.tsx
+++ b/app/termos-e-condicoes/page.tsx
@@ -18,7 +18,7 @@ export default function TermosECondicoes() {
   const lastUpdatedText = language === "pt" ? "Última atualização:" : "Last updated:";
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} on-light`}>
       {/* ============================================================
           HERO
           ============================================================ */}


### PR DESCRIPTION
## Summary
Converts the color system across multiple pages from a red/white brand-focused design to a light theme with white backgrounds and purple accents. This aligns secondary pages (course, about, FAQ, contact, legal) with the homepage's clear language design system.

## Key Changes

### Color System Migration
- **Background**: Changed from `var(--surface-brand)` (red) to `var(--surface)` (white) across all affected pages
- **Text**: Updated from `var(--color-white)` to `var(--ink)` (dark text) for main content
- **Accents**: Price cards and conversion CTAs now use `var(--surface-brand)` (purple) instead of white panels
- **Borders & dividers**: Migrated from `var(--hairline)` to `var(--line)` and related tokens for consistency

### Pages Updated
- `/o-curso` (course sales page)
- `/sobre` (about page)
- `/curso` (course reader)
- `/faq` (FAQ page)
- `/contactos` (contact page)
- `/cookies`, `/privacidade`, `/termos-e-condicoes` (legal pages)
- `/not-found` (404 page)

### Component-Level Changes
- **Price cards**: Now use purple background (`var(--surface-brand)`) with white text, matching homepage `.priceCard` pattern
- **CTA buttons**: Primary buttons changed to purple on white; inverted to white on purple when inside price cards
- **Title highlights** (`.italic`): Swapped from white box + red text to purple box + white text
- **Progress cards** (course page): Updated to purple accent with white text
- **Checkmarks**: Changed from red background to white background with purple text

### CSS Token Updates
- Replaced `--on-brand-2`, `--on-invert*` with generic tokens (`--body`, `--ink`, `--muted`)
- Updated color references to use semantic tokens instead of direct color values
- Added `on-light` class to page roots in `.tsx` files for proper token context

### Notable Details
- Course reader overlay maintains its existing white-on-red design (unchanged)
- Form inputs and functional surfaces remain elevated/white (not converted to purple)
- All three legal pages (cookies, privacy, terms) use identical styling per STYLEGUIDE.md
- Button hover states updated to match new purple accent system
- Border colors and dividers consistently use new `--line` token family

https://claude.ai/code/session_01413qWbqX5TvuJ63Wixjrv7